### PR TITLE
docs(roadmap): framework vision + 13 P0-P3 work items

### DIFF
--- a/TODO.roadmap/25-nist-threshold-call.md
+++ b/TODO.roadmap/25-nist-threshold-call.md
@@ -1,0 +1,72 @@
+# 25 — NIST Threshold Call response (NIST IR 8214C)
+
+## The call is LIVE
+
+NIST published the **First Call for Multi-Party Threshold Schemes**
+on January 20, 2026 (NIST IR 8214C). MPTS 2026 workshop was
+January 26-29, 2026. Submissions are being accepted.
+
+Sources:
+- https://csrc.nist.gov/projects/threshold-cryptography
+- https://csrc.nist.gov/Projects/threshold-cryptography/tcall-1
+- https://csrc.nist.gov/events/2026/mpts2026
+
+## What this means for Confium
+
+Confium's mission — bridging TC research to deployment — is now
+_time-critical_. The framework is the reference implementation
+platform that NIST MPTS evaluators need to:
+
+1. Run candidate schemes against shared vectors
+2. Benchmark performance apples-to-apples
+3. Publish results that map directly to deployable artifacts
+
+## Action items
+
+### 1. FROST submission support (P0)
+
+FROST is being actively submitted to the NIST Threshold Call.
+Confium's `confium-tc-frost-ed25519` crate is a working
+implementation. Action: ensure it passes the spec's official test
+vectors, prepare it as a reference plugin.
+
+### 2. Mask-FROST (new scheme)
+
+Mask-FROST was presented at MPTS 2026 — a 2-round partially
+non-interactive threshold Schnorr scheme. Add as
+`crates/confium-tc-mask-frost/`.
+
+### 3. NIST evaluation harness readiness
+
+Ensure `confium-test-harness` can:
+- Import NIST-provided vector sets (TOML format per TODO #17)
+- Run candidates against shared vectors
+- Produce JSON reports for NIST submission
+- Benchmark wall time + message sizes + peak memory
+
+### 4. Plugin registry: TC scheme catalog
+
+Populate `sites/registry/` with entries for submitted schemes so
+evaluators can install and test them via `confium install`.
+
+### 5. Documentation for NIST evaluators
+
+A dedicated "NIST Evaluator Guide" showing how to:
+- Install Confium
+- Install candidate scheme plugins
+- Run the evaluation harness
+- Submit results
+
+## Timeline
+
+The NIST Threshold Call has a submission window. Confium must be
+ready before the deadline. Check tcall-1 documentation for the
+exact date.
+
+## Sources
+
+- [NIST Threshold Call](https://csrc.nist.gov/projects/threshold-cryptography/tcall-1)
+- [MPTS 2026 Workshop](https://csrc.nist.gov/events/2026/mpts2026)
+- [FROST NIST Submission Update](https://csrc.nist.gov/presentations/2026/mpts2026-1a1)
+- [Mask-FROST Presentation](https://csrc.nist.gov/presentations/2026/mpts2026-1a5)
+- [MPTC Forum (Google Group)](https://groups.google.com/a/list.nist.gov/g/mptc-forum)

--- a/TODO.roadmap/26-confium-framework.md
+++ b/TODO.roadmap/26-confium-framework.md
@@ -1,0 +1,684 @@
+# 26 — Confium framework vision
+
+## The thesis
+
+**Confium is a general framework for multi-stakeholder threshold
+cryptography**, supporting three layered deployment modes that
+address progressively deeper use cases:
+
+- **Mode 1 — Peer-to-peer threshold cryptography**: nodes on the
+  internet do TC directly, no PKI required. (MPC, distributed
+  custody, BFT consensus signing.)
+- **Mode 2 — TC PKI replacement (drop-in)**: existing PKI consumers
+  (web TLS, code signing, email signing, PKCS#11 apps) replace
+  single-party keys with threshold keys **without changing their
+  ecosystem**. Includes PQC migration path.
+- **Mode 3 — TC Certificate PKI (custom formats)**: organizations
+  with their own certificate/document formats and workflow semantics
+  (OIML CNML, BIPM calibration, pharma approvals, accreditation,
+  supply chain, treaty orgs).
+
+The modes are layered: Mode 3 builds on Mode 2 builds on Mode 1.
+A deployment can use any mode or combination. CNML (Mode 3
+flagship, `TODO.roadmap/27`) is the proof; Modes 1 and 2 are the
+broader adoption surface.
+
+Confium is to threshold cryptography what TLS libraries are to
+transport security: a configurable framework organizations deploy
+with their own parameters, not a single-purpose system.
+
+## How the modes relate
+
+```
+Mode 3: TC Certificate PKI  (CNML, BIPM, pharma, accreditation)
+   └─ adds: custom formats, scoped delegation, transparency, archival
+        ↓ builds on
+Mode 2: TC PKI replacement   (web TLS, code signing, PKCS#11, PQC migration)
+   └─ adds: X.509 certs, CMS/TLS envelopes, PKCS#11 server, RFC compliance
+        ↓ builds on
+Mode 1: Peer-to-peer TC      (MPC, custody, BFT, wallets)
+   └─ adds: nothing — pure protocol execution between authenticated peers
+        ↓ builds on
+Confium primitives           (sig + enc + reshare + coordinator + hardware)
+```
+
+## Mode 1 — Peer-to-peer threshold cryptography
+
+### Definition
+
+N nodes on the internet do threshold cryptography directly with
+each other. No PKI, no hierarchy, no certificates (beyond mutual
+TLS or Noise for transport auth). They run a session, exchange
+messages, produce output.
+
+### Audience
+
+Cryptography engineers, distributed systems engineers, blockchain
+developers, MPC application builders, applied researchers.
+
+### Examples
+
+- Distributed key custody (cryptocurrency wallets, KMS clusters)
+- BFT consensus signature production (validators, distributed ledgers)
+- Multi-party computation with secret-output revelation
+- Sealed-bid auctions (encrypted bids, threshold-open at close)
+- Privacy-preserving analytics (threshold-decrypt aggregate results)
+- Distributed build/signing pipelines (multiple build agents collaborate)
+- Threshold SSH jump hosts (bastion cluster signs session certs)
+- Distributed database encryption (TDEK held across regions)
+
+### Architecture used
+
+- `confium-tc` — session primitives
+- `confium-net-tcp` / `confium-net-quic` / `confium-net-ws` — transport
+- One algorithm crate (`confium-tc-frost-ed25519`, etc.)
+- `confium-store` for share persistence
+- Mutual TLS or Noise Protocol for transport auth
+- Optional: `confium-tc-reshare` for committee evolution
+- Optional: `confium-tc-kem` + threshold enc crate for confidential output
+
+### Time to value
+
+Hours. Drop crate, write ~50 lines, run session.
+
+### PQC angle
+
+Pluggable. Pick `confium-tc-frost-ml-dsa-65` or `confium-tc-ml-kem`
+when ready.
+
+## Mode 2 — TC PKI replacement
+
+### Definition
+
+Existing PKI consumers (web servers, code signers, email signers,
+VPN gateways, database encryption, PKCS#11 applications) replace
+single-party keys with threshold keys **without changing their
+surrounding ecosystem**. Browsers still verify TLS normally;
+OpenSSH still works; OpenSSL still works. The PKCS#11 token they
+talk to is actually a Confium threshold coordinator dispatching to
+a quorum behind the scenes.
+
+### Audience
+
+Corporate security teams, CA operators, DevSecOps architects,
+HSM-using enterprises, government PKI operators.
+
+### Examples
+
+- **Web TLS for high-value sites** — root CAs, payment gateways,
+  treasury portals, government sites. TLS handshake normal; server
+  signing key threshold-held across multiple data centers.
+- **Code signing at scale** — software vendors signing release
+  artifacts. Multiple build/release agents collaborate per signature.
+- **Corporate S/MIME email signing** — outbound email threshold-signed.
+- **VPN gateway authentication** — enterprise VPN cluster shares
+  threshold identity.
+- **Database TDEK** — transparent data encryption key threshold-held
+  across regions.
+- **DNSSEC zone signing** — TLD or enterprise zone signing with
+  threshold key.
+- **DKIM email signing** — corporate domain threshold-signed.
+- **CA root key management** — internal CA root keys threshold-held
+  for compromise resilience.
+- **PKCS#11 drop-in** — any application already using PKCS#11
+  (OpenSSL, OpenSSH, Java KeyStore, etc.) gets threshold keys with
+  no code changes.
+
+### Architecture used
+
+- Everything from Mode 1
+- `confium-cert` for X.509 cert + CSR
+- **`confium-pkcs11-server`** — exposes PKCS#11 v3.0 API
+  (`C_Sign`, `C_Decrypt`, `C_GenerateKeyPair`, etc.); internally
+  dispatches to threshold protocol. **The killer feature for
+  Mode 2 — unlocks every existing PKCS#11 application with zero
+  code changes.**
+- **`confium-openssl-provider`** — OpenSSL 3.0 provider that uses
+  Confium for signing
+- `confium-cms` for PKCS#7 / CMS envelope compatibility
+- `confium-tls-signer` for TLS handshakes that satisfy via threshold
+- HSM-backed share storage (PKCS#11, TPM)
+- Optional: `confium-composite` for PQ hybrid signatures
+- Optional: `confium-transparency` for high-value deployments
+
+### Time to value
+
+Days to weeks. Deploy coordinator, configure HSM, integrate with
+existing PKI, test failover.
+
+### PQC angle (critical differentiator)
+
+Confium's PQ path is a major Mode 2 selling point. An enterprise
+deploying Confium for PKCS#11 today gets:
+
+- **2026**: threshold Ed25519/ECDSA via PKCS#11 server
+- **2027**: threshold ML-DSA-65 composite with Ed25519 (verifier
+  back-compat) via PKCS#11 server
+- **2028+**: PQ-only when ecosystem ready
+- **All without changing the PKCS#11 interface applications see.**
+
+Without Confium, the same enterprise would have to: upgrade all
+HSMs to PQ-capable firmware, re-do threshold protocols for new
+algorithms, re-issue all credentials. Confium makes this a
+software upgrade.
+
+### Strategic partnerships
+
+- **HSM vendors** (Yubico, Thales, Utimaco, AWS CloudHSM) — they
+  want threshold features but won't build them; Confium becomes
+  the recommended library
+- **PKI suite vendors** (HashiCorp Vault, DigiCert, Entrust) —
+  integration partnerships
+- **Cloud providers** (AWS KMS, GCP KMS, Azure KV) — their
+  customers want threshold; Confium provides the standard layer
+
+## Mode 3 — TC Certificate PKI
+
+### Definition
+
+Organizations with their own certificate/document formats and
+workflow semantics. Custom delegation rules, custom verification
+pipelines, custom archival rules.
+
+### Audience
+
+Institutional system architects — government tech leads, treaty
+org CIOs, regulator CTOs, accreditation body directors.
+
+### Examples
+
+- **OIML CNML** (flagship) — type approval certificates with
+  model-bound delegation, 5-tier hierarchy
+- **BIPM calibration** — SI-traceable calibration certificates
+- **Pharmaceutical regulator** — drug applications, GMP certs
+- **Academic accreditation** — diplomas with department/university/
+  accreditor tiers
+- **Financial audit firms** — audit attestations with engagement/
+  partner/firm tiers
+- **Supply chain provenance** — regulator/certifier/manufacturer/
+  shipper/customs
+- **Standards bodies** — ISO/IEC standards with working group/
+  committee/body tiers
+- **Treaty organizations** — international agreements with
+  multi-national signatories
+
+### Architecture used
+
+Everything from Mode 2 + custom configuration manifest + custom
+document formats + custom delegation rules + transparency log +
+archival + audit. Detailed in `TODO.roadmap/27`.
+
+### Time to value
+
+Months. Design manifest, integrate, test, deploy, train.
+
+## Architecture layers
+
+```
+Layer 1: Confium primitives (algorithm-agnostic, deployment-agnostic)
+   ├─ Threshold sig protocols (FROST, CMP20, GG18, ...)
+   ├─ Threshold enc protocols (ElGamal, ECIES, ML-KEM, ...)
+   ├─ Re-sharing + proactive refresh
+   ├─ Async coordinator service
+   ├─ Plugin loader + interface registry
+   ├─ Cert path validation
+   ├─ Hardware backends (PKCS#11, TPM, OpenPGP, cloud KMS)
+   ├─ Transparency log + OTS anchoring
+   └~30 crates, all published to crates.io
+
+Layer 2: Confium configuration + integration
+   ├─ Mode 1: minimal config, just session params
+   ├─ Mode 2: PKCS#11 server config, OpenSSL provider config,
+   │          algorithm choices, HSM backend
+   └─ Mode 3: deployment manifest with tier structure, quorum T/N,
+              attribute predicates, delegation rules, async policies,
+              transparency log policy
+
+Layer 3: Deployment (concrete instance)
+   ├─ Mode 1: peer apps running Confium crates
+   ├─ Mode 2: enterprise PKCS#11 + OpenSSL integration
+   └─ Mode 3: OIML CNML (flagship), BIPM calibration, future deployments
+```
+
+Layer 1 is the same across all modes. Layer 2 is what makes each
+deployment unique. Layer 3 is the running instance.
+
+## Audiences and adoption flywheel
+
+### Audience map
+
+| Mode | Audience | Volume | Revenue per user | Time to value |
+|---|---|---|---|---|
+| Mode 1 | Developers, researchers | High | Low (OSS) | Hours |
+| Mode 2 | Enterprise PKI operators | Mid | High (subscription/support) | Days-weeks |
+| Mode 3 | Institutional architects | Low | Highest (integrator model) | Months |
+
+### Expansion strategy per audience
+
+**Mode 1 (developers)** — biggest volume:
+- Rust crypto community, arewevcryptoyet.com
+- Academic conferences (RWC, CRYPTO, EUROCRYPT, USENIX Security) with artifact evaluations
+- Cookbook + FFI examples for Python/Go/C
+- "Awesome threshold crypto" curated list
+- Hackathon sponsorships
+- Plugin contribution pathway (these users often BUILD new algorithm plugins which enriches the framework)
+
+**Mode 2 (PKI operators)** — most revenue potential:
+- RSA Conference, Black Hat, DEF CON, EuroPKI presence
+- Vendor partnerships with HSM manufacturers (Yubico, Thales, Utimaco)
+- Standards body participation: IETF CFRG/LAMPS/TLS, NIST MPTS/PQC, CA/Browser Forum
+- Compliance certifications: FIPS 140-3, Common Criteria, SOC 2
+- Industry analyst (Gartner, Forrester) briefings
+- Case studies: "Company X replaced their HSM-cluster signing with Confium"
+- Open source the framework, sell support/enterprise edition/managed coordinator
+
+**Mode 3 (institutions)** — highest impact per deployment:
+- Targeted BD to specific organizations
+- NIST relationship is cornerstone — NIST MPTS evaluators become champions
+- Case study cascade: CNML → BIPM → pharma → supply chain → ...
+- Ribose integrator model (revenue from deployment services)
+- Academic validation: papers in top venues lend credibility
+- Government grant funding (EU Horizon, NSF, national CTO offices)
+
+### The flywheel
+
+The three modes reinforce each other:
+
+1. Mode 1 developers contribute plugins → enriches framework
+2. Mode 2 PKI operators provide enterprise credibility, fund compliance certifications, generate case studies
+3. Mode 3 institutional deployments produce academic papers, prove research-frontier features, generate press
+4. Academic papers drive Mode 1 developer interest
+5. Enterprise case studies drive Mode 2 operator adoption
+6. Press coverage drives Mode 3 institutional leads
+
+Each mode's success amplifies the others. CNML (Mode 3 flagship)
+is not just an end in itself — it's the proof that drives Mode 1
+and Mode 2 adoption.
+
+## Configuration model
+
+A Mode 3 deployment is described by a signed **deployment manifest**
+(`confium.toml`). Mode 2 uses a simpler config; Mode 1 needs no
+manifest.
+
+```toml
+# Example Mode 3 skeleton — OIML CNML configuration
+[deployment]
+name = "OIML CNML"
+operator = "BIML"
+charter_url = "https://oiml.org/..."
+manifest_version = 1
+
+[[tier]]
+name = "biml_root"
+role = "international root"
+signing_algorithm = "FROST-ed25519+ML-DSA-65-composite"
+encryption_algorithm = "ML-KEM-768-threshold"
+threshold = { t = 5, n = 7 }
+attributes = ["region", "expertise"]
+ceremony = { sync_required = true, frequency = "annual" }
+
+[[tier]]
+name = "ia"
+role = "national issuing authority"
+signing_algorithm = "FROST-P256"
+encryption_algorithm = "ElGamal-P256-threshold"
+threshold = { t = 2, n = 3 }
+delegated_by = "biml_root"
+ceremony = { sync_required = false }
+
+# ... (TL, manufacturer_model, manufacturer_instance tiers)
+
+[transparency]
+log_operator = "biml"
+anchors = ["bitcoin-ots"]
+public_mirror_urls = [...]
+
+[async_signing]
+default_unlock_window_minutes = 240
+coordinator_operator = "biml"
+
+[archival]
+renewal_period_years = 5
+re_sign_under = "current-algorithm-suite"
+```
+
+This manifest is published; verifiers can read it to understand
+the deployment's rules.
+
+```toml
+# Example Mode 2 skeleton — enterprise PKCS#11 server
+[deployment]
+name = "Acme Corp PKI"
+mode = "pkcs11_replacement"
+
+[pkcs11_server]
+slot_count = 8
+default_signing_algorithm = "FROST-P256"
+default_threshold = { t = 3, n = 5 }
+share_storage = "pkcs11-wrap"           # HSM holds wrapping key
+hsm_module = "/usr/lib/pkcs11/yubihsm.so"
+
+[quorum.enterprise_root]
+threshold = { t = 3, n = 5 }
+coordinator = "coordinator.acme.corp"
+
+[pqc_migration]
+current = "ECDSA-P256"
+target_2027 = "composite-ECDSA-P256-ML-DSA-65"
+target_2029 = "ML-DSA-65"
+```
+
+Mode 1 needs no manifest — it's just session parameters in code.
+
+## Research-frontier contributions (general)
+
+These contributions advance the framework itself, applicable across
+modes:
+
+1. **Multi-tier hierarchical threshold with delegated signing** —
+   configurable tier structure with bounded scope delegation (Mode 3)
+2. **Post-quantum composite threshold signatures** — composite
+   (classical + PQ) at the threshold layer (Modes 2, 3)
+3. **Threshold ML-KEM with proactive security** — long-term
+   confidential archival under PQ adversary (Modes 1, 2, 3)
+4. **Async threshold signing with coordinator** — globally
+   distributed signers, no simultaneity required (all modes)
+5. **Share re-sharing with public-key preservation** — committee
+   evolution without re-issuance cascade (Modes 2, 3)
+6. **Byzantine identification with administrative-grade proof** —
+   signed evidence sufficient for proceedings (all modes)
+7. **Multi-decade archival with periodic re-quorum** — "living
+   will" cryptography for institutions (Mode 3)
+8. **Confidential threshold with accountability** — threshold ring
+   signatures (research, long horizon; Modes 1, 3)
+9. **PKCS#11 dispatch to threshold protocol** — drop-in compatibility
+   for every existing PKCS#11 application (Mode 2)
+
+Each contribution is a paper with Confium as reference implementation.
+
+## Engineering scope
+
+### Threshold signing crates (all modes)
+
+| Crate | Algorithm | Status |
+|---|---|---|
+| `confium-tc-frost-ed25519` | FROST over Ed25519 | shipped |
+| `confium-tc-cmp20` | CMP20 over ECDSA P-256 | shipped |
+| `confium-tc-gg18` | GG18 over ECDSA P-256 | shipped |
+| `confium-tc-frost-p256` | FROST over ECDSA P-256 | new — P0 |
+| `confium-tc-bls` | Threshold BLS for cross-org aggregation | new — P2 |
+| `confium-tc-frost-ml-dsa-65` | Threshold ML-DSA-65 (research) | new — P1 |
+
+### Threshold encryption crates (all modes)
+
+| Crate | Purpose | Priority |
+|---|---|---|
+| `confium-tc-kem` | Threshold KEM session interface | P0 |
+| `confium-tc-elgamal-p256` | Threshold ElGamal | P1 |
+| `confium-tc-ml-kem` | **Threshold ML-KEM (FIPS 203) — research** | P1 |
+| `confium-tc-ecies-p256` | Threshold ECIES | P2 |
+| `confium-tc-fhe-bfv` | Threshold BFV FHE (research) | P3 |
+
+### Mode 2 specific — PKI replacement interface shims
+
+| Crate | Purpose | Priority |
+|---|---|---|
+| `confium-pkcs11-server` | Exposes PKCS#11 v3.0; dispatches to threshold protocol | **P0 — Mode 2 cornerstone** |
+| `confium-openssl-provider` | OpenSSL 3.0 provider using Confium for signing | P0 |
+| `confium-tls-signer` | TLS 1.3 signature callback satisfying via threshold | P1 |
+| `confium-jce-provider` | Java Cryptography Extension provider (Java KeyStore compat) | P2 |
+
+### Mode 3 specific — institutional configuration
+
+| Crate | Purpose | Priority |
+|---|---|---|
+| `confium-config` | Deployment manifest schema + validation | P0 |
+| `confium-cert-delegation` | Scoped delegation templates | P0 |
+| `confium-xmldsig` | XMLDSig + Exclusive C14N (CNML uses) | P0 |
+| `confium-ers` | RFC 4998 Evidence Record Syntax | P1 |
+| `confium-attributes` | Attribute-based threshold party selection | P2 |
+| `confium-ring` | Threshold ring signatures (research) | P3 |
+
+### Framework infrastructure (all modes)
+
+| Crate | Purpose | Priority |
+|---|---|---|
+| `confium-cert` | X.509 v3 cert + CSR types, path validation | P0 |
+| `confium-cms` | CMS/PKCS#7 SignedData envelope | P0 |
+| `confium-identity` | Actor identity: signing + encryption keypairs | P0 |
+| `confium-tc-coordinator` | Async session coordinator (multi-quorum, multi-tenant) | P0 |
+| `confium-tc-reshare` | Share refresh + dynamic committee re-sharing | P0 |
+| `confium-ots` | OpenTimestamps client + verifier | P1 |
+| `confium-transparency` | Append-only Merkle tree with OTS-anchored roots | P1 |
+| `confium-composite` | Composite (multi-alg) signature aggregation | P1 |
+
+### Hardware backends (all modes, standards-only)
+
+| Crate | Standard | Status |
+|---|---|---|
+| `confium-store-pkcs11` | PKCS#11 v3.0 | extend existing |
+| `confium-store-tpm` | TPM 2.0 | extend existing |
+| `confium-store-cloud` | AWS/GCP/Azure KMS REST | extend existing |
+| `confium-store-openpgp-card` | OpenPGP card | new — P0 |
+
+### Extended existing crates
+
+| Crate | Extension |
+|---|---|
+| `confium-tc` | `SessionParams` gains `quorum_id`, `attribute_predicate`, `unlock_window` |
+| `confium-tc` | `SessionResult` gains `signed_proof_of_misbehavior` |
+| `confium-tc` | Async session lifecycle states |
+| `confium-tc-frost-ed25519`, `confium-tc-cmp20` | Expose identifiable abort via FFI |
+| `confium-sandbox-wasm` | Browser signing client (any mode) |
+| `confium-net-ws` | WebSocket transport for async sessions |
+
+## Hardware standards — no vendor lock-in
+
+Industry-de-facto standard interfaces only. No vendor-specific SDKs.
+
+| Backend | Standard | Covers |
+|---|---|---|
+| PKCS#11 (OASIS v3.0) | All HSMs | YubiKey PIV, SoftHSM, AWS CloudHSM, Thales Luna, Utimaco |
+| TPM 2.0 (TCG) | All modern hardware | Laptops, servers, IoT |
+| OpenPGP card | Open standard | YubiKey OpenPGP applet, Nitrokey, Gnuk |
+| WebAuthn / FIDO2 | W3C standard | Browser-native authentication |
+| Cloud KMS (REST) | Open APIs | AWS KMS, GCP KMS, Azure Key Vault |
+| Android Keystore / iOS Secure Enclave | Platform | Mobile signing |
+
+The wrapped-share pattern works across all of these uniformly.
+Explicitly out of scope: any vendor SDK. If a vendor offers a
+non-standard API, the answer is "implement PKCS#11 or stay
+unsupported."
+
+## Transparency infrastructure (framework-level)
+
+Every Mode 3 deployment gets append-only Merkle tree transparency
+with OTS anchoring. Mode 2 deployments opt in for high-value use
+cases. Mode 1 rarely needs transparency.
+
+```
+Deployment operates its own append-only Merkle tree of all issued
+artifacts (certs, signatures, revocations, re-sharing events)
+   ↓ tree root periodically committed to Bitcoin via OTS
+   ↓ tree published on deployment's website + IPFS mirror
+Verifier (offline): downloads Merkle branch + OTS proof
+   → proves "this artifact was in the tree as of block N"
+```
+
+## Crate publishing — parsanol-rs conventions
+
+Following the parsanol-rs pattern, all public Confium crates
+publish to crates.io.
+
+### Workspace metadata
+
+```toml
+[workspace.package]
+version = "0.1.0"
+edition = "2024"
+authors = ["Ribose Inc. <open.source@ribose.com>"]
+license = "MIT"
+repository = "https://github.com/confium/confium"
+homepage = "https://confium.org"
+rust-version = "1.85"
+```
+
+### Per-crate metadata
+
+Every published crate carries `description`, `documentation`,
+`keywords`, `categories`, `rust-version`, `readme`, with
+`metadata.docs.rs` set to `all-features = true`.
+
+### CI workflows
+
+| Workflow | Purpose |
+|---|---|
+| `ci.yml` | fmt + clippy + test + deny + machete on every PR |
+| `release.yml` | release-plz on push to main → auto version bump, changelog, crates.io publish |
+| `docs.yml` | Deploy RustDoc to docs.rs mirror on confium.org |
+| `release-binary.yml` | Static `confium` CLI binaries for Linux/macOS/Windows |
+| `wasm.yml` | `confium-wasm` artifact published to npm |
+
+### Downstream rebuild triggers
+
+When `confium-core` publishes, trigger rebuild of:
+- `confium-ruby` (Ruby bindings via FFI)
+- `confium.github.io` (Jekyll site)
+- `rnp-rs` (RNP bindings)
+- CNML project (OIML SMART, Mode 3 flagship)
+- Future: any downstream deployment or integration
+
+## Demonstration strategy
+
+### Mode 1 demonstrations
+
+- 5-minute quickstart tutorials (peer-to-peer signing, MPC)
+- Cookbook recipes on docs.confium.org
+- FFI examples for Python/Go/C calling Confium
+- WASM demo: browser-based MPC
+- Conference demos at RWC, RustConf
+
+### Mode 2 demonstrations
+
+- `confium-pkcs11-server` deployed alongside OpenSSL, signing
+  certs via threshold protocol (zero OpenSSL code changes)
+- "Replace your HSM with a Confium cluster" tutorial
+- Case study: enterprise code-signing deployment
+- RSA Conference booth demo
+
+### Mode 3 demonstrations
+
+- **OIML CNML** (Q3 2026 – Q2 2027) — flagship deployment.
+  Detailed in `TODO.roadmap/27`. NIST MPTS submission Q2 2027.
+- **BIPM calibration** (potential, post-Q2 2027) — second
+  deployment, validates framework generality.
+- **One non-metrology deployment** (potential, post-Q3 2027) —
+  demonstrates Mode 3 applies beyond metrology. Candidate:
+  pharmaceutical regulator or financial audit firm.
+- **Reference deployment profiles** (ongoing) — pre-built
+  `confium.toml` templates for common organizational patterns.
+
+## Why this framing works as an adoption driver
+
+- **Framework, not single-purpose system.** Three modes cover
+  virtually every threshold cryptography use case.
+
+- **Mode 1 builds developer mindshare.** Open source developers
+  adopt Confium for peer-to-peer TC; many contribute plugins.
+
+- **Mode 2 builds enterprise revenue.** PKCS#11 drop-in is the
+  enterprise Trojan horse — every PKCS#11 app is a potential
+  Confium consumer.
+
+- **Mode 3 builds institutional credibility.** CNML and similar
+  deployments prove the framework at the highest stakes.
+
+- **PQ migration is the Mode 2 killer feature.** Enterprises
+  facing PQ transition can either replace all their HSMs or
+  deploy Confium. Software wins.
+
+- **Real flagship.** OIML CNML anchors the framework in real
+  institution-grade deployment, not toy examples.
+
+- **Real research output.** Each paper cites Confium as reference
+  implementation; each deployment adds to the corpus.
+
+- **Real publishing pipeline.** Crates on crates.io, docs on
+  docs.rs, downstream consumers auto-rebuilt.
+
+## Anti-goals / scope discipline
+
+- **Not** a single-mode system. All three modes are first-class.
+- **Not** a single-deployment system. CNML is one Mode 3
+  configuration; the framework must support many.
+- **Not** a new transparency log architecture. Append-only Merkle
+  tree + OTS anchoring. CoSi is a future enhancement.
+- **Not** a new PKI. X.509 v3, CMS, XMLDSig — all standardized.
+- **Not** "blockchain for X." OTS anchoring is sufficient.
+- **Not** general-purpose attribute-based signatures formally.
+  ABT predicates scoped to organizational needs.
+- **Not** any vendor-SDK-backed HSM integration. Standards only.
+- **Not** the workflow orchestrator. Multi-tier composition lives
+  in the deployment application.
+- **Not** a NIST gatekeeper. Confium provides the bench, not the
+  verdict.
+
+## Open questions (framework-level)
+
+1. **PQ threshold schedule.** Threshold ML-KEM and ML-DSA are
+   research-frontier. Approach academic collaborator after classical
+   system fully deployed (post-Q2 2027).
+
+2. **Composite signature standardization.** IETF COMPOSITE SIG
+   draft in flux. Ship current and re-version, or wait for FIPS
+   800-208A final?
+
+3. **Funding.** Framework scope is ~18-24 months. Mode 1 work
+   is OSS; Mode 2 work may attract enterprise funding; Mode 3
+   work may attract government grants.
+
+4. **PKCS#11 server scope.** Full PKCS#11 v3.0 is huge. MVP is
+   sign + decrypt + generate-key-pair + minimal key management.
+   What's the minimum to call it a real drop-in?
+
+5. **OpenSSL provider vs engine.** OpenSSL 3.0 deprecated engines
+   in favor of providers. Provider is the right target. Engine
+   compatibility for OpenSSL 1.1 if needed.
+
+6. **NIST transparency log hosting.** Does NIST host a mirror of
+   deployment transparency logs (independent verifier anchor)?
+
+7. **Cross-organization recognition.** When deployment A's
+   certificates need to be recognized by deployment B (e.g., OIML
+   MAA pattern), what's the cryptographic composition? BLS
+   aggregate? Multi-sig? Threshold-over-deployment-quorums?
+
+8. **Configuration schema versioning.** As deployments evolve,
+   their manifests change. How do verifiers handle manifest
+   version skew?
+
+9. **Plugin compatibility across deployments.** A deployment
+   might require specific plugin versions or features. How does
+   the plugin registry express deployment-specific requirements?
+
+## Reference
+
+- `TODO.roadmap/00-vision-and-mission.md` — why NIST MPTS matters
+- `TODO.roadmap/04-threshold-cryptography.md` — TC interface design
+- `TODO.roadmap/08-security-model.md` — memory, sandbox, audit
+- `TODO.roadmap/09-nist-evaluation-harness.md` — eval bench
+- `TODO.roadmap/25-nist-threshold-call.md` — the deadline
+- `TODO.roadmap/27-cnml-deployment.md` — Mode 3 flagship case study
+- `~/src/oimlsmart/digital-certificates/README.md` — CNML project
+- `~/src/parsanol/parsanol-rs/release-plz.toml` — publishing template
+- [IETF COMPOSITE SIG draft](https://datatracker.ietf.org/wg/lamps/documents/)
+- [RFC 4998 Evidence Record Syntax](https://www.rfc-editor.org/rfc/rfc4998)
+- [FIPS 203 ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)
+- [FIPS 204 ML-DSA](https://csrc.nist.gov/pubs/fips/204/final)
+- [NIST MPTS 2026 workshop](https://csrc.nist.gov/events/2026/mpts2026)
+- [OASIS PKCS #11 v3.0](https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html)
+- [OpenSSL 3.0 Provider API](https://www.openssl.org/docs/manmaster/man7/provider.html)
+- [TCG TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/)
+- [Herzberg et al., "Proactive Secret Sharing," 1995](https://www.cs.cornell.edu/people/rafael/papers/ProactiveSecretSharing.ps)
+- [FROST draft-irtf-cfrg-frost-13](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)

--- a/TODO.roadmap/27-cnml-deployment.md
+++ b/TODO.roadmap/27-cnml-deployment.md
@@ -1,0 +1,569 @@
+# 27 — CNML flagship deployment: OIML sovereign threshold PKI
+
+## CNML is the Mode 3 flagship
+
+Confium supports three layered deployment modes (see
+`TODO.roadmap/26`): Mode 1 (peer-to-peer TC), Mode 2 (TC PKI
+replacement via PKCS#11 drop-in and PQC migration), Mode 3
+(TC Certificate PKI with custom formats and deep workflows).
+
+The OIML Certificat Numérique de Métrologie Légale (CNML) project —
+Ribose's existing project at `~/src/oimlsmart/digital-certificates/`,
+delivered under the OIML SMART program — is the **Mode 3 flagship
+reference deployment**. It demonstrates Confium at the highest-stakes
+end of the spectrum:
+
+- **International treaty organization** (OIML, 60+ member states)
+- **Nation-state adversary** (cyber + political pressure)
+- **Decades-long archival** (instruments last 10-20 years)
+- **Sovereignty sensitivity** (no single nation trusted)
+- **Globally distributed directors** (async signing required)
+- **Annual ceremony cadence** (root operations only)
+
+Partnerships locked in:
+- **Ribose** operates OIML SMART, owns CNML, owns Confium
+- **BIML** (OIML secretariat) is the institutional partner
+- **NIST** partners on MPTS evaluation
+
+This deployment is what NIST MPTS evaluators, OIML member states,
+and the cryptographic research community will see as proof that
+threshold cryptography solves real governance problems. The
+**framework** (`TODO.roadmap/26`) supports all three modes; this
+is the Mode 3 deployment that proves it works at the deepest level.
+
+Mode 1 deployments are typically small-scale developer use cases
+(distributed custody, MPC, BFT signing) covered by API docs and
+examples. Mode 2 deployments are enterprise PKI replacements
+(`confium-pkcs11-server` is the cornerstone; future case studies
+will follow).
+
+## What's wrong with CNML's status quo
+
+Today CNML uses:
+
+- **Single-party ECDSA P-256** for every signing layer
+- **2-of-2 Shamir** for BIML root key — recombined on a signing
+  workstation during ceremony (the recovery step is the weak point)
+- **Browser IndexedDB** software keys for end-entity signers
+- **OpenTimestamps** for blockchain anchoring (good)
+- **CRL** for revocation (good, but no accountability)
+- **No encryption layer** — confidential test reports stored in
+  plaintext, or protected only by transport TLS
+- **No async signing** — every ceremony requires synchronous
+  coordination, infeasible for globally distributed directors
+- **No director rotation without root renewal** — changing the
+  threshold party requires changing the keypair, invalidating all
+  issued certificates
+
+Confium replaces all of these with framework primitives configured
+for CNML's specific tier structure and policies.
+
+## CNML's five-tier configuration
+
+CNML deploys Confium with a **five-tier hierarchy** including
+**delegated signing at the manufacturer tier**.
+
+```
+BIML Root (OIML directors, threshold 5-of-7, annual ceremony)
+  │ signs
+  ▼
+IA Cert (national Issuing Authority, threshold 2-of-3, async signing)
+  │ signs                                       │ signs
+  ▼                                             ▼
+TL Cert (Testing Lab accreditation)         Manufacturer Model Cert
+  │                                             (scoped delegation: manufacturer
+  │                                             can issue instance certs for
+  │                                             THIS specific model only)
+  │                                             │ signs (manufacturer, single-party)
+  │                                             ▼
+  │                                          Instance Cert (individual measuring
+  │                                             instrument, physical or software)
+  │
+  └─→ signs test report → encrypts to IA threshold KEM
+```
+
+| Tier | Signing | Encryption | Threshold | Ceremony |
+|---|---|---|---|---|
+| **BIML** | Threshold FROST-Ed25519 + ML-DSA-65 composite | Threshold ML-KEM-768 | 5-of-7 directors | Annual sync (root ops); emergency async |
+| **IA** | Threshold FROST-P256 | Threshold ElGamal-P256 | 2-of-3 officers | Async |
+| **TL** | ECDSA-P256 single-party | ECIES-P256 single-party | 1-of-1 | Async |
+| **Manufacturer (Model)** | ECDSA-P256 single-party | ECIES-P256 single-party | 1-of-1 | Async |
+| **Manufacturer (Instance)** | ECDSA-P256 single-party | n/a | 1-of-1 | Async |
+
+Each national IA has its own threshold quorum, independently keyed
+via its own DKG. Hundreds of distinct IA quorums coexist with the
+single BIML root quorum.
+
+### Delegated signing at the manufacturer tier
+
+The IA's Manufacturer Model Certificate is a **scoped delegation**:
+it authorizes a specific manufacturer to issue instance certificates
+for instruments of a specific model only.
+
+The Model Cert contains:
+- Manufacturer identity (name, national registration)
+- Model identifier (OIML R-Recommendation, model number, accuracy class)
+- Profile / specs hash (binding the model definition cryptographically)
+- Validity period (e.g., 5 years)
+- Issuance-count limit (optional)
+- Delegation scope extension: "may issue instance certs for model X only"
+
+The manufacturer's Instance Certs:
+- Reference the Model Cert (X.509 authorityKeyIdentifier)
+- Bind to a specific instrument (serial number, manufacturing date)
+- Bind to instance-specific data (firmware hash for software;
+  hardware measurements for physical)
+- Path validation: instance valid only if (a) signed by manufacturer,
+  (b) Model Cert valid, (c) Model Cert issued by recognized IA,
+  (d) IA cert chains to BIML root, (e) scope check passes
+
+A manufacturer **cannot** issue instance certs for a model it wasn't
+approved for. Path validation rejects them.
+
+### Tier-transition cryptography
+
+Every upward tier transition is **sign-then-encrypt-to-recipient-quorum**:
+
+```
+Manufacturer → TL:        encrypt(instrument + test plan, tl_pub)
+TL → IA:                  encrypt(sign(test_report, tl_priv), ia_threshold_pub)
+IA → BIML:                encrypt(escalation, biml_threshold_pub)
+IA → Public:              sign(cnml_cert, ia_threshold_priv)
+BIML → Public:            sign(ia_cert, biml_threshold_priv)
+Manufacturer → Public:    sign(instance_cert, manufacturer_priv)
+                          (under Model Cert scope)
+```
+
+Confium provides the primitives; the orchestration is the CNML
+application's job (`oiml-pki-server` Ruby + browser WASM clients).
+
+### Selective disclosure per artifact
+
+Each artifact has an audience scope, encrypted to the appropriate
+recipient:
+
+- **Test plan** — manufacturer + TL only (trade secrets)
+- **Test report** — TL + commissioning IA only (one IA, not all IAs
+  the TL works with)
+- **CNML certificate** — public (signed, transparency-logged)
+- **Instance certificate** — public (signed by manufacturer)
+- **Revocation evidence** — sealed (threshold-encrypted to BIML
+  quorum; decryptable only on court order via quorum ceremony)
+
+## Async signing — the operational model
+
+OIML directors are globally distributed. In-person annual ceremony
+is feasible only once per year, only for root operations. **All
+IA cert issuance, CNML cert issuance, and routine operations run
+async.**
+
+### Async session coordinator (BIML-operated)
+
+A coordinator service operated by BIML staff (one per quorum)
+buffers commitments and shares from directors. Directors
+participate when convenient — different time zones, different
+schedules.
+
+```
+Director's laptop (when convenient):
+  1. Director opens Confium app
+  2. Sees pending signing session (e.g., "IA-France cert issuance")
+  3. Reviews cert details
+  4. Enters passphrase → YubiKey decrypts wrapping key → share unwrapped
+     into Sensitive<T> memory
+  5. App generates Round 1 commitment (FROST nonce)
+  6. Commitment signed by YubiKey identity key (non-repudiation)
+  7. Commitment uploaded to coordinator
+  8. Director walks away. Session stays unlocked for ~4 hours
+     (configurable; refreshable).
+
+Coordinator (operated by BIML staff):
+  9. Detects T commitments received → broadcasts aggregated commitment
+  10. Notifies each participating director's app
+
+Director's laptop (later, when convenient):
+  11. App generates Round 2 share (session still in unlock window)
+  12. Share signed by YubiKey
+  13. Share uploaded
+
+Coordinator:
+  14. Once T shares received, aggregates → final signature
+  15. Signature applied to certificate
+  16. Full transcript audit-logged
+```
+
+Director active time: ~5 minutes per round. Director never
+coordinates with other directors. Total session wall time: hours
+to days depending on director availability.
+
+The coordinator is honest-but-curious: it sees commitments and
+shares but cannot reconstruct the secret key. Director identity-key
+signatures prevent forged commitments. Session unlock window
+default: 4 hours (configurable per quorum).
+
+### Annual ceremony — what's done there
+
+The annual ceremony is sacred: in-person, network-isolated,
+ambassador-credential-verified. Operations performed:
+
+- **Root DKG** (initial keypair generation, one-time)
+- **Root renewal** (new keypair, cross-signed with old, every N
+  years for algorithm migration or compromise recovery)
+- **Director rotation** (sync re-sharing, in-person verification
+  of new directors)
+- **Quorum policy changes** (e.g., changing T from 5-of-7 to 6-of-9)
+- **Audit review** (physical evidence inspection, transparency log
+  reconciliation)
+
+Everything else runs async via the coordinator.
+
+## Director identity and key management
+
+### Standardized hardware, self-generated keys
+
+Two-tier protection: **YubiKey/OpenPGP card proves director identity**
+(signs protocol messages, decrypts share wrapping key); **laptop
+runs the threshold protocol** with unwrapped share in `Sensitive<T>`
+memory.
+
+- **Hardware**: OIML specifies the standard model (e.g., YubiKey 5
+  CSPN-certified or OpenPGP card v3.4). Procured centrally by OIML
+  to ensure firmware integrity, distributed to directors at ceremony.
+- **Key generation**: each director generates their own identity
+  keypair on the device, in person, during annual ceremony. No OIML
+  escrow of private keys.
+- **Registration**: director's public identity key certified under
+  BIML identity cert (separate from root signing cert).
+- **Share storage**: threshold share stored on disk, encrypted with
+  AES-256-GCM under a key wrapped by the YubiKey's PIV decrypt key.
+  Share is unusable without physical device + passphrase.
+
+### Why this design
+
+- **No OIML key escrow**: directors generate their own keys
+- **Hardware standardization**: consistent security level
+- **Two-tier protection**: compromised laptop alone cannot use share
+- **Duress codes**: YubiKey PIN can be configured so a special PIN
+  wipes the share locally and alerts coordinator
+
+## Director rotation and committee evolution
+
+Two distinct operations, often confused:
+
+| Operation | What changes | Public key | When |
+|---|---|---|---|
+| **Share re-sharing** | Committee composition (add/remove director) | **Unchanged** | Any time (T current directors collaborate) |
+| **Root renewal** | Root keypair itself | **New keypair** | Annual ceremony, every N years |
+
+For director rotation: **share re-sharing preserves the public key**.
+All dependent certs (IA certs, CNML certs, instance certs) remain
+valid. No re-issuance cascade. This is critical because BIML has
+hundreds of IA certs in the field, each potentially with thousands
+of CNML certs and millions of instance certs beneath.
+
+### Re-sharing protocol
+
+```
+Setup: C_old = {Alice, Bob, Carol, Dave, Eve}, T=3-of-5
+       Alice is leaving. Frank is joining.
+       C_new = {Bob, Carol, Dave, Eve, Frank}
+
+Step 1: T current directors (e.g., Bob, Carol, Dave) participate
+Step 2: Each participating director computes Lagrange interpolation
+        of their share at each new party's index:
+          For each j in C_new:
+            s_j_new = Σ over participating-i of (Lagrange_basis(j, i) * s_i_old)
+Step 3: Each new share s_j_new encrypted to party j's YubiKey
+        (using party j's registered identity public key)
+Step 4: Encrypted shares transmitted
+Step 5: All old shares (including participating directors' old shares,
+        including departing director's share) destroyed (zeroized)
+Step 6: New committee tests: produces signature, verifies it validates
+        under same aggregate public key
+Step 7: Audit log records entire procedure, signed by all participants
+```
+
+Public key unchanged. All existing certs remain valid.
+
+### Scheduling rotations
+
+- **Routine rotation** (director term expires, new director elected):
+  sync re-sharing at annual ceremony. In-person verification is the
+  trust anchor.
+- **Emergency rotation** (director dies, YubiKey lost, director
+  compromised): async re-sharing. T current directors run the protocol
+  remotely. Documented in audit log with reason.
+- **Proactive refresh** (no committee change, just share refresh):
+  monthly or quarterly async refresh. Defends against gradual share
+  compromise over time.
+
+### Root renewal (rare)
+
+Root renewal generates a **new keypair**. Required for algorithm
+migration (Ed25519 → composite PQ), compromise recovery, or periodic
+refresh every 10-20 years.
+
+Protocol at annual ceremony:
+1. New DKG among current committee produces new root keypair
+2. New public key cross-signed by old root (transition cert)
+3. Transition cert published in transparency log
+4. Old root scheduled for retirement (1-year grace period)
+5. During grace: dependents (IAs) re-issue under new root
+6. After grace: old root marked revoked, transparency log finalized
+
+## The CNML demo narrative
+
+A CNML certificate for a high-stakes custody-transfer gas flow meter
+(OIML R 117 type approval), produced through the full 5-tier flow:
+
+```
+Setup (one-time per actor)
+  Each IA registered, has BIML-signed IA cert (threshold 2-of-3)
+  Each TL registered, has IA-signed TL cert
+  Each Manufacturer registered, may receive Model Certs from IAs
+  BIML root quorum (5-of-7 directors) — annual ceremony
+  All certs public, all in BIML transparency log
+
+Step 1 — Manufacturer develops new instrument model
+  Manufacturer designs gas flow meter model "FM-2026-A"
+  Submits to IA-France for type approval
+
+Step 2 — IA-France commissions TL for testing
+  IA-France threshold quorum signs a commissioning order
+  Order encrypted to chosen TL's encryption public key
+  TL decrypts, schedules tests
+
+Step 3 — Manufacturer submits instrument to TL
+  Manufacturer ships physical instance + test plan
+  Test plan encrypted to TL's encryption public key
+
+Step 4 — TL generates test report
+  TL runs tests per OIML R 117
+  TL signs test report (single-party)
+  TL encrypts (test report + signature) to IA-France's threshold
+    KEM public key (NOT to all IAs — only the commissioning IA)
+  Encrypted blob transmitted to IA-France
+
+Step 5 — IA-France reviews
+  IA-France threshold quorum (2-of-3 officers) collaboratively decrypt
+  IA verifies TL's signature against TL's certified public key
+  IA reviews content, makes determination
+  IA threshold-signs internal review record
+
+Step 6 — IA-France issues Manufacturer Model Cert (async BIML pathway)
+  IA threshold quorum signs Manufacturer Model Cert
+  Model Cert: manufacturer X, model "FM-2026-A", accuracy class 0.5,
+    validity 5 years, scope: "may issue instance certs for FM-2026-A only"
+  Model Cert committed to BIML transparency log, OTS-anchored
+
+Step 7 — Manufacturer issues Instance Certs (delegated, single-party)
+  Manufacturer produces gas flow meter S/N 0001
+  Manufacturer signs Instance Cert: serial 0001, model FM-2026-A,
+    firmware hash 0x..., manufacturing date, calibration data
+  Instance Cert references Model Cert via authorityKeyIdentifier
+  Manufacturer uploads Instance Cert to public transparency log
+  → Verifier (customs officer) can path-validate:
+    Instance Cert → Model Cert → IA-France cert → BIML root
+  → Scope check: model in Instance Cert must match Model Cert scope
+
+Step 8 — Field deployment
+  Instrument S/N 0001 deployed at a gas pipeline
+  Verifier (regulator, customer) scans instrument QR code
+  Verifier downloads Instance Cert + chain from public log
+  Standard XMLDSig verifier validates chain to BIML root
+  OTS proof demonstrates cert existed at deployment time
+
+Step 9 — Optional BIML oversight / high-stakes countersign
+  BIML samples some Manufacturer Model Certs for review
+  For high-stakes classes (custody-transfer), BIML threshold
+    quorum countersigns the Model Cert
+  Async — directors participate over hours
+
+Step 10 — Revocation (if needed)
+  Issue detected (field failure, lab fraud discovered)
+  IA-France threshold quorum revokes Model Cert (signed reason)
+  All Instance Certs under that Model Cert auto-revoked via OCSP/CRL
+  Manufacturer cannot issue new Instance Certs for that model
+  Revocation evidence threshold-encrypted to BIML quorum (sealed)
+  Transparency log records revocation with timestamp
+
+Step 11 — Long-term archival
+  Test report encrypted under IA-France threshold KEM
+  Every 5 years, current IA-France quorum re-encrypts under new KEM
+    (no plaintext exposure during re-encryption)
+  Survives decades — decryptable only via T-of-N ceremony
+```
+
+## Two co-equal cryptographic primitives
+
+CNML uses both threshold signing and threshold encryption at the
+institutional tiers.
+
+| Operation | Threshold primitive | CNML use case |
+|---|---|---|
+| IA cert issuance | **Threshold signing** | BIML quorum signs IA cert (async) |
+| TL cert issuance | **Threshold signing** | IA quorum signs TL cert (async) |
+| Manufacturer Model Cert issuance | **Threshold signing** | IA quorum signs scoped delegation |
+| CNML cert issuance | **Threshold signing** | IA quorum signs CNML cert |
+| Test report submission | **Threshold encryption** | TL encrypts to IA; IA quorum decrypts |
+| Cross-tier escalation | **Threshold encryption** | IA encrypts to BIML; BIML quorum decrypts |
+| Sealed revocation evidence | **Threshold encryption** | IA encrypts evidence; only court-ordered quorum decrypts |
+| Long-term calibration data | **Threshold PQ encryption** | Survives quantum adversary for 50+ years |
+| Director share wrapping | Single-party encryption | YubiKey-held key wraps share on disk |
+
+## Practical failure modes and recovery
+
+| Scenario | Recovery |
+|---|---|
+| Director loses YubiKey | Emergency async re-sharing: T remaining directors re-share excluding lost YubiKey's identity. Replacement director issued new YubiKey at next ceremony. |
+| Director's laptop compromised | Proactive share refresh (monthly): all current directors refresh; old shares invalidated. |
+| Director dies / resigns | Sync re-sharing at next annual ceremony (preferred) or async emergency. |
+| Director coerced during signing | Duress code on YubiKey PIN: wipes share locally, alerts coordinator. |
+| Coordinator compromised | Threshold property preserved. Director identity-key signatures prevent forged commitments. Coordinator can DoS but cannot corrupt. |
+| Quorum cannot form (too many unavailable) | Lower T at next ceremony. Between ceremonies, operations wait. |
+| Annual ceremony disrupted (pandemic) | Async emergency re-sharing as fallback. Root renewal deferred. Audit-logged. |
+| TL loses signing key | Single-party — TL reissues new key, gets new TL cert from IA. Old reports remain valid (signature already applied). |
+| Manufacturer loses signing key | Same as TL: new key, new Model Cert from IA. Old Instance Certs remain valid. |
+
+## CNML-specific engineering scope
+
+Most crates are framework-level (see `TODO.roadmap/26`). CNML adds
+configuration and integration:
+
+### CNML-specific configuration
+
+- `confium.toml` deployment manifest encoding the 5-tier hierarchy,
+  BIML 5-of-7 + IA 2-of-3 + TL/Mfr 1-of-1 thresholds, attribute
+  predicates (geography, expertise, COI), annual ceremony policy,
+  model-bound delegation rules
+- XMLDSig signing profile scoped to CNML XML schema
+- CMS envelope profile for CNML document signatures
+
+### CNML application integration
+
+- `oiml-pki-server` (Ruby) calls Confium via FFI for DKG, signing,
+  re-sharing, threshold encryption
+- Browser-based director UI (Vue island in CNML Astro app) loads
+  Confium WASM, signs via WebSocket to coordinator
+- Browser-based TL UI: TLs sign reports, encrypt to specific IA
+- Browser-based manufacturer UI: manufacturers issue instance certs
+  under their Model Cert scope
+- Existing 46 TS + 49 Ruby + 52 Playwright CNML tests pass against
+  Confium-backed CA
+
+### CNML-specific deployment artifacts
+
+- BIML transparency log operated by BIML staff
+- Per-IA quorum coordinators (operated by IA or by BIML on behalf)
+- Annual ceremony runbook (operational, not cryptographic)
+- Director training materials (UI walkthrough, passphrase management)
+
+## Demonstration plan
+
+### Audience 1: NIST MPTS evaluators (mandatory, Q2 2027)
+
+Reproducible artifact submitted to NIST's MPTS portal:
+
+- A signed CNML certificate, signed by a 5-of-7 BIML quorum (async)
+- A test report, signed by a TL, threshold-encrypted to a 2-of-3 IA
+  quorum, threshold-decrypted, then a Manufacturer Model Cert
+  threshold-signed by IA
+- A Manufacturer Instance Cert, signed by manufacturer under Model
+  Cert scope, path-validated
+- Async signing demonstrated: director commitments submitted over
+  hours, not simultaneously
+- Director rotation demonstrated: re-sharing preserves public key
+- Standard XMLDSig verifier passes on all public certs
+- Byzantine-fault simulation: rogue director caught, signed proof
+  emitted in <50ms
+- Performance report: signing and encryption ceremony wall times
+  across party counts 3, 5, 7, 11
+
+### Audience 2: BIML / OIML member states (operational)
+
+Working integration with the CNML project:
+
+- All CNML tests pass against Confium-backed CA
+- Live deployment to BIML test environment
+- Public transparency log live on confium.org
+- Annual ceremony runbook drafted
+- Director training delivered to first cohort
+
+### Audience 3: Academic community (research output, post-Q2 2027)
+
+Three papers, sequenced after classical system deployment:
+
+1. **"Sovereign threshold PKI: international metrology as a case
+   study"** — systems paper, USENIX Security or IEEE S&P.
+   Contributions: 5-tier architecture, delegated signing, async
+   coordinator, share re-sharing deployment.
+
+2. **"Threshold ML-KEM with proactive security for long-term
+   archival"** — theory + implementation, CRYPTO or EUROCRYPT.
+
+3. **"Attribute-based threshold signatures for cross-jurisdictional
+   governance"** — theory, CCS.
+
+Each paper cites Confium as reference implementation; each has
+artifact evaluation pointing at the OIML deployment.
+
+## Timeline
+
+| Quarter | Milestone |
+|---|---|
+| Q3 2026 | Publish framework core crates to crates.io. Ship `confium-cert` (with scoped delegation), `confium-cms`, `confium-identity`, `confium-store-pkcs11` + `confium-store-openpgp-card` wrapping backends. |
+| Q4 2026 | `confium-xmldsig`, `confium-tc-frost-p256`, `confium-tc-kem` interface, `confium-tc-coordinator` v0, `confium-tc-reshare` v0. First end-to-end CNML signature via Confium. |
+| Q1 2027 | Async signing flow deployed: director app, coordinator, session lifecycle. Composite signatures. Byzantine-proof FFI. Manufacturer Model Cert + Instance Cert flow. |
+| Q2 2027 | `confium-ots`, `confium-transparency` v0, threshold ElGamal. NIST MPTS submission: 5-tier architecture with signing + encryption + async + re-sharing. |
+| Q3 2027 | Approach academic collaborator with complete classical system. `confium-tc-ml-kem` research prototype begins. |
+| Q4 2027 | `confium-tc-frost-ml-dsa-65` (research). Composite PQ signing ceremony in CNML. |
+| Q1 2028 | `confium-ers` archival, periodic re-quorum demo. |
+| Q2 2028 | `confium-attributes` ABT, paper #1 submission. |
+| Q3 2028 | `confium-ring` (research), paper #2 submission. |
+| Q4 2028 | Paper #3 submission, full case study writeup. |
+
+NIST Threshold Call deadline gates Q2 2027. Classical system ships
+first; PQ threshold work follows with collaborator onboarded against
+a complete reference system.
+
+## CNML-specific open questions
+
+1. **Director identity cert chain.** Director identity keys are
+   certified separately from the root signing cert. What CA issues
+   the director identity cert? BIML itself (separate identity CA)?
+   Needed for async signing non-repudiation.
+
+2. **Re-sharing ceremony documentation.** Sync (annual) vs async
+   (emergency) procedures need formal writeup that BIML directors
+   can follow. Cryptographic protocol is clear; operational
+   procedure (who is in the room, what they verify, what they sign)
+   needs CNML-side documentation.
+
+3. **Cross-IA recognition crypto.** OIML MAA pattern: when IA-A's
+   CNML is recognized by IA-B. BLS aggregate? Simple multi-sig?
+   Threshold-over-IA-quorums?
+
+4. **BIML transparency log infrastructure.** Operated by BIML staff
+   on BIML-controlled infrastructure. Where hosted? BIML on-prem?
+   Cloud? Distributed across OIML member states for redundancy?
+
+5. **Test report retention policy.** Some OIML Recommendations
+   require test report retention for instrument lifetime (10-20
+   years). How does this interact with re-encryption cadence and
+   quorum evolution?
+
+## Reference
+
+- `TODO.roadmap/26-confium-framework.md` — framework vision (general)
+- `TODO.roadmap/00-vision-and-mission.md` — why NIST MPTS matters
+- `TODO.roadmap/04-threshold-cryptography.md` — TC interface design
+- `TODO.roadmap/08-security-model.md` — memory, sandbox, audit
+- `TODO.roadmap/09-nist-evaluation-harness.md` — eval bench
+- `TODO.roadmap/25-nist-threshold-call.md` — the deadline
+- `~/src/oimlsmart/digital-certificates/README.md` — CNML project
+- `~/src/parsanol/parsanol-rs/release-plz.toml` — publishing template
+- [FIPS 203 ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)
+- [FIPS 204 ML-DSA](https://csrc.nist.gov/pubs/fips/204/final)
+- [NIST MPTS 2026 workshop](https://csrc.nist.gov/events/2026/mpts2026)
+- [Herzberg et al., "Proactive Secret Sharing," 1995](https://www.cs.cornell.edu/people/rafael/papers/ProactiveSecretSharing.ps)
+- [FROST draft-irtf-cfrg-frost-13](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)

--- a/TODO.roadmap/28-mode2-pki-replacement.md
+++ b/TODO.roadmap/28-mode2-pki-replacement.md
@@ -1,0 +1,141 @@
+# 28 — Mode 2: TC PKI replacement
+
+## Scope
+
+Mode 2 deployments replace single-party PKI with threshold PKI
+**without changing the surrounding ecosystem**. Existing apps
+continue to use PKCS#11, OpenSSL, Java KeyStore, TLS — they don't
+know the keys are threshold-held.
+
+This is the enterprise Trojan horse: every PKCS#11 app in the world
+is a potential Confium consumer.
+
+## Audience
+
+Corporate security teams, CA operators, DevSecOps architects,
+HSM-using enterprises, government PKI operators.
+
+## Architecture
+
+```
+Existing app (nginx, OpenSSL, OpenSSH, Java app, etc.)
+   │ standard PKCS#11 / OpenSSL provider / JCE interface
+   ▼
+Confium compatibility shim
+   ├─ confium-pkcs11-server    (PKCS#11 v3.0 server)
+   ├─ confium-openssl-provider (OpenSSL 3.0 provider)
+   ├─ confium-jce-provider     (Java Cryptography Extension)
+   └─ confium-tls-signer       (TLS 1.3 callback)
+   │ Confium threshold dispatch protocol
+   ▼
+Confium coordinator + threshold quorum
+```
+
+## Crate scope
+
+### `confium-pkcs11-server` (P0 — cornerstone)
+
+Exposes PKCS#11 v3.0 API; dispatches internally to threshold
+protocol. Implemented as a shared library loaded by PKCS#11
+consumers (via `p11-kit` or direct `CK_C_Initialize`).
+
+**MVP functions** (covering ~95% of real-world PKCS#11 usage):
+
+| Function | Behavior |
+|---|---|
+| `C_Initialize` | Connect to coordinator, register session |
+| `C_Finalize` | Disconnect |
+| `C_GetInfo` | Report Confium as crypto backend |
+| `C_GetSlotList` | One slot per quorum |
+| `C_GetTokenInfo` | Quorum metadata as token info |
+| `C_OpenSession` | Open coordinator session |
+| `C_CloseSession` | Close session |
+| `C_GenerateKeyPair` | Trigger DKG; threshold keypair generated |
+| `C_SignInit` | Begin threshold signing session |
+| `C_Sign` | Synchronous threshold sign |
+| `C_SignUpdate` / `C_SignFinal` | Streaming threshold sign |
+| `C_VerifyInit` / `C_Verify` | Standard single-party verify (no threshold needed) |
+| `C_EncryptInit` / `C_Encrypt` | Standard single-party encrypt |
+| `C_DecryptInit` / `C_Decrypt` | Threshold decryption |
+| `C_GenerateRandom` | Standard RNG |
+| `C_SeedRandom` | No-op (threshold RNG not seedable) |
+| `C_GetAttributeValue` | Object metadata |
+| `C_FindObjectsInit` / `C_FindObjects` | Find threshold key objects |
+
+**Out of MVP**: certificate objects, secret key objects, key
+derivation, wrapping/unwrapping (deferred).
+
+### `confium-openssl-provider` (P0)
+
+OpenSSL 3.0 provider exposing Confium signing via the OpenSSL
+provider API. Consumers configure OpenSSL to load the Confium
+provider; subsequent signing operations via OpenSSL use threshold.
+
+### `confium-tls-signer` (P1)
+
+TLS 1.3 signature callback that satisfies `CertificateVerify` via
+threshold protocol. Useful for high-value TLS endpoints (root CAs,
+payment gateways).
+
+### `confium-jce-provider` (P2)
+
+Java Cryptography Extension provider. Java KeyStore and JCA apps
+use Confium-backed keys transparently.
+
+## Configuration (Mode 2 manifest)
+
+```toml
+[deployment]
+name = "Acme Corp PKI"
+mode = "pkcs11_replacement"
+manifest_version = 1
+
+[pkcs11_server]
+slot_count = 8
+default_signing_algorithm = "FROST-P256"
+default_threshold = { t = 3, n = 5 }
+share_storage = "pkcs11-wrap"
+hsm_module = "/usr/lib/pkcs11/yubihsm.so"
+
+[quorum.enterprise_root]
+threshold = { t = 3, n = 5 }
+coordinator = "coordinator.acme.corp:443"
+
+[quorum.code_signing]
+threshold = { t = 2, n = 3 }
+coordinator = "coordinator.acme.corp:443"
+
+[pqc_migration]
+current = "ECDSA-P256"
+target_2027 = "composite-ECDSA-P256-ML-DSA-65"
+target_2029 = "ML-DSA-65"
+```
+
+## Deployment pattern
+
+1. Deploy coordinator service (one per quorum)
+2. Deploy Confium share daemons on threshold party machines
+3. Install `confium-pkcs11-server` shared library on app machines
+4. Configure app's PKCS#11 module path to point at Confium
+5. App continues working unchanged
+
+## PQC migration path
+
+The killer Mode 2 feature. Enterprises facing PQ transition:
+
+- **Without Confium**: upgrade all HSMs to PQ-capable firmware
+  (years of vendor cooperation), re-do threshold protocols for
+  new algorithms, re-issue all credentials.
+- **With Confium**: software upgrade. PKCS#11 interface unchanged.
+
+Algorithm choices per quorum via manifest. Migration via composite
+signatures (classical + PQ) for verifier back-compat. See
+`TODO.roadmap/35-pq-composite-signatures.md`.
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md` — three-mode framework vision
+- `TODO.roadmap/29-tc-coordinator-design.md` — coordinator details
+- `TODO.roadmap/35-pq-composite-signatures.md` — PQC migration
+- [OASIS PKCS#11 v3.0](https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html)
+- [OpenSSL 3.0 Provider](https://www.openssl.org/docs/manmaster/man7/provider.html)

--- a/TODO.roadmap/29-tc-coordinator-design.md
+++ b/TODO.roadmap/29-tc-coordinator-design.md
@@ -1,0 +1,162 @@
+# 29 — Async session coordinator design
+
+## Purpose
+
+The coordinator service enables globally distributed threshold
+signers to participate when convenient — no simultaneity required.
+
+This is the operational backbone for institutional deployments
+(BIML directors, IA officers) where sync ceremonies are infeasible
+for routine operations.
+
+## Design
+
+### Roles
+
+- **Coordinator** — service buffering commitments and shares;
+  honest-but-curious. Cannot reconstruct secret. Sees commitments
+  and shares; signs every step.
+- **Signer** — director / officer app holding a threshold share.
+  Submits commitments and shares when convenient.
+- **Requester** — application requesting a signature. Submits
+  the message to be signed; receives the final signature.
+
+### Session lifecycle (state machine)
+
+```
+Pending           Session created by requester; awaiting signer commitments
+   ↓
+CommitmentsCollected   T commitments received by coordinator
+   ↓
+SharesCollected   T shares received by coordinator
+   ↓
+Completed         Signature produced, applied to artifact
+   ↓
+Closed            Final state, audit log complete
+
+Or:
+
+Expired           Unlock window elapsed before T commitments/shares
+   ↓
+Closed
+```
+
+### FFI sketch
+
+```c
+// Coordinator-side
+uint32_t cfmc_session_create(
+    Coordinator *c,
+    const char *quorum_id,
+    const uint8_t *message, size_t message_len,
+    const char *scheme,
+    uint32_t threshold_t,
+    uint32_t unlock_window_seconds,
+    CoordinatorSession **out);
+
+uint32_t cfmc_session_status(
+    CoordinatorSession *s,
+    SessionStatus *status_out);
+
+uint32_t cfmc_session_submit_commitment(
+    CoordinatorSession *s,
+    const char *signer_id,
+    const uint8_t *commitment, size_t commitment_len,
+    const uint8_t *signer_signature, size_t sig_len);
+
+uint32_t cfmc_session_submit_share(
+    CoordinatorSession *s,
+    const char *signer_id,
+    const uint8_t *share, size_t share_len,
+    const uint8_t *signer_signature, size_t sig_len);
+
+uint32_t cfmc_session_aggregate(
+    CoordinatorSession *s,
+    uint8_t **signature_out,
+    size_t *sig_len_out);
+
+// Signer-side
+uint32_t cfms_signer_pending_sessions(
+    Signer *s,
+    const char *quorum_id,
+    PendingSession **sessions_out,
+    size_t *count_out);
+
+uint32_t cfms_signer_submit_commitment(
+    Signer *s,
+    CoordinatorSession *session,
+    const uint8_t *share_unlocked, size_t share_len);
+
+uint32_t cfms_signer_submit_share(
+    Signer *s,
+    CoordinatorSession *session);
+```
+
+### Transport
+
+- Signer ↔ Coordinator: WebSocket (`confium-net-ws`) for push
+  notifications, or HTTP long-poll for compatibility
+- Requester ↔ Coordinator: HTTP REST
+- All messages signed by sender identity key
+
+### Trust model
+
+Coordinator sees commitments and shares but cannot:
+- Reconstruct the secret key (threshold property)
+- Forge commitments (director identity-key signatures)
+- Forge shares (director identity-key signatures)
+- Modify transcript (audit log is append-only, OTS-anchored)
+
+Coordinator can:
+- DoS the session (withhold aggregation)
+- Identify which signers participated (no anonymity)
+
+For high-stakes deployments, multiple coordinators can run in
+parallel; signers submit to all; aggregation requires any
+coordinator to succeed. Reduces DoS surface.
+
+## Crate scope
+
+### `confium-tc-coordinator` (P0)
+
+- `Coordinator` struct owning quorum configs and active sessions
+- `CoordinatorSession` state machine
+- HTTP/WS server (using `axum` + `tokio-tungstenite`)
+- Persistence: SQLite for session state (recoverable across restarts)
+- Audit log: append-only JSONL with hash chaining
+- Multi-tenant: one coordinator can serve multiple quorums
+
+### `confium-cli` extensions
+
+- `confium coordinator start` — run coordinator service
+- `confium coordinator status` — list active sessions
+- `confium coordinator session <id>` — session details
+
+### `confium-sandbox-wasm` extensions
+
+- WASM signer UI: list pending sessions, submit commitment/share
+- Used by browser-based director/TL/manufacturer apps
+
+## Security
+
+- Every protocol message signed by sender identity key (non-repudiation)
+- Every coordinator action logged with timestamp + director signatures
+- Replay protection: each session has unique nonce; old commitments rejected
+- Coordinator compromise: threshold property preserved; can DoS, cannot corrupt
+- Audit log OTS-anchored periodically (transparency integration)
+
+## Failure modes
+
+| Scenario | Recovery |
+|---|---|
+| Coordinator crashes mid-session | SQLite state recovered on restart; sessions resume |
+| Signer submits then goes offline | Coordinator waits; session expires after unlock window |
+| Coordinator maliciously withholds aggregation | Requester can rerun with different coordinator (if multi-coordinator config) |
+| Network partition | Signers queue commitments locally; submit when partition heals |
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/27-cnml-deployment.md` — BIML async signing model
+- `TODO.roadmap/30-tc-reshare-protocol.md` — uses coordinator for re-sharing sessions
+- FROST draft-irtf-cfrg-frost-13 § 5 (signing flow)

--- a/TODO.roadmap/30-tc-reshare-protocol.md
+++ b/TODO.roadmap/30-tc-reshare-protocol.md
@@ -1,0 +1,164 @@
+# 30 — Share re-sharing and proactive refresh
+
+## Purpose
+
+Enable threshold committee evolution **without changing the public
+key**. Director/officer rotation, proactive security refresh,
+emergency committee changes — all preserve existing dependent certs.
+
+This is the operational enabler for long-term institution-grade
+threshold crypto. Without it, every director change forces a
+re-issuance cascade.
+
+## Two distinct operations
+
+| Operation | What changes | Public key | When |
+|---|---|---|---|
+| **Re-sharing** | Committee composition (add/remove party) | **Unchanged** | Any time |
+| **Proactive refresh** | All shares refreshed; committee same | **Unchanged** | Periodic (monthly/quarterly) |
+| **Root renewal** | Root keypair itself | **New keypair** | Rare — algorithm migration |
+
+This document covers re-sharing and proactive refresh. Root
+renewal is in `TODO.roadmap/35-pq-composite-signatures.md`.
+
+## Re-sharing protocol
+
+### Setup
+
+Current committee `C_old = {p_1, ..., p_n}` with shares `s_1, ..., s_n`,
+threshold `T_old`. Aggregate secret `s = Σ s_i · λ_i(0)` (Lagrange
+interpolation at origin) defines the public key `P = s · G`.
+
+New committee `C_new = {q_1, ..., q_m}` with threshold `T_new`.
+
+### Protocol (T-old-of-N-old directors participate)
+
+```
+Step 1: T current directors (e.g., p_1, ..., p_T) agree to re-share
+Step 2: Each participating director p_i:
+   For each new party q_j in C_new:
+     Compute share contribution:
+       s_i→j = s_i · Lagrange_basis(j evaluated at p_i's index)
+   Send each s_i→j encrypted to q_j's identity key
+
+Step 3: Each new party q_j:
+   Receives T contributions s_1→j, ..., s_T→j
+   Computes new share: s_j_new = Σ contributions
+   Verifies new share is consistent (test signature validates
+     under same public key P)
+
+Step 4: All old shares destroyed (zeroized)
+Step 5: New committee produces test signature, verifies under P
+Step 6: Audit log records entire procedure, signed by all participants
+```
+
+Public key P unchanged. All dependent certs remain valid.
+
+### FFI sketch
+
+```c
+uint32_t cfmp_reshare_session_create(
+    FFITcSession **out,
+    const char *scheme,
+    const CFMTcPartyList *old_committee,
+    const CFMTcPartyList *new_committee,
+    uint32_t t_old,
+    uint32_t t_new,
+    const Option *opts);
+
+uint32_t cfmp_reshare_session_round(
+    FFITcSession *s,
+    const CFMTcMessage *incoming, uint32_t incoming_count,
+    CFMTcMessage **outgoing, uint32_t *outgoing_count,
+    uint8_t *complete,
+    const Option *opts);
+
+uint32_t cfmp_reshare_session_new_share(
+    FFITcSession *s,
+    CFMTcShare **new_share_out);
+
+uint32_t cfmp_reshare_session_destroy(FFITcSession *s);
+```
+
+## Proactive refresh protocol
+
+Periodic share refresh defends against gradual compromise. An
+adversary who collects T-1 shares over time still cannot sign —
+each refresh invalidates previous shares.
+
+### Protocol (Herzberg et al. 1995 pattern)
+
+```
+Step 1: Each party p_i generates random polynomial f_i(x) of degree T-1
+        with f_i(0) = 0 (so sum of all f_i(0) = 0)
+Step 2: Each p_i sends f_i(j) to each other party p_j (encrypted)
+Step 3: Each p_j computes new share: s_j_new = s_j_old + Σ_i f_i(j)
+Step 4: All old shares (s_j_old) destroyed
+Step 5: Aggregate secret s = Σ s_j_new · λ_j(0) unchanged
+        (because Σ f_i(0) = 0)
+```
+
+Public key unchanged. Old shares useless after refresh.
+
+### Schedule
+
+- Default: monthly refresh
+- Configurable per quorum in manifest
+- Triggered by coordinator (async, like signing sessions)
+
+## Scheduling rotations
+
+| Trigger | Type | Sync? |
+|---|---|---|
+| Director term expires | Routine | Sync (annual ceremony) |
+| Director dies / resigns | Emergency | Async |
+| Director YubiKey lost | Emergency | Async |
+| Director compromised | Emergency | Async |
+| Periodic refresh | Routine | Async |
+| Quorum policy change | Routine | Sync (annual ceremony) |
+
+## Re-sharing on the coordinator
+
+The async coordinator (`TODO.roadmap/29-tc-coordinator-design.md`)
+handles re-sharing sessions like signing sessions:
+
+- T current directors submit re-share commitments
+- Coordinator collects, broadcasts
+- Each new party submits new-share confirmation
+- Coordinator records in audit log
+
+## Crate scope
+
+### `confium-tc-reshare` (P0)
+
+- `ReshareSession` struct managing the protocol state
+- Implements both re-sharing and proactive refresh
+- Algorithms: any that support Lagrange interpolation over the
+  secret-sharing field (FROST, CMP20, GG18 — all compatible)
+- FFI via `cfmp_reshare_*` functions
+
+### `confium-tc` extensions
+
+- `SessionKind` enum: `Signing | Dkg | Reshare | Refresh`
+- Existing session lifecycle extended to support reshare/refresh
+
+### `confium-cli` extensions
+
+- `confium quorum reshare --quorum <id> --add <party> --remove <party>`
+- `confium quorum refresh --quorum <id>`
+
+## Security
+
+- Every re-share message signed by sender identity key
+- Old shares MUST be cryptographically destroyed (zeroize + audit)
+- Test signature after re-share verifies new committee works
+- Re-share ceremony audit-logged with all participant signatures
+- Compromise window: between last refresh and current share — T-1
+  collected shares in this window still cannot sign
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/29-tc-coordinator-design.md`
+- [Herzberg et al., "Proactive Secret Sharing," 1995](https://www.cs.cornell.edu/people/rafael/papers/ProactiveSecretSharing.ps)
+- [FROST draft-irtf-cfrg-frost-13](https://datatracker.ietf.org/doc/draft-irtf-cfrg-frost/)

--- a/TODO.roadmap/31-threshold-encryption.md
+++ b/TODO.roadmap/31-threshold-encryption.md
@@ -1,0 +1,171 @@
+# 31 — Threshold encryption
+
+## Purpose
+
+Threshold encryption is the co-equal of threshold signing. Anyone
+can encrypt to a public key; T-of-N parties collaborate to decrypt.
+
+Without threshold encryption, the framework only solves half the
+problem. Confidential data sent to an institution must be readable
+only via quorum ceremony, not by a single party.
+
+## Use cases
+
+- **Confidential archival**: lab test reports sealed to BIML quorum
+  for decades. Decryptable only via T-of-N ceremony.
+- **Sealed evidence**: revocation evidence threshold-encrypted,
+  revealed only on court order via quorum.
+- **Cross-tier escalation**: IA encrypts sensitive data to BIML
+  quorum; only BIML threshold can decrypt.
+- **Key escrow**: end-entity signer keys escrowed to quorum for
+  recovery.
+- **Browser-side encryption**: labs encrypt test reports in
+  browser to IA threshold public key.
+
+## Architecture
+
+Threshold encryption is a 2-phase protocol:
+
+```
+Phase 1: Encapsulation (anyone can do this, no coordination)
+  - Encryptor runs KEM encapsulate against threshold public key
+  - Produces (encapsulated_key, ciphertext)
+  - Encapsulated_key is a "partial" — needs T parties to reconstruct
+
+Phase 2: Decapsulation (T-of-N parties collaborate)
+  - Each of T parties computes partial decapsulation from their share
+  - Coordinator aggregates T partials → full shared secret
+  - Shared secret + ciphertext → plaintext (via AEAD)
+```
+
+This mirrors threshold signing's session lifecycle.
+
+## Crate scope
+
+### `confium-tc-kem` (P0 — interface)
+
+Threshold KEM session interface, parallel to `confium-tc` for
+signing.
+
+```c
+// Encapsulator-side (anyone)
+uint32_t cfmp_tc_kem_encapsulate(
+    const uint8_t *recipient_public_key, size_t pk_len,
+    uint8_t **encapsulated_key_out, size_t *ek_len_out,
+    uint8_t **shared_secret_out, size_t *ss_len_out);
+
+// Decapsulator-side (T-of-N threshold session)
+uint32_t cfmp_tc_kem_session_create(
+    FFITcKemSession **out,
+    const char *scheme,                  // "ElGamal-P256-threshold", "ML-KEM-768-threshold"
+    const CFMTcPartyList *parties,
+    uint32_t threshold,
+    uint32_t this_party_idx,
+    const CFMTcShare *local_share,
+    const Option *opts);
+
+uint32_t cfmp_tc_kem_session_round(
+    FFITcKemSession *s,
+    const CFMTcMessage *incoming, uint32_t incoming_count,
+    CFMTcMessage **outgoing, uint32_t *outgoing_count,
+    uint8_t *complete,
+    const Option *opts);
+
+uint32_t cfmp_tc_kem_session_result(
+    FFITcKemSession *s,
+    uint8_t *out, uint32_t out_max, uint32_t *out_len);
+
+uint32_t cfmp_tc_kem_session_destroy(FFITcKemSession *s);
+
+// DKG (parallel to signing DKG)
+uint32_t cfmp_tc_kem_dkg_output_share(
+    FFITcKemSession *s,
+    CFMTcShare **share_out,
+    uint8_t *public_key_out, uint32_t pk_max, uint32_t *pk_len);
+```
+
+### `confium-tc-elgamal-p256` (P1)
+
+Threshold ElGamal over P-256. Mature, well-analyzed. Suitable for
+medium-term sealed data (5-10 year appeals window).
+
+### `confium-tc-ecies-p256` (P2)
+
+Threshold ECIES for browser key escrow. Each browser-held key
+encrypted under threshold ECIES public key; recoverable via quorum.
+
+### `confium-tc-ml-kem` (P1 — research frontier)
+
+**No production-quality threshold ML-KEM exists today.** This
+crate would be the first. Based on FIPS 203 (ML-KEM / Kyber).
+
+Research questions:
+- Proactive share refresh for lattice schemes
+- Threshold decryption ceremony with audit trail
+- Re-encryption for quorum composition changes
+- Composition with AEAD for symmetric encryption of actual data
+- Cross-tier re-encryption (IA → BIML without plaintext exposure)
+
+This crate ships as research prototype; production use requires
+academic collaborator engagement (see `TODO.roadmap/26`).
+
+### `confium-tc-fhe-bfv` (P3 — research)
+
+Threshold BFV FHE. Allows computation on encrypted data without
+decryption. For OIML: statistical analysis of test reports without
+revealing individual reports.
+
+Long horizon. Separate research track.
+
+## Hybrid encryption pattern
+
+Threshold KEM produces a shared secret. Actual data encrypted with
+AEAD using shared secret as key. Standard hybrid:
+
+```rust
+// Encryptor
+let (encapsulated_key, shared_secret) = kem.encapsulate(recipient_pk)?;
+let ciphertext = aead.encrypt(&shared_secret, plaintext)?;
+
+// Transmit: (encapsulated_key, ciphertext, aad)
+
+// Decryptor (T-of-N quorum)
+let shared_secret = threshold_decapsulate(encapsulated_key)?; // coordinator-managed
+let plaintext = aead.decrypt(&shared_secret, ciphertext)?;
+```
+
+The KEM shared secret is short (32 bytes). The AEAD handles
+arbitrary-length plaintext. Standard, well-analyzed.
+
+## Selective disclosure
+
+Each artifact encrypted to a specific recipient quorum's public key:
+
+- Test report → IA threshold public key (one IA, not all IAs)
+- Escalation → BIML threshold public key
+- Sealed evidence → BIML threshold public key + court-order tag
+
+Public keys published in deployment manifest (`TODO.roadmap/33-config-manifest.md`).
+
+## Security
+
+- Threshold property: T-1 parties cannot decrypt
+- Proactive refresh: monthly share refresh invalidates prior compromises
+- Audit: every decryption ceremony logged with director signatures
+- Compromise recovery: re-share to new committee, old shares destroyed
+
+## Performance
+
+| Operation | Wall time (target) |
+|---|---|
+| Encapsulate (encrypt) | <10ms |
+| Threshold decapsulate (3-of-5 P-256) | <500ms |
+| Threshold decapsulate (5-of-7 ML-KEM-768) | <2s (research estimate) |
+| Re-encrypt archive (1M docs, ML-KEM) | minutes (background) |
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/30-tc-reshare-protocol.md` — share refresh applies to KEM shares
+- [FIPS 203 ML-KEM](https://csrc.nist.gov/pubs/fips/203/final)
+- [Shoup, "Practical Threshold Signatures," EUROCRYPT 2000](https://www.shoup.net/papers/thresh.ps)

--- a/TODO.roadmap/32-cert-delegation-cms-xmldsig.md
+++ b/TODO.roadmap/32-cert-delegation-cms-xmldsig.md
@@ -1,0 +1,199 @@
+# 32 — X.509 certificates, scoped delegation, CMS, XMLDSig
+
+## Purpose
+
+Standard PKI envelopes that Confium-produced threshold signatures
+fit into. Verifiers use existing tools (OpenSSL, xmlsec1, browser-
+native XMLDSig) without knowing Confium was involved.
+
+## Scope
+
+Four concerns, MECE-separated:
+
+1. **X.509 cert + CSR types** — `confium-cert`
+2. **Scoped delegation templates** — `confium-cert-delegation`
+3. **CMS (PKCS#7) envelopes** — `confium-cms`
+4. **XMLDSig + Exclusive C14N** — `confium-xmldsig`
+
+## Crate scope
+
+### `confium-cert` (P0)
+
+X.509 v3 certificate and CSR types built on the `x509-cert` crate.
+Path validation. Aware of Confium-specific extensions (delegation
+scope, threshold metadata).
+
+```rust
+pub struct Certificate(pub x509_cert::Certificate);
+pub struct CertificateSigningRequest(pub reqwest::Certificate);
+
+pub fn parse_cert(der: &[u8]) -> Result<Certificate>;
+pub fn parse_cert_pem(pem: &str) -> Result<Certificate>;
+pub fn cert_to_der(cert: &Certificate) -> Result<Vec<u8>>;
+pub fn cert_to_pem(cert: &Certificate) -> Result<String>;
+
+pub struct CertPath<'a> {
+    leaf: &'a Certificate,
+    intermediates: Vec<&'a Certificate>,
+    root: &'a Certificate,
+}
+
+pub fn validate_path(path: &CertPath, now: DateTime<Utc>) -> Result<PathValidation>;
+pub struct PathValidation {
+    pub valid: bool,
+    pub failures: Vec<PathFailure>,
+}
+
+pub enum PathFailure {
+    Expired,
+    NotYetValid,
+    SignatureInvalid,
+    ScopeViolation { expected: String, actual: String },
+    ChainTooLong,
+    UntrustedRoot,
+    Revoked { crl_url: String, serial: String },
+}
+```
+
+### `confium-cert-delegation` (P0)
+
+Scoped delegation templates. Parent cert delegates bounded authority
+to child cert. Used for OIML Manufacturer Model Cert → Instance Cert
+pattern, and similar patterns in other deployments.
+
+```rust
+pub struct DelegationScope {
+    pub allowed_operations: Vec<Operation>,
+    pub constraints: Vec<Constraint>,
+}
+
+pub enum Operation {
+    SignCert(SignCertSpec),
+    SignDocument(SignDocSpec),
+    ThresholdSign(ThresholdSignSpec),
+}
+
+pub enum Constraint {
+    ModelBound { model_id: String },
+    NameBound { name_pattern: String },
+    TimeBound { not_before: DateTime, not_after: DateTime },
+    CountBound { max_issuances: u32 },
+    GeographicBound { regions: Vec<String> },
+}
+
+pub fn build_model_cert(
+    issuer: &Certificate,
+    issuer_key: &SigningKey,
+    subject: &Subject,
+    model: &ModelSpec,
+    validity: Duration,
+) -> Result<Certificate>;
+
+pub fn validate_delegation(
+    parent: &Certificate,
+    child: &Certificate,
+    scope: &DelegationScope,
+) -> Result<DelegationValidation>;
+```
+
+OIML-specific template included; users can define their own.
+
+### `confium-cms` (P0)
+
+CMS (PKCS#7 / RFC 5652) SignedData envelope. Takes (payload, cert
+chain, signature) → CMS SignedData bytes. Standard format verifiable
+by OpenSSL, Thunderbird/RNP, Adobe, etc.
+
+```rust
+pub struct SignedData {
+    pub version: u32,
+    pub digest_algorithms: Vec<AlgorithmIdentifier>,
+    pub encap_content_info: EncapContentInfo,
+    pub certificates: Vec<Certificate>,
+    pub signer_infos: Vec<SignerInfo>,
+}
+
+pub fn build_signed_data(
+    payload: &[u8],
+    payload_type: &Oid,
+    signers: &[Signer],
+) -> Result<Vec<u8>>;
+
+pub fn parse_signed_data(der: &[u8]) -> Result<SignedData>;
+pub fn verify_signed_data(signed_data: &SignedData, trusted_roots: &[Certificate]) -> Result<VerificationResult>;
+```
+
+This is the bridge to **email signing** (S/MIME), **document
+signing** (PAdES), and **code signing** (Authenticode).
+
+### `confium-xmldsig` (P0)
+
+XMLDSig + Exclusive C14N for CNML-style XML documents. Direct
+integration point with OIML CNML project.
+
+```rust
+pub struct XmlDSigSignature {
+    pub signed_info: SignedInfo,
+    pub signature_value: Vec<u8>,
+    pub key_info: KeyInfo,
+    pub objects: Vec<XmlObject>,
+}
+
+pub fn sign_xml(
+    xml: &str,
+    references: &[Reference],
+    signer: &Signer,
+    transform: Canonicalization,
+) -> Result<String>;
+
+pub fn verify_xml(
+    signed_xml: &str,
+    trusted_roots: &[Certificate],
+) -> Result<VerificationResult>;
+
+pub enum Canonicalization {
+    ExclusiveC14N,
+    ExclusiveC14NWithComments,
+    InclusiveC14N,
+}
+```
+
+CNML's 6-check verify pipeline includes XMLDSig verification via
+this crate.
+
+## Verification result unified
+
+All four crates produce a unified `VerificationResult`:
+
+```rust
+pub struct VerificationResult {
+    pub valid: bool,
+    pub checks_run: Vec<CheckResult>,
+}
+
+pub struct CheckResult {
+    pub name: String,
+    pub passed: bool,
+    pub detail: Option<String>,
+}
+```
+
+This composes with CNML's check pipeline (each check returns a
+CheckResult; pipeline aggregates).
+
+## Standards compliance
+
+- RFC 5280: X.509 PKI
+- RFC 5652: CMS
+- RFC 6960: OCSP
+- RFC 5280: CRL
+- XML-Signature Syntax and Processing (W3C)
+- Exclusive XML Canonicalization (W3C)
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `~/src/oimlsmart/digital-certificates/README.md` — CNML's existing XMLDSig implementation
+- [RFC 5280](https://www.rfc-editor.org/rfc/rfc5280)
+- [RFC 5652 CMS](https://www.rfc-editor.org/rfc/rfc5652)
+- [W3C XMLDSig](https://www.w3.org/TR/xmldsig-core/)

--- a/TODO.roadmap/33-config-manifest.md
+++ b/TODO.roadmap/33-config-manifest.md
@@ -1,0 +1,189 @@
+# 33 — Deployment manifest and configuration model
+
+## Purpose
+
+A Confium deployment is described by a **signed deployment manifest**
+— the public charter of the deployment. Anyone can read it to
+understand the rules.
+
+This is what makes Confium a framework rather than a single-purpose
+system. Different deployments write different manifests.
+
+## Three manifest types
+
+| Mode | Manifest | Required? |
+|---|---|---|
+| Mode 1 (peer TC) | None (session params in code) | No |
+| Mode 2 (PKI replacement) | TOML with PKCS#11 server config | Yes |
+| Mode 3 (certificate PKI) | Full deployment manifest | Yes |
+
+## Mode 3 manifest schema
+
+```toml
+# confium.toml — OIML CNML deployment
+[deployment]
+name = "OIML CNML"
+operator = "BIML"
+charter_url = "https://oiml.org/..."
+manifest_version = 1
+mode = "certificate_pki"
+
+[[tier]]
+name = "biml_root"
+role = "international root"
+signing_algorithm = "FROST-ed25519+ML-DSA-65-composite"
+encryption_algorithm = "ML-KEM-768-threshold"
+threshold = { t = 5, n = 7 }
+attributes = ["region", "expertise"]
+ceremony = { sync_required = true, frequency = "annual" }
+
+[[tier]]
+name = "ia"
+role = "national issuing authority"
+signing_algorithm = "FROST-P256"
+encryption_algorithm = "ElGamal-P256-threshold"
+threshold = { t = 2, n = 3 }
+delegated_by = "biml_root"
+ceremony = { sync_required = false }
+
+[[tier]]
+name = "tl"
+role = "testing laboratory"
+signing_algorithm = "ECDSA-P256"
+encryption_algorithm = "ECIES-P256"
+threshold = { t = 1, n = 1 }
+delegated_by = "ia"
+
+[[tier]]
+name = "manufacturer_model"
+role = "manufacturer model authorization (scoped delegation)"
+signing_algorithm = "ECDSA-P256"
+threshold = { t = 1, n = 1 }
+delegated_by = "ia"
+delegation_scope = "model-bound"
+
+[[tier]]
+name = "manufacturer_instance"
+role = "individual instrument instance"
+signing_algorithm = "ECDSA-P256"
+threshold = { t = 1, n = 1 }
+delegated_by = "manufacturer_model"
+
+[transparency]
+log_operator = "biml"
+anchors = ["bitcoin-ots"]
+gossip = false
+public_mirror_urls = ["https://log.confium.org/oiml-cnml", "ipfs://..."]
+
+[async_signing]
+default_unlock_window_minutes = 240
+coordinator_operator = "biml"
+
+[archival]
+renewal_period_years = 5
+re_sign_under = "current-algorithm-suite"
+```
+
+## Mode 2 manifest schema
+
+```toml
+# confium.toml — enterprise PKI replacement
+[deployment]
+name = "Acme Corp PKI"
+operator = "Acme Corporation"
+mode = "pkcs11_replacement"
+manifest_version = 1
+
+[pkcs11_server]
+slot_count = 8
+default_signing_algorithm = "FROST-P256"
+default_threshold = { t = 3, n = 5 }
+share_storage = "pkcs11-wrap"
+hsm_module = "/usr/lib/pkcs11/yubihsm.so"
+
+[quorum.enterprise_root]
+threshold = { t = 3, n = 5 }
+coordinator = "coordinator.acme.corp:443"
+share_storage_backend = "yubihsm"
+
+[quorum.code_signing]
+threshold = { t = 2, n = 3 }
+coordinator = "coordinator.acme.corp:443"
+
+[pqc_migration]
+current = "ECDSA-P256"
+target_2027 = "composite-ECDSA-P256-ML-DSA-65"
+target_2029 = "ML-DSA-65"
+```
+
+## Crate scope
+
+### `confium-config` (P0)
+
+```rust
+pub struct Manifest {
+    pub deployment: DeploymentHeader,
+    pub mode: DeploymentMode,
+    pub tiers: Vec<Tier>,           // Mode 3 only
+    pub transparency: TransparencyConfig,
+    pub async_signing: AsyncSigningConfig,
+    pub archival: ArchivalConfig,
+    pub quorums: Vec<Quorum>,       // Mode 2 only
+    pub pkcs11_server: Option<Pkcs11ServerConfig>,
+    pub pqc_migration: Option<PqcMigrationPlan>,
+}
+
+pub fn parse_manifest(toml_str: &str) -> Result<Manifest>;
+pub fn validate_manifest(manifest: &Manifest) -> Result<ValidationReport>;
+pub fn manifest_to_toml(manifest: &Manifest) -> Result<String>;
+
+pub struct Tier {
+    pub name: String,
+    pub role: String,
+    pub signing_algorithm: String,
+    pub encryption_algorithm: Option<String>,
+    pub threshold: Threshold,
+    pub delegated_by: Option<String>,
+    pub delegation_scope: Option<String>,
+    pub ceremony: Option<Ceremony>,
+    pub attributes: Vec<String>,
+}
+
+pub enum DeploymentMode {
+    PeerToPeer,           // Mode 1
+    Pkcs11Replacement,    // Mode 2
+    CertificatePki,       // Mode 3
+}
+```
+
+The manifest is signed by deployment operator. Verifiers check
+signature before trusting manifest.
+
+## Versioning
+
+`manifest_version` field. As schema evolves, old manifests still
+parseable via versioned deserializers.
+
+This is the answer to "what happens when deployments evolve?":
+manifest version field, semver-compatible schema changes.
+
+## Per-deployment overrides
+
+Manifest is the public charter. Per-environment overrides
+(test/staging/prod) live in separate files (`confium.local.toml`),
+not signed, used for non-security-critical params (log levels,
+coordinator hostnames).
+
+## CLI
+
+```sh
+confium manifest validate confium.toml
+confium manifest sign confium.toml --key <keyfile>
+confium manifest verify confium.toml --pubkey <pubkey>
+confium manifest apply confium.toml  # deploy to local node
+```
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/28-mode2-pki-replacement.md`

--- a/TODO.roadmap/34-identity-and-hardware.md
+++ b/TODO.roadmap/34-identity-and-hardware.md
@@ -1,0 +1,197 @@
+# 34 — Identity management and hardware backends
+
+## Purpose
+
+Each actor in a Confium deployment (manufacturer, lab, IA officer,
+BIML director) has cryptographic identity. This identity binds to:
+
+- A signing keypair (signs artifacts)
+- An encryption keypair (decrypts incoming encrypted data)
+- A certificate chain (proves identity to verifiers)
+- Optional hardware token (YubiKey, OpenPGP card) for key protection
+
+Hardware backends store keys securely. Standards-only — no vendor
+SDKs.
+
+## Actor identity model
+
+```rust
+pub struct ActorIdentity {
+    pub actor_id: String,                    // "biml-director-alice", "ia-france-officer-1"
+    pub actor_type: ActorType,
+    pub signing_key: SigningKeyHandle,
+    pub encryption_key: EncryptionKeyHandle,
+    pub certificate_chain: Vec<Certificate>,
+    pub hardware_token: Option<HardwareToken>,
+}
+
+pub enum ActorType {
+    Manufacturer,
+    TestingLab,
+    IssuingAuthorityOfficer,
+    BimlDirector,
+    QuorumCoordinator,
+}
+
+pub enum SigningKeyHandle {
+    Software(SoftwareKey),                   // in-process
+    Hardware(HardwareKeyRef),                // PKCS#11/TPM/OpenPGP card
+}
+
+pub enum HardwareToken {
+    YubiKeyPiv { slot: PivSlot, pin_policy: PinPolicy },
+    YubiKeyOpenpgp { slot: OpenpgpSlot },
+    OpenpgpCard { card_id: String, slot: OpenpgpSlot },
+    Tpm { handle: u32 },
+}
+```
+
+## Hardware backends
+
+### `confium-store-pkcs11` (existing, extended)
+
+PKCS#11 v3.0 wrapping backend. HSM holds AES-256 wrapping key;
+share on disk encrypted under that key.
+
+```rust
+pub struct Pkcs11WrappingBackend {
+    module: Pkcs11Module,
+    wrapping_key_handle: ObjectHandle,
+}
+
+impl StoreBackend for Pkcs11WrappingBackend {
+    fn store(&self, key_id: &str, plaintext: &[u8]) -> Result<()>;
+    fn load(&self, key_id: &str) -> Result<Vec<u8>>;
+    fn delete(&self, key_id: &str) -> Result<()>;
+    fn list(&self) -> Result<Vec<String>>;
+}
+```
+
+Wraps AES-256-GCM encryption with `C_WrapKey` / `C_UnwrapKey`. All
+major HSMs support this.
+
+### `confium-store-tpm` (existing, extended)
+
+TPM 2.0 sealed storage. Uses TPM-internal AES key to seal arbitrary
+data. Bound to PCR state (optional).
+
+### `confium-store-cloud` (existing, extended)
+
+AWS KMS / GCP KMS / Azure KV via REST. Wrapping key lives in cloud
+KMS; share on local disk encrypted.
+
+### `confium-store-openpgp-card` (P0, new)
+
+OpenPGP card support. YubiKey OpenPGP applet, Nitrokey, Gnuk.
+
+```rust
+pub struct OpenpgpCardBackend {
+    card: Card<Open>,
+    signing_slot: KeySlot,
+    encryption_slot: KeySlot,
+    auth_slot: KeySlot,
+}
+
+impl StoreBackend for OpenpgpCardBackend { ... }
+impl SigningBackend for OpenpgpCardBackend { ... }
+impl DecryptionBackend for OpenpgpCardBackend { ... }
+```
+
+OpenPGP card spec supports both signing and decryption natively —
+the card performs the operation, the key never leaves the device.
+
+## Two-tier protection pattern
+
+For high-value actors (BIML directors, IA officers):
+
+```
+YubiKey / OpenPGP card holds:
+  - Identity signing key (signs protocol messages for non-repudiation)
+  - AES wrapping key (decrypts threshold share from disk)
+
+Laptop holds:
+  - Wrapped threshold share (encrypted under YubiKey's wrapping key)
+  - Confium session state
+
+At signing time:
+  1. Director enters passphrase → unlocks YubiKey
+  2. App asks YubiKey to decrypt wrapped share
+  3. Plaintext share lives briefly in Sensitive<T> (mlock + zeroize)
+  4. Protocol runs on laptop
+  5. Share zeroized when session ends
+  6. Every protocol message signed by YubiKey identity key
+```
+
+Two-tier protection: compromised laptop alone insufficient; attacker
+needs physical YubiKey + passphrase.
+
+## Director identity cert chain
+
+Director identity keys (on YubiKey) are certified under a separate
+BIML identity CA, distinct from the root signing cert.
+
+```
+BIML Identity CA (separate from root)
+   │ signs
+   ▼
+Director Identity Cert (per director)
+   │ binds YubiKey-held public key to director name
+   ▼
+Used to verify director signatures on protocol messages
+```
+
+Why separate? Because the root signing cert is threshold-held by
+directors — using it to certify director identity would be circular.
+Identity CA can be a simpler offline single-party CA, or a separate
+threshold quorum.
+
+## Hardware token distribution
+
+- OIML procures standard hardware (YubiKey 5 CSPN, OpenPGP card v3.4)
+  centrally
+- Distributed at annual ceremony (in-person verification)
+- Director generates own keys on-device at ceremony (no OIML escrow)
+- Public identity keys registered with BIML, certified under BIML Identity CA
+
+For non-ceremony enrollment (lab onboarding, manufacturer
+registration): remote identity verification + physical token ship
+via secure courier.
+
+## Crate scope
+
+### `confium-identity` (P0)
+
+```rust
+pub struct IdentityStore {
+    backend: Box<dyn StoreBackend>,
+}
+
+impl IdentityStore {
+    pub fn register_actor(&self, actor: ActorIdentity) -> Result<()>;
+    pub fn lookup_actor(&self, actor_id: &str) -> Result<ActorIdentity>;
+    pub fn list_actors_by_type(&self, actor_type: ActorType) -> Result<Vec<ActorIdentity>>;
+    pub fn revoke_actor(&self, actor_id: &str, reason: &str) -> Result<()>;
+}
+```
+
+### `confium-store-openpgp-card` (P0)
+
+Uses `openpgp-card` crate (Rust). Supports YubiKey OpenPGP, Nitrokey,
+Gnuk, any OpenPGP card v3+.
+
+## Failure modes
+
+| Scenario | Recovery |
+|---|---|
+| Director loses YubiKey | Emergency re-share excludes old identity key; new YubiKey at next ceremony |
+| YubiKey firmware bug | Re-place with new model; re-share to new identity keys |
+| Laptop compromised | Proactive refresh invalidates exfiltrated shares |
+| Director forgets passphrase | Duress code path: YubiKey admin PIN resets, but share is wiped; re-share required |
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/30-tc-reshare-protocol.md` — emergency re-share on token loss
+- [OpenPGP card spec](https://g10code.com/docs/openpgp-card-3.0.pdf)
+- [PKCS#11 v3.0](https://docs.oasis-open.org/pkcs11/pkcs11-base/v3.0/pkcs11-base-v3.0.html)
+- [TCG TPM 2.0](https://trustedcomputinggroup.org/resource/tpm-library-specification/)

--- a/TODO.roadmap/35-pq-composite-signatures.md
+++ b/TODO.roadmap/35-pq-composite-signatures.md
@@ -1,0 +1,140 @@
+# 35 — Post-quantum composite signatures
+
+## Purpose
+
+PQ migration without breaking existing verifiers. Composite
+signatures combine classical (Ed25519, ECDSA) and PQ (ML-DSA,
+SLH-DSA) algorithms so breaking either alone doesn't break the
+composite.
+
+For Mode 2 deployments, this is the killer feature: enterprises
+facing PQ migration can deploy Confium and get a software-only
+migration path.
+
+## Composite signature model
+
+A composite signature is a single signature object containing
+multiple component signatures over the same message. Verifier
+validates all components; signature valid iff all valid.
+
+```
+CompositeSig {
+   algorithm_ids: [Ed25519, ML-DSA-65],
+   public_keys: [Ed25519_pub, ML-DSA-65_pub],
+   signatures: [Ed25519_sig, ML-DSA-65_sig],
+}
+```
+
+### Threshold composite
+
+Each component is independently threshold-signed:
+
+- FROST-Ed25519 produces Ed25519_sig (threshold T-of-N)
+- FROST-ML-DSA-65 produces ML-DSA-65_sig (threshold T-of-N, possibly
+  different T or N)
+- Both assembled into composite
+
+Two DKG ceremonies per quorum (one per algorithm). Both public keys
+bound to single X.509 certificate via composite extension.
+
+## IETF COMPOSITE SIG draft
+
+Track the standardization. Current draft proposes specific algorithm
+combinations:
+
+- `id-MLDSA65-Ed25519` (target for OIML/CNML)
+- `id-MLDSA65-ECDSA-P256`
+- `id-MLDSA87-ECDSA-P384`
+- `id-SLHDSA-SHA2-128S-Ed25519`
+- ... (more)
+
+Implement composite matching current draft. Re-version if draft
+changes. Final FIPS 800-208A expected ~2027.
+
+## Crate scope
+
+### `confium-composite` (P1)
+
+```rust
+pub struct CompositeSignature {
+    pub components: Vec<ComponentSignature>,
+}
+
+pub struct ComponentSignature {
+    pub algorithm: SignatureAlgorithm,
+    pub public_key: PublicKey,
+    pub signature: Vec<u8>,
+}
+
+pub fn build_composite(
+    message: &[u8],
+    signers: &[ComponentSigner],
+) -> Result<CompositeSignature>;
+
+pub fn verify_composite(
+    composite: &CompositeSignature,
+    message: &[u8],
+    trusted_roots: &[Certificate],
+) -> Result<VerificationResult>;
+```
+
+Threshold-aware: `ComponentSigner` can be a single-party signer OR
+a threshold signer (uses `confium-tc` session underneath).
+
+### `confium-tc-frost-ml-dsa-65` (P1 — research)
+
+Threshold FROST over ML-DSA-65. Lattice-based threshold signature.
+Boneh et al. 2024 paper basis. Research prototype.
+
+This is genuinely at the research frontier. Production deployment
+requires academic collaborator engagement.
+
+## Migration path
+
+Phased PQ migration via composite:
+
+| Phase | Composite | Classical-only verifiers | PQ-aware verifiers |
+|---|---|---|---|
+| Phase 1 (2026-2027) | Ed25519 + ML-DSA-65 | Verify Ed25519, ignore PQ | Verify both |
+| Phase 2 (2028-2030) | Ed25519 + ML-DSA-65 (default) | Warn on missing PQ | Verify both |
+| Phase 3 (2030+) | ML-DSA-65 only | Reject (no classical) | Verify PQ only |
+
+Phase boundaries driven by NIST PQ migration guidance. Confium's
+`pqc_migration` manifest section expresses the current phase.
+
+## Threshold-specific PQ challenges
+
+Lattice-based signatures (ML-DSA, ML-KEM, SLH-DSA) have different
+algebraic structure than discrete-log signatures. Threshold variants:
+
+- **FROST-ML-DSA**: lattice-based FROST. State-of-art research.
+  Non-trivial because ML-DSA's signing is more complex than
+  Schnorr/Ed25519.
+- **Threshold ML-KEM**: lattice-based threshold KEM. Slightly
+  easier than ML-DSA (decryption is conceptually simpler).
+- **SLH-DSA**: stateful hash-based signatures; threshold variants
+  even more research-stage.
+
+For Mode 2 deployments, threshold ML-DSA-65 is the priority
+(it's the NIST-recommended general-purpose PQ signature).
+
+## Why composites matter for Confium adoption
+
+Enterprises face the PQ migration cliff:
+
+- **Without Confium**: replace all HSMs (years of vendor work),
+  re-issue all credentials, re-do threshold protocols per algorithm.
+- **With Confium**: software upgrade. PKCS#11 interface unchanged.
+  Composite signatures maintain back-compat with classical verifiers
+  during transition.
+
+This is the single strongest enterprise sales pitch.
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/28-mode2-pki-replacement.md`
+- [IETF LAMPS COMPOSITE SIG draft](https://datatracker.ietf.org/wg/lamps/documents/)
+- [NIST PQC migration guidance](https://csrc.nist.gov/projects/post-quantum-cryptography)
+- [FIPS 204 ML-DSA](https://csrc.nist.gov/pubs/fips/204/final)
+- [Boneh et al., "Threshold Lattice Signatures," 2024]

--- a/TODO.roadmap/36-transparency-and-ots.md
+++ b/TODO.roadmap/36-transparency-and-ots.md
@@ -1,0 +1,146 @@
+# 36 — Transparency log and OpenTimestamps infrastructure
+
+## Purpose
+
+Prove every issued artifact was publicly logged. Catches compelled
+issuance, rogue issuance, retroactive forgery.
+
+Simpler than CT-style gossip. No academic witness network required.
+Append-only Merkle tree with Bitcoin-anchored roots.
+
+## Architecture
+
+```
+Deployment operates its own append-only Merkle tree of all issued
+artifacts (certs, signatures, revocations, re-sharing events)
+   ↓ tree root periodically committed to Bitcoin via OTS
+   ↓ tree published on deployment's website + IPFS mirror
+Verifier (offline): downloads Merkle branch + OTS proof
+   → proves "this artifact was in the tree as of block N"
+   → missing artifacts detectable via tree root comparison
+```
+
+## Components
+
+### 1. Append-only Merkle tree (`confium-transparency`)
+
+```rust
+pub struct MerkleTree {
+    entries: Vec<MerkleEntry>,
+    storage: Box<dyn TransparencyStorage>,
+}
+
+pub struct MerkleEntry {
+    pub sequence: u64,
+    pub timestamp: DateTime<Utc>,
+    pub artifact_hash: [u8; 32],
+    pub artifact_type: ArtifactType,
+    pub metadata: serde_json::Value,
+}
+
+pub enum ArtifactType {
+    CertificateIssuance,
+    CertificateRevocation,
+    ThresholdSignature,
+    ThresholdEncryption,
+    DirectorRotation,
+    QuorumPolicy,
+}
+
+impl MerkleTree {
+    pub fn append(&mut self, entry: MerkleEntry) -> Result<u64>;
+    pub fn root(&self) -> Result<[u8; 32]>;
+    pub fn inclusion_proof(&self, sequence: u64) -> Result<MerkleProof>;
+    pub fn verify_inclusion(entry: &MerkleEntry, proof: &MerkleProof, root: [u8; 32]) -> Result<()>;
+    pub fn consistency_proof(&self, from_root: [u8; 32]) -> Result<ConsistencyProof>;
+    pub fn verify_consistency(from_root: [u8; 32], to_root: [u8; 32], proof: &ConsistencyProof) -> Result<()>;
+}
+```
+
+RFC 6962-style inclusion and consistency proofs. Standard,
+well-analyzed.
+
+### 2. OTS anchoring (`confium-ots`)
+
+```rust
+pub struct OtsClient {
+    calendar_servers: Vec<Url>,
+}
+
+impl OtsClient {
+    pub async fn stamp(&self, hash: [u8; 32]) -> Result<OtsProof>;
+    pub fn verify(proof: &OtsProof, hash: [u8; 32], bitcoin_height: u32) -> Result<OtsVerification>;
+}
+```
+
+Periodic anchor: every N entries, compute tree root, OTS-stamp it,
+publish (root, OTS proof, sequence range) in deployment transparency
+log.
+
+### 3. Publication
+
+Tree published on deployment website. Mirror on IPFS for
+tamper-resistance (BIML cannot retroactively rewrite history without
+breaking IPNS).
+
+JSON API for verifiers:
+- `GET /log/entries?seq=N` → entry at sequence N
+- `GET /log/root?leq_seq=N` → tree root as of sequence N
+- `GET /log/proof/inclusion?seq=N` → Merkle branch
+- `GET /log/proof/consistency?from=M&to=N` → consistency proof
+- `GET /log/ots/root?seq=N` → OTS proof for root at sequence N
+
+## Why this works without a witness network
+
+OTS provides time-of-existence proof. The Merkle tree provides
+inclusion proof. Bitcoin anchoring prevents retroactive rewriting.
+
+Three properties combined:
+1. **Time**: OTS proves root existed at Bitcoin block N
+2. **Inclusion**: Merkle branch proves artifact in tree at root
+3. **Public log**: tree published; missing artifacts detectable
+
+A malicious CA cannot silently issue a fraudulent cert because:
+- If they DON'T log it, verifier can't validate (cert not in tree)
+- If they DO log it, public sees the issuance
+- If they try to rewrite history, Bitcoin anchor catches it
+
+## Optional: CoSi enhancement
+
+Future work. CoSi-style witness co-signatures from NIST + BIPM +
+independent academic institutions, providing offline-verifiable
+transparency (witness signatures travel with the cert itself, no
+log lookup required).
+
+Useful for customs officers at borders (offline verification). Not
+required for core deployment.
+
+## Crate scope
+
+### `confium-transparency` (P1)
+
+- Merkle tree implementation
+- Storage backends: SQLite (default), PostgreSQL (large deployments)
+- HTTP API server (axum)
+- Inclusion and consistency proofs (RFC 6962)
+- Periodic root anchoring hook
+
+### `confium-ots` (P1)
+
+- OpenTimestamps client using public calendar servers
+- Local calendar server for offline / private deployments
+- Bitcoin Core RPC for direct anchoring (optional)
+- Proof verification
+
+## Operational
+
+- Tree storage grows ~1KB per entry → 1M entries ~1GB (SQLite)
+- OTS stamp cost: free (public calendars), or Bitcoin transaction
+  fee (~$1) for direct anchoring
+- Anchor cadence: every 1000 entries or every hour, whichever first
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- [RFC 6962 Certificate Transparency](https://www.rfc-editor.org/rfc/rfc6962)
+- [OpenTimestamps](https://opentimestamps.org/)

--- a/TODO.roadmap/37-long-term-archival.md
+++ b/TODO.roadmap/37-long-term-archival.md
@@ -1,0 +1,133 @@
+# 37 — Long-term archival (RFC 4998 Evidence Record Syntax)
+
+## Purpose
+
+Artifacts signed in 2026 must verify in 2046. Hash algorithms
+weaken over time. RFC 4998 ERS (Evidence Record Syntax) provides
+periodic re-timestamping as algorithms age.
+
+For OIML: instruments last 10-20 years. Calibration data and test
+reports retained for instrument lifetime. Decades-long archival
+required.
+
+## ERS overview
+
+RFC 4998 defines an Evidence Record — a chain of timestamps
+protecting an artifact over time. As hash algorithms weaken, new
+timestamps are added using stronger algorithms.
+
+```
+Artifact (2026)
+   │ timestamped with SHA-256 (2026)
+   │ timestamped with SHA-384 (2031, after SHA-256 weakens)
+   │ timestamped with SHA-512 (2036, after SHA-384 weakens)
+   │ ... etc
+   ▼
+Evidence Record proves artifact existed at each timestamp
+```
+
+## Confium extension: periodic re-quorum
+
+Standard ERS only re-timestamps. Confium extends:
+
+Every N years, the **current** deployment quorum:
+1. Re-signs the artifact under **current** algorithm suite
+   (signature renewal)
+2. Re-encrypts archived data under **current** threshold KEM
+   (encryption renewal)
+3. Adds new Evidence Record entry
+
+The artifact's trust chain evolves with the institution. "Living
+will" cryptography.
+
+## Architecture
+
+```rust
+pub struct EvidenceRecord {
+    pub version: u32,
+    pub digest_algorithms: Vec<HashAlgorithm>,
+    pub crypto_objects: Vec<CryptoObject>,
+    pub archive_time_stamp_sequences: Vec<ArchiveTimeStampSequence>,
+}
+
+pub struct ArchiveTimeStampSequence {
+    pub sequence_number: u32,
+    pub hash_tree: ReducedHashTree,
+    pub time_stamp: TimeStamp,           // RFC 3161
+    pub attributes: ArchiveTimestampAttributes,
+}
+
+pub fn build_initial_evidence_record(
+    artifact_hash: [u8; 32],
+    initial_algorithm: HashAlgorithm,
+) -> Result<EvidenceRecord>;
+
+pub fn renew_evidence_record(
+    existing: &EvidenceRecord,
+    new_algorithm: HashAlgorithm,
+    threshold_quorum: &Quorum,
+) -> Result<EvidenceRecord>;
+
+pub fn verify_evidence_record(
+    record: &EvidenceRecord,
+    artifact: &[u8],
+    trusted_tsas: &[Tsa>,
+) -> Result<VerificationResult>;
+```
+
+## Re-encryption extension
+
+For threshold-encrypted archives (test reports, calibration data):
+
+```rust
+pub fn renew_threshold_encryption(
+    encrypted_archive: &ThresholdEncryptedBlob,
+    old_quorum_pubkey: &PublicKey,
+    new_quorum_pubkey: &PublicKey,
+    threshold_quorum: &Quorum,
+) -> Result<ThresholdEncryptedBlob>;
+```
+
+Old quorum threshold-decrypts; new quorum threshold-encrypts. No
+plaintext exposure beyond the brief renewal window.
+
+## Ceremony
+
+Every 5 years (configurable):
+
+1. Coordinator schedules renewal
+2. Current quorum members participate async (like signing session)
+3. Each artifact re-signed under current algorithm
+4. Each encrypted archive re-encrypted under current KEM
+5. New Evidence Record entries added
+6. Transparency log records all renewals
+7. OTS-anchored
+
+## Schedule for OIML/CNML
+
+- 2026: Initial signatures (Ed25519 + ML-DSA-65 composite)
+- 2031: Re-quorum. Composite adds third algorithm if available.
+- 2036: Re-quorum. Migration to next-gen PQ if ML-DSA weakens.
+- 2041: Re-quorum.
+- ...
+
+Each re-quorum is itself an event in the transparency log, signed
+by the then-current BIML quorum.
+
+## Crate scope
+
+### `confium-ers` (P1)
+
+- RFC 4998 Evidence Record implementation
+- RFC 3161 timestamp client
+- Re-quorum ceremony orchestration
+- Re-encryption coordination (uses `confium-tc-kem`)
+- Storage: Evidence Records stored alongside artifacts
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/31-threshold-encryption.md` — re-encryption
+- `TODO.roadmap/36-transparency-and-ots.md` — re-quorum events logged
+- [RFC 4998 Evidence Record Syntax](https://www.rfc-editor.org/rfc/rfc4998)
+- [RFC 3161 Time-Stamp Protocol](https://www.rfc-editor.org/rfc/rfc3161)

--- a/TODO.roadmap/38-attribute-based-threshold.md
+++ b/TODO.roadmap/38-attribute-based-threshold.md
@@ -1,0 +1,156 @@
+# 38 — Attribute-based threshold signing
+
+## Purpose
+
+Not just "any T of N" but "any T of N satisfying attribute predicate
+P". Enables policies like:
+
+- Geographic distribution (≥ K regions must be represented)
+- Subject-matter expertise (≥ M domain experts)
+- Conflict-of-interest exclusion (signer must NOT be from country
+  of the manufacturer)
+- Time-of-day (live human signers only)
+- Role-based (≥ 1 officer + ≥ 2 directors)
+
+## Predicates
+
+Predicate language over signer attributes:
+
+```rust
+pub enum Predicate {
+    /// At least K signers have attribute
+    MinCount { attribute: String, count: usize },
+    /// At least K distinct values of attribute (e.g., K regions)
+    MinDistinct { attribute: String, count: usize },
+    /// No signer has attribute
+    None { attribute: String },
+    /// At least one signer has attribute
+    Any { attribute: String },
+    /// All signers have attribute
+    All { attribute: String },
+    /// Boolean combination
+    And(Vec<Predicate>),
+    Or(Vec<Predicate>),
+    Not(Box<Predicate>),
+}
+
+pub struct AttributePredicate(pub Predicate);
+
+pub fn evaluate(predicate: &Predicate, signers: &[&SignerAttributes]) -> Result<bool>;
+```
+
+## Attributes per signer
+
+```rust
+pub struct SignerAttributes {
+    pub signer_id: String,
+    pub region: Option<String>,           // "europe", "asia-pacific", "americas"
+    pub expertise: Vec<String>,           // ["metrology", "gas-flow", "high-precision"]
+    pub nationality: Option<String>,      // for COI exclusion
+    pub role: Vec<String>,                // ["director", "officer", "expert"]
+    pub available_until: Option<DateTime<Utc>>,
+    pub custom: HashMap<String, String>,
+}
+```
+
+## Sample CNML predicates
+
+```rust
+// Standard BIML quorum: 5-of-7 directors
+let biml_standard = Predicate::MinCount {
+    attribute: "role:director".into(),
+    count: 5,
+};
+
+// Geographic distribution: 5-of-7 with at least 3 distinct regions
+let biml_geographic = Predicate::And(vec![
+    Predicate::MinCount { attribute: "role:director".into(), count: 5 },
+    Predicate::MinDistinct { attribute: "region".into(), count: 3 },
+]);
+
+// High-precision class: requires metrology expert
+let high_precision = Predicate::And(vec![
+    Predicate::MinCount { attribute: "role:director".into(), count: 5 },
+    Predicate::MinDistinct { attribute: "region".into(), count: 3 },
+    Predicate::MinCount { attribute: "expertise:metrology".into(), count: 2 },
+]);
+
+// COI exclusion: no signer from manufacturer's country
+let coi_aware = Predicate::And(vec![
+    high_precision.clone(),
+    Predicate::None { attribute: format!("nationality:{}", manufacturer_country) },
+]);
+```
+
+## Integration with threshold session
+
+The predicate is part of session params. Coordinator enforces:
+
+```rust
+pub struct SessionParams {
+    pub scheme: String,
+    pub quorum_id: String,
+    pub threshold: usize,
+    pub attribute_predicate: Option<AttributePredicate>,  // NEW
+    pub unlock_window: Duration,
+    // ...
+}
+```
+
+Coordinator accepts commitments only from signers whose attributes
+satisfy the predicate. If predicate not satisfied when threshold
+commitments arrive, session fails with predicate-violation error.
+
+## Cryptographic enforcement
+
+Beyond coordinator enforcement, attributes can be cryptographically
+bound:
+
+- Each signer's identity cert contains attribute extensions
+- Predicate satisfaction verified from cert chain, not just
+  coordinator's word
+- Verifier can independently confirm predicate was satisfied
+
+This is closer to attribute-based signatures (ABS) in formal
+cryptography literature. Confium provides practical subset.
+
+## Manifest expression
+
+```toml
+[[quorum]]
+name = "biml_high_precision"
+threshold = { t = 5, n = 7 }
+predicate = """
+  and(
+    min_count("role:director", 5),
+    min_distinct("region", 3),
+    min_count("expertise:metrology", 2)
+  )
+"""
+```
+
+DSL parsed by `confium-attributes` crate.
+
+## Crate scope
+
+### `confium-attributes` (P2)
+
+- Predicate AST
+- DSL parser (string → Predicate)
+- Evaluator
+- Cert extension encoding/decoding (attribute bindings)
+- Integration with `confium-tc` session params
+
+## Security
+
+- Coordinator enforces predicate before accepting commitments
+- Verifier can independently re-check predicate from cert chain
+- Predicate violation aborts session with signed error
+- Audit log includes predicate and signer attributes (anonymized
+  if ring signature mode — see `TODO.roadmap/39`)
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- `TODO.roadmap/27-cnml-deployment.md` — CNML uses predicates
+- [Attribute-Based Signatures](https://eprint.iacr.org/2010/595)

--- a/TODO.roadmap/39-threshold-ring-signatures.md
+++ b/TODO.roadmap/39-threshold-ring-signatures.md
@@ -1,0 +1,108 @@
+# 39 — Threshold ring signatures (research)
+
+## Purpose
+
+For sensitive national-security type approvals, hide WHICH
+directors signed. Public can verify the signature; watchdogs know
+SOMETHING was signed; signer identities anonymized among the
+eligible set; revealed only to designated auditor.
+
+Currently no production-quality threshold ring signature
+implementation exists. Confium's would be the first.
+
+## Research frontier
+
+This is genuinely long-horizon research. Not in scope for Q2 2027
+NIST MPTS submission. Tracked as future research contribution,
+paper #3 in academic plan.
+
+## Cryptographic landscape
+
+### Ring signatures (Rivest-Shamir-Tauman 2001)
+
+N members form a "ring". Signer produces signature on behalf of
+the ring without revealing which member. Verifier confirms some
+ring member signed, but cannot identify which.
+
+### Threshold ring signatures (Bender-Ostrovsky-Pinkas 2006)
+
+T-of-N members collaborate to produce a ring signature. Verifier
+confirms T ring members signed, but cannot identify which T.
+
+### Confium extension: accountable confidentiality
+
+Combine threshold ring signature with designated auditor:
+- Public sees anonymous threshold signature
+- Watchdogs see "T members of the BIML ring signed"
+- Designated auditor (court, treaty body) can decrypt identity
+  evidence to determine which T members
+
+This composition is novel. Likely paper-worthy.
+
+## Use cases for OIML/CNML
+
+- **National-security instruments**: defense-related type approvals
+  where signer identities are sensitive
+- **Diplomatic-pressured approvals**: where revealing which
+  directors approved could cause diplomatic incident
+- **Whistleblower-protected reports**: lab reports where lab
+  identity hidden from public
+
+## Crate scope (future, P3)
+
+### `confium-ring` (P3 — research)
+
+```rust
+pub struct RingSignature {
+    pub ring_members: Vec<PublicKey>,        // all eligible signers
+    pub signature: Vec<u8>,                  // anonymous signature
+    pub signer_count: usize,                 // T (how many signed)
+    pub auditor_evidence: Option<EncryptedEvidence>,
+}
+
+pub fn threshold_ring_sign(
+    message: &[u8],
+    ring_members: &[PublicKey],
+    signer_keys: &[&SigningKey],             // T actual signers
+) -> Result<RingSignature>;
+
+pub fn verify_ring_signature(
+    sig: &RingSignature,
+    message: &[u8],
+) -> Result<()>;
+
+pub fn auditor_reveal(
+    sig: &RingSignature,
+    auditor_key: &AuditorKey,
+) -> Result<Vec<SignerIdentity>>;
+```
+
+## Implementation challenges
+
+- **Performance**: ring signatures are typically 10-100x slower
+  than threshold signatures due to witness hiding
+- **Size**: ring signatures are larger (linear in ring size)
+- **Composability**: combining with threshold ceremony adds latency
+- **Auditor accountability**: need to ensure auditor can identify
+  signers WITHOUT enabling public identification
+
+## Deployment phasing
+
+- **Phase 1 (through 2027)**: standard threshold signatures,
+  signer identities public in audit log. Sufficient for most
+  OIML work.
+- **Phase 2 (2028+)**: research threshold ring signature prototype.
+  Deployed for sensitive classes only.
+- **Phase 3 (2029+)**: production deployment if research matures.
+
+## Out of scope for initial framework
+
+Threshold ring signatures are research output, not framework
+primitive. Tracked here for completeness; not blocking Q2 2027
+NIST submission.
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- [Rivest-Shamir-Tauman 2001, "How to Leak a Secret"](https://people.csail.mit.edu/rivest/pubs/RST01.pdf)
+- [Bender-Ostrovsky-Pinkas 2006, "Threshold Ring Signatures"](https://eprint.iacr.org/2005/395)

--- a/TODO.roadmap/40-threshold-fhe.md
+++ b/TODO.roadmap/40-threshold-fhe.md
@@ -1,0 +1,139 @@
+# 40 — Threshold FHE (research)
+
+## Purpose
+
+Threshold Fully Homomorphic Encryption (FHE) enables computation
+on encrypted data without decryption. Plus threshold: computation
+requires quorum agreement.
+
+For OIML: statistical analysis of test reports without decrypting
+individual reports. Compute aggregate quality metrics across
+manufacturers without revealing individual measurements.
+
+Long horizon research. Separate track from main framework.
+
+## FHE overview
+
+FHE allows arbitrary computation on ciphertexts:
+
+```
+encrypt(x), encrypt(y)
+   ↓ homomorphic computation (e.g., add, multiply)
+encrypt(x + y), encrypt(x * y)
+```
+
+Decryption reveals only the result, not the inputs.
+
+## BFV scheme
+
+BFV (Brakerski-Fan-Vercauteren) operates on integer arithmetic
+over polynomial rings. Suitable for arithmetic-heavy computation
+(statistics, machine learning).
+
+BFV parameters trade off between:
+- **Security**: large polynomial degree, large coefficient modulus
+- **Performance**: smaller parameters
+- **Correctness**: noise budget degrades with each operation
+
+## Threshold BFV
+
+Each party holds a share of the BFV decryption key. Decryption
+requires T-of-N shares:
+
+```
+Encryptor:
+  - Run BFV encrypt on plaintext → ciphertext
+  - Ciphertext published
+
+Computor (anyone, including non-quorum):
+  - Run homomorphic operations on ciphertext
+  - Result is still encrypted
+
+Decryptor (T-of-N quorum):
+  - Each party computes partial decryption
+  - Coordinator aggregates partials → full decryption
+  - Plaintext result revealed
+```
+
+The "computor" can be anyone — that's the point. Computation on
+encrypted data doesn't require key access. Only decryption requires
+quorum.
+
+## Use cases (research)
+
+- **Aggregate statistics** across encrypted test reports
+- **Privacy-preserving benchmarking** across manufacturers
+- **Outlier detection** without revealing individual reports
+- **Regulatory analytics** without compromising trade secrets
+
+For OIML: "across 200 gas flow meter type approvals, the average
+calibration drift is X, with no individual report revealed."
+
+## Crate scope (future, P3)
+
+### `confium-tc-fhe-bfv` (P3 — research)
+
+```rust
+pub struct BfvParams {
+    pub polynomial_degree: usize,           // typically 4096-32768
+    pub plaintext_modulus: u64,
+    pub coefficient_modulus: Vec<u64>,
+    pub security_level: SecurityLevel,      // 128-bit target
+}
+
+pub struct BfvPublicKey(pub Vec<u8>);
+pub struct BfvSecretKeyShare(pub Vec<u8>);
+pub struct BfvCiphertext(pub Vec<u8>);
+
+pub fn bfv_dkg(parties: &[PartyId], params: &BfvParams) -> Result<DkgResult>;
+
+pub fn bfv_encrypt(pk: &BfvPublicKey, plaintext: &Plaintext) -> Result<BfvCiphertext>;
+pub fn bfv_add(a: &BfvCiphertext, b: &BfvCiphertext) -> Result<BfvCiphertext>;
+pub fn bfv_mul(a: &BfvCiphertext, b: &BfvCiphertext) -> Result<BfvCiphertext>;
+
+pub fn bfv_decrypt_partial(share: &BfvSecretKeyShare, ct: &BfvCiphertext) -> Result<PartialDecryption>;
+pub fn bfv_combine_partials(partials: &[PartialDecryption]) -> Result<Plaintext>;
+```
+
+## Implementation challenges
+
+- **Performance**: FHE operations are 1000-100000x slower than
+  equivalent plaintext operations. Minutes to hours per operation.
+- **Parameter selection**: choosing secure parameters is hard;
+  requires expertise
+- **Bootstrapping**: deep computations require "refreshing" noise
+  budget, which is expensive
+- **Threshold BFV**: combining shares adds complexity
+
+## Alternative: threshold computation oracles
+
+For some use cases, simpler than full FHE:
+
+- **MPC** (multi-party computation): parties collaboratively compute
+  on plaintext inputs without revealing them. Confium's threshold
+  signing infrastructure partially reusable.
+- **Secure aggregation**: parties send encrypted aggregates;
+  quorum combines. Less expressive than FHE but much faster.
+
+For Mode 3 deployments needing aggregate analytics, MPC via
+`confium-tc` may suffice without FHE.
+
+## Deployment phasing
+
+- **Phase 1 (through 2027)**: no FHE. Aggregates computed by
+  trusted coordinator.
+- **Phase 2 (2028+)**: research threshold BFV prototype. Not for
+  production deployment.
+- **Phase 3 (2030+)**: if FHE matures, deploy for niche use cases.
+
+## Out of scope for initial framework
+
+Threshold FHE is research output, not framework primitive. Tracked
+for completeness; not blocking Q2 2027 NIST submission.
+
+## References
+
+- `TODO.roadmap/26-confium-framework.md`
+- [BFV paper](https://eprint.iacr.org/2012/144)
+- [Microsoft SEAL](https://github.com/microsoft/SEAL) (reference FHE library)
+- [Zama Concrete](https://www.zama.ai/concrete) (Rust FHE library)


### PR DESCRIPTION
## Summary

Adds 16 roadmap documents covering the full Confium framework vision:

- **Strategic**: 25 (NIST threshold call), 26 (framework vision with three deployment modes), 27 (CNML flagship Mode 3 deployment)
- **Mode 2 (PKI replacement)**: 28 (PKCS#11/OpenSSL drop-in enterprise integration)
- **Threshold infrastructure**: 29 (async coordinator), 30 (share re-sharing), 31 (threshold encryption)
- **Cert/envelope layer**: 32 (X.509/CMS/XMLDSig/scoped delegation), 33 (deployment manifest)
- **Operational**: 34 (identity + hardware backends), 35 (PQ composites), 36 (transparency + OTS), 37 (long-term archival ERS)
- **Research frontier**: 38 (attribute-based threshold), 39 (threshold ring signatures), 40 (threshold FHE)

The three-mode framing in 26 is the key architectural shift: Confium is the general framework; OIML/CNML is the flagship reference deployment. Mode 1 (peer TC), Mode 2 (PKI replacement), Mode 3 (certificate PKI) are layered, with each mode building on the previous.

## Test plan

- [x] All files are markdown documentation, no code changes
- [x] Conventional commit message
- [x] No AI attribution trailers
