### PR TITLE
feat(wasm): Certificate + CMS::SignedData verifiers (Phase 2B)

### DIFF
--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -21,23 +21,26 @@ rustdoc-args = ["--cfg", "docsrs"]
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["verify-composite", "verify-transparency", "verify-attributes"]
+default = ["verify-composite", "verify-transparency", "verify-attributes", "verify-pki"]
 # Each verify-* flag gates a subtree of the verifier surface. Off by default
 # would let consumers tree-shake aggressively; we ship them all on by default
 # so `@confium/confium-wasm` works out of the box.
 verify-composite = ["dep:confium-composite"]
 verify-transparency = ["dep:confium-transparency"]
 verify-attributes = ["dep:confium-attributes"]
+verify-pki = ["dep:confium-pki"]
 
 [dependencies]
 confium-composite = { workspace = true, optional = true }
 confium-transparency = { workspace = true, optional = true }
 confium-attributes = { workspace = true, optional = true }
+confium-pki = { workspace = true, optional = true }
 
 wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
 js-sys = "0.3"
+chrono = { workspace = true }
 
 # Verifier-only deps — all WASM-friendly, no filesystem, no threads.
 ed25519-dalek = { workspace = true }

--- a/crates/confium-wasm/src/lib.rs
+++ b/crates/confium-wasm/src/lib.rs
@@ -30,6 +30,12 @@ mod attributes;
 #[cfg(feature = "verify-attributes")]
 pub use attributes::Predicate;
 
+#[cfg(feature = "verify-pki")]
+mod pki;
+
+#[cfg(feature = "verify-pki")]
+pub use pki::{Certificate, SignedData};
+
 /// Package version (mirrors the Cargo version).
 #[wasm_bindgen]
 pub fn version() -> String {

--- a/crates/confium-wasm/src/pki.rs
+++ b/crates/confium-wasm/src/pki.rs
@@ -1,0 +1,125 @@
+//! `Certificate` + `CMS::SignedData` — PKI verifiers for the browser/Node.js
+//! surface.
+
+use confium_pki::{
+    cert::Certificate as RustCert,
+    cms::SignedData as RustSignedData,
+};
+use wasm_bindgen::prelude::*;
+
+/// Parsed X.509 v3 certificate. Construct via [`Certificate::from_der`] or
+/// [`Certificate::from_pem`]; inspect validity window, fingerprint, serial.
+#[wasm_bindgen]
+pub struct Certificate {
+    inner: RustCert,
+}
+
+#[wasm_bindgen]
+impl Certificate {
+    /// Parse a certificate from DER bytes (`Uint8Array`).
+    #[wasm_bindgen(constructor)]
+    pub fn from_der(der: &[u8]) -> Result<Certificate, JsValue> {
+        let inner = RustCert::from_der(der)
+            .map_err(|e| JsValue::from_str(&format!("DER parse error: {e}")))?;
+        Ok(Self { inner })
+    }
+
+    /// Parse a certificate from PEM (RFC 7468) text.
+    pub fn from_pem(pem: &str) -> Result<Certificate, JsValue> {
+        let inner = RustCert::from_pem(pem)
+            .map_err(|e| JsValue::from_str(&format!("PEM parse error: {e}")))?;
+        Ok(Self { inner })
+    }
+
+    /// SHA-256 fingerprint as a lowercase hex string.
+    #[wasm_bindgen(getter)]
+    pub fn fingerprint_sha256(&self) -> String {
+        self.inner.fingerprint_sha256()
+    }
+
+    /// Serial number as a lowercase hex string.
+    #[wasm_bindgen(getter)]
+    pub fn serial_hex(&self) -> String {
+        let bytes = self.inner.serial_bytes();
+        let mut out = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            out.push_str(&format!("{:02x}", b));
+        }
+        out
+    }
+
+    /// DER bytes (`Uint8Array`).
+    #[wasm_bindgen]
+    pub fn to_der(&self) -> Vec<u8> {
+        self.inner.to_der()
+    }
+
+    /// Whether the certificate is within its validity window at the given
+    /// epoch-millisecond timestamp.
+    #[wasm_bindgen]
+    pub fn is_within_validity(&self, epoch_ms: f64) -> bool {
+        let now = chrono::DateTime::<chrono::Utc>::from_timestamp_millis(epoch_ms as i64)
+            .unwrap_or_else(|| chrono::Utc::now());
+        self.inner.is_within_validity(now)
+    }
+}
+
+/// CMS SignedData JSON model — wraps `confium_pki::cms::SignedData`.
+///
+/// Construct via [`SignedData::from_json`] (the canonical wire format) and
+/// inspect signer / certificate / content fields. Verification of the
+/// signatures themselves happens at a higher layer (the verifier is
+/// caller-supplied because each signer algorithm needs its own callback).
+#[wasm_bindgen]
+pub struct SignedData {
+    inner: RustSignedData,
+}
+
+#[wasm_bindgen]
+impl SignedData {
+    /// Parse SignedData from its canonical JSON form.
+    #[wasm_bindgen(constructor)]
+    pub fn from_json(json: &str) -> Result<SignedData, JsValue> {
+        let inner: RustSignedData = serde_json::from_str(json)
+            .map_err(|e| JsValue::from_str(&format!("SignedData JSON parse error: {e}")))?;
+        Ok(Self { inner })
+    }
+
+    /// Round-trip back to canonical JSON.
+    #[wasm_bindgen]
+    pub fn to_json(&self) -> Result<String, JsValue> {
+        serde_json::to_string(&self.inner)
+            .map_err(|e| JsValue::from_str(&format!("serialize: {e}")))
+    }
+
+    /// Number of signer infos.
+    #[wasm_bindgen(getter)]
+    pub fn signer_count(&self) -> usize {
+        self.inner.signer_infos.len()
+    }
+
+    /// Content type OID.
+    #[wasm_bindgen(getter)]
+    pub fn content_type(&self) -> String {
+        self.inner.encap_content_info.content_type.clone()
+    }
+
+    /// Number of attached X.509 certificates.
+    #[wasm_bindgen(getter)]
+    pub fn certificate_count(&self) -> usize {
+        self.inner.certificates.len()
+    }
+
+    /// Get the DER bytes of the certificate at `index`, or `undefined` if
+    /// out of range.
+    #[wasm_bindgen]
+    pub fn certificate_at(&self, index: usize) -> Option<Vec<u8>> {
+        self.inner.certificates.get(index).cloned()
+    }
+
+    /// Get the encapsulated content bytes, or `None` if detached.
+    #[wasm_bindgen]
+    pub fn content(&self) -> Option<Vec<u8>> {
+        self.inner.encap_content_info.content.clone()
+    }
+}

--- a/crates/confium-wasm/tests/wasm_smoke.rs
+++ b/crates/confium-wasm/tests/wasm_smoke.rs
@@ -77,3 +77,33 @@ fn predicate_parse_and_evaluate() {
     let signers_short = r#"[{"role:director": ["yes"]}]"#;
     assert!(!pred.satisfied_by(signers_short).unwrap());
 }
+
+#[wasm_bindgen_test]
+fn certificate_from_der_rejects_garbage() {
+    use confium_wasm::*;
+    let err = Certificate::from_der(&[0u8; 10]);
+    assert!(err.is_err(), "garbage DER should error");
+}
+
+#[wasm_bindgen_test]
+fn signed_data_round_trips_through_json() {
+    use confium_wasm::*;
+    let json = r#"{
+        "version": 1,
+        "digest_algorithms": [{"oid":"2.16.840.1.101.3.4.2.1"}],
+        "encap_content_info": {
+            "content_type":"1.2.840.113549.1.7.1",
+            "content":[72,101,108,108,111]
+        },
+        "certificates":[],
+        "signer_infos":[]
+    }"#;
+    let sd = SignedData::from_json(json).unwrap();
+    assert_eq!(sd.signer_count(), 0);
+    assert_eq!(sd.content_type(), "1.2.840.113549.1.7.1");
+    assert_eq!(sd.certificate_count(), 0);
+    assert_eq!(sd.content().unwrap(), vec![72, 101, 108, 108, 111]);
+
+    let round = SignedData::from_json(&sd.to_json().unwrap()).unwrap();
+    assert_eq!(round.content_type(), sd.content_type());
+}


### PR DESCRIPTION
Phase 2B PKI verifiers for the browser/Node.js surface.

- `Certificate.from_der / from_pem` + `#fingerprint_sha256 / #serial_hex / #to_der / #is_within_validity(epoch_ms)`
- `SignedData.from_json / to_json` + `#signer_count / #content_type / #content / #certificate_count / #certificate_at`
- New `verify-pki` Cargo feature, on by default.

## Test plan
- [x] `cargo build -p confium-wasm --target wasm32-unknown-unknown` — clean
- [x] `cargo test -p confium-wasm --lib` — compiles
- [x] 2 new wasm-bindgen-test cases (Certificate rejects garbage, SignedData JSON round-trip)
- [ ] CI green

## Next
Phase 1D-1 Ruby: TC subsystem (FROST, CMP20, GG18, ElGamal, Coordinator, Reshare).