### PR TITLE
chore(wasm): switch release workflow to npm trusted publishing

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,15 +1,27 @@
-# Build and publish the `confium-wasm` package to npm.
+# Build and publish `@confium/confium-wasm` to npm via **trusted publishing**.
+#
+# npm's modern publishing model uses OIDC-based trusted publishing: no
+# long-lived NPM_TOKEN secret. The flow is:
+#
+#   1. **First publish** is done manually by the package owner:
+#        - `wasm-pack build crates/confium-wasm --target bundler --release --scope confium`
+#        - `cd crates/confium-wasm/pkg && npm publish --access public`
+#      This creates the package on the npm registry and lets the owner
+#      configure trusted publishing for the GitHub repo.
+#
+#   2. **Trusted publishing setup** (one-time, on npm side):
+#        - Visit https://www.npmjs.com/package/@confium/confium-wasm/access
+#        - Under "Configured GitHub Actions" add:
+#            repository: confium/confium
+#            workflow:   .github/workflows/wasm.yml
+#            environment: release
+#        - Configure the GitHub environment `release` to require it.
+#
+#   3. **Subsequent publishes** run from this workflow on tag push. The
+#      `id-token: write` permission lets npm verify the workflow's OIDC
+#      identity and accept the publish without a token.
 #
 # Triggered on release tags (v*.*.*) and via workflow_dispatch.
-# Produces a single npm package containing:
-#
-#   - the WASM binary blob (confium_wasm_bg.wasm)
-#   - the generated JS bindings (confium_wasm.js)
-#   - TypeScript definitions (confium_wasm.d.ts)
-#
-# The package is published under `@confium/confium-wasm` on the public npm
-# registry. The npm token is configured as the `NPM_TOKEN` repository
-# secret.
 
 name: Release WASM
 
@@ -37,10 +49,12 @@ jobs:
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
 
+      # Build the bundler target — produces ESM + CJS + .d.ts that npm
+      # consumers can use regardless of their bundler.
       - name: Build WASM package
         run: |
           wasm-pack build crates/confium-wasm \
-            --target web \
+            --target bundler \
             --release \
             --scope confium
 
@@ -56,7 +70,11 @@ jobs:
   publish-npm:
     needs: build-wasm
     runs-on: ubuntu-latest
+    environment: release  # matches the npm trusted-publishing config
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      id-token: write  # required for npm trusted publishing (OIDC)
+      contents: read
     steps:
       - uses: actions/checkout@v7
 
@@ -72,8 +90,6 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Publish
-        run: npm publish --access public
+      - name: Publish via trusted publishing (OIDC, no NPM_TOKEN)
+        run: npm publish --access public --provenance
         working-directory: pkg/
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/crates/confium-wasm/RELEASE.md
+++ b/crates/confium-wasm/RELEASE.md
@@ -1,0 +1,77 @@
+# Releasing `@confium/confium-wasm`
+
+This package uses npm's **trusted publishing** model — no long-lived
+`NPM_TOKEN` secret. The setup is a one-time per-package ritual; subsequent
+releases happen automatically from the `wasm.yml` workflow on tag push.
+
+## First-time setup (do this once)
+
+1. **Build the package locally**:
+   ```sh
+   wasm-pack build crates/confium-wasm \
+     --target bundler \
+     --release \
+     --scope confium
+   ```
+
+2. **First publish (manual)** — creates the package on the npm registry:
+   ```sh
+   cd crates/confium-wasm/pkg
+   npm publish --access public
+   ```
+   This must be done by an owner of the `@confium` scope on npm.
+
+3. **Configure trusted publishing** on npm:
+   - Visit <https://www.npmjs.com/package/@confium/confium-wasm/access>
+   - Under **Configured GitHub Actions**, add:
+     - **Repository**: `confium/confium`
+     - **Workflow**: `.github/workflows/wasm.yml`
+     - **Environment**: `release`
+
+4. **Configure the `release` environment** on GitHub:
+   - Visit <https://github.com/confium/confium/settings/environments>
+   - Create environment `release`
+   - (Optional but recommended) Add required reviewers + deployment-branch
+     protection (`v*` tags only).
+
+## Subsequent releases
+
+From now on, releasing is just:
+
+```sh
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The `wasm.yml` workflow will:
+1. Build the WASM package via `wasm-pack`
+2. Request an OIDC token from GitHub Actions
+3. Publish to npm with `--provenance` (so consumers can verify the
+   published tarball was built from this repo's source)
+
+## Verifying a release
+
+Once published, consumers can install:
+
+```sh
+npm install @confium/confium-wasm
+```
+
+And check provenance:
+
+```sh
+npm view @confium/confium-wasm --json | jq '.dist.attestation'
+```
+
+## Why trusted publishing?
+
+The classic flow (long-lived `NPM_TOKEN` secret) has two problems:
+- The token leaks if the repo is compromised.
+- The token expires and breaks releases silently.
+
+Trusted publishing fixes both: npm trusts a *transient* OIDC token
+minted by GitHub Actions for this specific workflow + environment. No
+secret to leak, nothing to expire.
+
+See <https://docs.npmjs.com/guides/open-source-from-github#enabling-trusted-publishing-on-npm>
+for npm's docs on this flow.


### PR DESCRIPTION
Removes the NPM_TOKEN secret requirement; uses OIDC trusted publishing instead. Adds crates/confium-wasm/RELEASE.md with the one-time setup steps for the package owner.