### PR TITLE
docs: restore TODO.roadmap/13-18

### DIFF
--- a/TODO.roadmap/13-rnp-rust-binding.md
+++ b/TODO.roadmap/13-rnp-rust-binding.md
@@ -1,0 +1,12 @@
+# 13 — RNP Rust binding (rnp-rs)
+
+**Status**: SHIPPED. Sibling repo at github.com/rnpgp/rnp-rs, PR #1 merged.
+
+Provides idiomatic Rust access to RNP's C FFI for OpenPGP operations.
+Confium uses it for plugin artifact verification, OpenPGP key format,
+and TC party authentication.
+
+**Shipped**: Context, Key (generate/import/export/locate), Signature
+(sign/verify/detached), keygen (RSA/EdDSA/ECDSA/ECDH/SM2/DSA), PQC
+support (ML-KEM/ML-DSA via feature flags), vendored RNP build,
+callbacks, secret memory, parity tests.

--- a/TODO.roadmap/14-real-tc-schemes.md
+++ b/TODO.roadmap/14-real-tc-schemes.md
@@ -1,0 +1,18 @@
+# 14 — Real threshold cryptography schemes
+
+**Status**: 4 of ~10 shipped.
+
+Shipped:
+- mock-tc-sig (demonstration scheme)
+- FROST-ed25519 (draft-irtf-cfrg-frost, real curve25519-dalek impl)
+- GG18-ECDSA-P256 (Gennaro & Goldfeder 2018, real p256 impl)
+- CMP20-ECDSA-P256 (Canetti et al. 2020, 3-round signing)
+
+Remaining:
+- FROST-ECDSA-P256 (different curve)
+- Mask-FROST (2-round variant from MPTS 2026)
+- Pedersen DKG standalone
+- Feldman DKG standalone
+- Shoup threshold RSA
+- Threshold BLS
+- PQC threshold schemes (awaiting NIST specs)

--- a/TODO.roadmap/15-wasm-sandboxing.md
+++ b/TODO.roadmap/15-wasm-sandboxing.md
@@ -1,0 +1,13 @@
+# 15 — WASM sandboxing
+
+**Status**: SHIPPED. crates/confium-sandbox-wasm + confium-sandbox-process.
+
+WASM sandbox via wasmtime 27 with capability-based access control.
+Capability types: InterfaceAccess, NetworkEndpoint, KeyAccess,
+FilesystemPath. Grant/revoke per instance.
+
+Out-of-process sandbox via subprocess IPC (JSON-RPC over stdin/stdout).
+Shared Sandbox/SandboxInstance trait across both implementations.
+
+Tests: inline WAT compilation, capability gating (denied → sentinel,
+granted → success), grant-then-revoke, multi-call independence.

--- a/TODO.roadmap/16-confiumd-daemon.md
+++ b/TODO.roadmap/16-confiumd-daemon.md
@@ -1,0 +1,13 @@
+# 16 — confiumd daemon
+
+**Status**: SHIPPED. crates/confium-daemon.
+
+Long-running JSON-RPC 2.0 daemon over Unix socket or TCP. 14 method
+groups mirroring the C FFI (plugin, hash, cipher, aead, kdf, rng,
+signature, kem, keyfmt, keystore, tc, registry, audit, meta).
+
+Length-prefix framing (4-byte big-endian). LocalSet-based concurrency
+for the !Send Confium engine. CancellationToken for graceful shutdown.
+
+Integration test: spin up daemon on ephemeral port, JSON-RPC version()
+call, verify response.

--- a/TODO.roadmap/17-nist-vector-sets.md
+++ b/TODO.roadmap/17-nist-vector-sets.md
@@ -1,0 +1,13 @@
+# 17 — NIST vector sets
+
+**Status**: SHIPPED (schema + mock vectors). FROST/GG18 spec vectors pending.
+
+TOML schema with conformance levels: MUST_PASS, SHOULD_PASS,
+INFORMATIONAL. Runner honors levels (SHOULD_PASS failure = warning,
+not error).
+
+Shipped vectors:
+- mock-3-of-5.toml, mock-2-of-3.toml, mock-byzantine-drop.toml
+- Registry catalog at sites/registry/vectors/
+
+Pending: extract official KAT vectors from FROST/GG18/CMP20 specs.

--- a/TODO.roadmap/18-hardware-keystore-backends.md
+++ b/TODO.roadmap/18-hardware-keystore-backends.md
@@ -1,0 +1,14 @@
+# 18 — Hardware-backed keystore backends
+
+**Status**: SHIPPED (skeletons). Real operations pending.
+
+Three backend crates:
+- confium-store-pkcs11: via cryptoki crate, real open/session/login path,
+  NotImplemented for actual put/get (pending cfmp_sign_with_handle contract)
+- confium-store-tpm: via tss-esapi (feature-gated, doesn't compile on
+  macOS without tpm2-tss), NotImplemented stubs
+- confium-store-cloud: AWS/GCP/Azure KMS via feature flags,
+  NotImplemented stubs (actual REST/gRPC calls pending)
+
+All three implement the StoreBackend trait from confium-store,
+registered via register_backend! macro. Drop-in for filesystem/memory.


### PR DESCRIPTION
Restores 6 roadmap files lost during worktree merge operations. All document work that is already implemented in the codebase.