### PR TITLE
ci(upgrade-actions): pin/upgrade GHA actions to latest stable versions

### DIFF
--- a/.github/workflows/_rust-setup.yml
+++ b/.github/workflows/_rust-setup.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install Rust ${{ inputs.rust }}
         if: ${{ inputs.rust != '' }}
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: ${{ inputs.rust }}
           components: rustfmt, clippy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.45.0
+      - uses: crate-ci/typos@v1.47.1
 
   # ============================================================================
   # Pre-flight: skip CI when only docs/markdown changed
@@ -78,7 +78,7 @@ jobs:
         run: cargo generate-lockfile
 
       - name: Run cargo-audit
-        uses: rustsec/audit-check@v2
+        uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -228,7 +228,7 @@ jobs:
           tool: cbindgen
 
       - name: Install cmake
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.31.0
 
       - name: Install boost
         uses: MarkusJx/install-boost@v2.4.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.5
+        uses: MarcoIeni/release-plz-action@v0.5.40
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -35,7 +35,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        uses: jetli/wasm-pack-action@v0.4.0
+        uses: jetli/wasm-pack-action@v0.4.1
 
       - name: Build WASM package
         run: |


### PR DESCRIPTION
## Summary

Pins and upgrades GHA shared actions to latest stable versions across all workflows.

| Action | Before | After | Reason |
|---|---|---|---|
| `dtolnay/rust-toolchain` | `master` | `stable` | Avoid tracking moving target |
| `MarcoIeni/release-plz-action` | `v0.5` | `v0.5.40` | Latest patch release |
| `jetli/wasm-pack-action` | `v0.4.0` | `v0.4.1` | Latest patch |
| `crate-ci/typos` | `v1.45.0` | `v1.47.1` | Latest typos checker |
| `rustsec/audit-check` | `v2` | `v2.0.0` | Pin exact version |
| `lukka/get-cmake` | `latest` | `v3.31.0` | Pin instead of floating |

Already up to date (no changes needed):
- `actions/checkout@v4` ✅
- `Swatinem/rust-cache@v2` ✅
- `actions/upload-artifact@v4` ✅
- `actions/download-artifact@v4` ✅
- `actions/cache@v4` ✅
- `actions/setup-python@v5` ✅
- `actions/setup-node@v4` ✅
- `actions/configure-pages@v5` ✅
- `actions/deploy-pages@v4` ✅
- `actions/upload-pages-artifact@v3` ✅
- `taiki-e/install-action@v2` ✅
- `MarkusJx/install-boost@v2.4.1` ✅

## Test plan

- [x] All workflow YAML files valid
- [x] All action versions verified against GitHub releases
- [x] Conventional commit message
- [x] No AI attribution trailers
