### PR TITLE
chore(store-openpgp-card): switch rnp-rs dep from path to crates.io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,10 +122,9 @@ tungstenite = { version = "0.30", default-features = false, features = ["handsha
 wasmtime = "27"
 cryptoki = "0.12"
 curve25519-dalek = { version = "4", features = ["rand_core"] }
-# rnp-rs: idiomatic Rust binding to librnp (OpenPGP C FFI).
-# Vendored locally at ~/src/rnp/rnp-rs; switch to a git/crates.io ref
-# once it is published. The lib name is `rnp` (crate name `rnp-rs`).
-rnp = { package = "rnp-rs", path = "../../rnp/rnp-rs", version = "0.1.3" }
+# rnp-rs: idiomatic Rust binding to librnp (OpenPGP C FFI). Published on
+# crates.io. We alias to `rnp` because the crate's lib name is `rnp`.
+rnp = { package = "rnp-rs", version = "0.1.6" }
 ed25519-dalek = "2"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 aes-gcm = "0.10"


### PR DESCRIPTION
## Summary

- Switches the `rnp` workspace dependency from a local path (`../../rnp/rnp-rs`) to the published crates.io version `0.1.6`. rnp-rs 0.1.6 is now live on crates.io.
- Package-name → lib-name alias (`rnp-rs` → `rnp`) is preserved, so `use rnp::*` imports in `confium-store-openpgp-card` keep working unchanged.

## Test plan

- [x] `cargo build -p confium-store-openpgp-card` — clean build against `rnp-rs v0.1.6` from crates.io
- [x] `cargo test -p confium-store-openpgp-card` — all 3 integration tests still pass:
  - `sign_verify_round_trip_via_rnp_backend`
  - `factory_reset_clears_session_state`
  - `standalone_rnp_smoke_test_for_comparison`
- [x] `cargo build --workspace` — full workspace resolves cleanly
- [ ] CI green

## Notes

This unblocks downstream consumers (and the Ruby / WASM bindings work) from needing the `~/src/rnp/rnp-rs` sibling repo to be present. The path dep was always meant as a stopgap until rnp-rs was published.
