### PR TITLE
docs(confium): Rust workspace docs tree + TODO.completion 032-043

### DIFF
--- a/TODO.completion/032-rust-workspace-docs.md
+++ b/TODO.completion/032-rust-workspace-docs.md
@@ -1,0 +1,64 @@
+# 032 — Rust workspace `docs/` tree
+
+**Category**: Documentation
+**Severity**: High (per-repo docs are the canonical developer reference; needed before website pull-through)
+**Effort**: Medium (one PR — many AsciiDoc files)
+
+## Problem
+
+The Rust workspace at `confium/` ships 43 crates with deep functionality
+but no consolidated `docs/` tree. The README points at the workspace
+README and `CLAUDE.md`, but neither is structured for public
+consumption. Per the plan at `/Users/mulgogi/.claude/plans/prancy-riding-honey.md`,
+each repo owns its `/docs/` and the central Astro site at
+`confium.github.io` pulls them via sparse-checkout.
+
+Without `confium/docs/`, `www.confium.org/software/rust/docs/` will be
+empty.
+
+## Acceptance criteria
+
+- [ ] `docs/index.adoc` — landing page that orients the reader: what
+  Confium is, how to install, where to go next.
+- [ ] `docs/installation.adoc` — three paths: `cargo add confium-core`,
+  Nix flake (`nix develop`), build from source.
+- [ ] `docs/workspace-map.adoc` — 43 crates grouped by category
+  (Engine, TC, TC-encryption, PKI, Storage, Mode 2, Network, Research).
+  Links to docs.rs for each.
+- [ ] `docs/architecture.adoc` — engine, plugin loader, registry,
+  FFI entry points, the 10 shipped interfaces.
+- [ ] `docs/plugin-author-guide.adoc` — `#[plugin_interface]`,
+  `#[export]`, `register_interface!`, the `cfmp_*` contract.
+- [ ] `docs/conventions.adoc` — Snafu 0.8 (`NullPointerSnafu`),
+  edition 2024 quirks (`#[unsafe(no_mangle)]`), `#![forbid(unsafe_code)]`,
+  `#![warn(missing_docs)]`.
+- [ ] `docs/crates/{frost-ed25519,frost-p256,cmp20,gg18,elgamal-p256,composite,transparency,coordinator,reshare}.adoc`
+  — per-crate deep dives (purpose, public API, security notes).
+- [ ] `docs/examples/{threshold-signing,pq-migration,transparency-log}.adoc`
+  — runnable end-to-end examples in Rust.
+- [ ] Every file is AsciiDoc with `= Title` H1 + `:toc:` macro.
+- [ ] No "OIML" anywhere; CNML OK as one example among many.
+- [ ] No "TODO", "coming soon", "planned", "milestone", or "roadmap"
+  language — read as shipped.
+
+## Anti-patterns
+
+- Dumping `cargo doc` output — that's at `docs.confium.org`, not here.
+- Copying `CLAUDE.md` verbatim — it's an LLM-oriented file, not a user doc.
+- Cross-linking into `TODO.roadmap/` or `TODO.finalize/` — those are
+  internal; public docs link only to public artifacts.
+
+## Approach
+
+One PR per logical group if review load is high, otherwise one bundled
+PR. Each file is 100–300 lines, AsciiDoc with code blocks and tables.
+Pull workspace structure from `Cargo.toml` and `CLAUDE.md`. Verify
+anchors render correctly with `asciidoctor docs/index.adoc` locally
+before pushing.
+
+## Related
+
+- [033-ruby-docs-augmentation.md](033-ruby-docs-augmentation.md) —
+  parallel work in the Ruby gem.
+- [041-software-bindings-specs-pull-through.md](041-software-bindings-specs-pull-through.md)
+  — consumes this tree via `fetch-sources.mjs`.

--- a/TODO.completion/033-ruby-docs-augmentation.md
+++ b/TODO.completion/033-ruby-docs-augmentation.md
@@ -1,0 +1,64 @@
+# 033 — Ruby gem `docs/` augmentation
+
+**Category**: Documentation
+**Severity**: High (Ruby is the launch language binding; per-repo docs are sparse today)
+**Effort**: Medium (one PR — AsciiDoc + RBS extraction)
+
+## Problem
+
+`confium-ruby/docs/` already has three good documents
+(`executive/why-confium.adoc`, `pq-migration/composite-signatures.adoc`,
+`quickstarts/sinatra-verifier.adoc`) but is missing the canonical
+reference docs a Ruby developer expects: installation, API reference,
+error handling, policy/configuration, examples index.
+
+## Acceptance criteria
+
+- [ ] `docs/index.adoc` — landing page orienting Ruby developers.
+- [ ] `docs/installation.adoc` — `gem install confium`, Bundler, building
+  the native extension from source, platform support (Linux/macOS,
+  Windows via rake-compiler-dock).
+- [ ] `docs/api-reference.adoc` — every public class and module:
+  `Confium::PKI::Certificate`, `Confium::PKI::CMS::SignedData`,
+  `Confium::Composite::Signature`, `Confium::Transparency::MerkleTree`,
+  `Confium::TC::FrostP256`, `Confium::TC::ElGamalP256`,
+  `Confium::Attributes::Predicate`, `Confium::Identity::*`,
+  `Confium::Config::Manifest`, `Confium::SecureBytes`, `Confium::Policy`.
+  Generated/curated from the RBS signatures in `sig/`.
+- [ ] `docs/error-handling.adoc` — the typed error hierarchy
+  (`Confium::Error` + 9 subclasses), rescue patterns, `details` accessor.
+- [ ] `docs/policy.adoc` — jurisdictional policies (`Confium::Policy`),
+  FIPS 140 mode toggle, algorithm allow-lists.
+- [ ] `docs/cnml-profile.adoc` — the CNML certificate profile (required
+  extensions, cert roles). **No "OIML" branding in body** — refer to
+  CNML as a "reference institutional deployment".
+- [ ] `docs/examples/index.adoc` — index over `examples/*.rb` with one
+  paragraph of motivation per example.
+- [ ] No `require_relative` in any example code — use `require "confium"`.
+- [ ] No `double()` in any spec referenced from docs.
+- [ ] No "OIML" anywhere; CNML OK as one example.
+
+## Anti-patterns
+
+- Auto-generating the API reference purely from yardocs — curated prose
+  beats raw yardoc output for orientation.
+- Inlining long Ruby code blocks — link to `examples/*.rb` for full
+  source, show only the essence inline.
+- Cross-linking to internal `TODO.*` directories.
+
+## Approach
+
+Extract class/method lists from `sig/confium/*.rbs` (the source of
+truth for the Ruby surface). For each class, write a 1-paragraph
+orientation + key method signatures + one usage snippet. Cross-link to
+`examples/` for full demos. One PR; land before TODO 041 so the website
+has content to pull.
+
+## Related
+
+- [032-rust-workspace-docs.md](032-rust-workspace-docs.md) — parallel
+  work in the Rust workspace.
+- [017-sinatra-verifier-quickstart.md](017-sinatra-verifier-quickstart.md)
+  — already shipped; this TODO does not touch it.
+- [041-software-bindings-specs-pull-through.md](041-software-bindings-specs-pull-through.md)
+  — consumes this tree via `fetch-sources.mjs`.

--- a/TODO.completion/034-astro-site-scaffolding.md
+++ b/TODO.completion/034-astro-site-scaffolding.md
@@ -1,0 +1,92 @@
+# 034 — Astro 7 site scaffolding (replaces Jekyll)
+
+**Category**: Documentation
+**Severity**: Critical (foundation for all subsequent website work)
+**Effort**: Large (one big PR — full stack replacement)
+
+## Problem
+
+`confium.github.io/` is a thin Jekyll site dragging a dead
+`confium-dot-org/` React/Paneron attempt. The user directed a full
+replacement with the Astro 7 + Vite 8 + Tailwind 4 + Vue islands stack,
+architecturally identical to the sister project RNP's site at
+`~/src/rnp/rnpgp.org/`.
+
+This TODO establishes the scaffolding so subsequent TODOs (035–043) can
+layer content on top.
+
+## Acceptance criteria
+
+- [ ] `astro.config.mjs` mirrors RNP's (Vue + sitemap integrations,
+  Tailwind via `@tailwindcss/vite`, `trailingSlash: 'always'`,
+  `compressHTML: true`, dual Shiki themes).
+- [ ] `package.json` pins: astro@7.1.1, vue@3.5.40, @astrojs/vue@7.0.1,
+  @astrojs/sitemap@3.7.3, @astrojs/rss@4.0.19, tailwindcss@4.3.3,
+  @tailwindcss/vite@4.3.3, @tailwindcss/typography@0.5.20,
+  asciidoctor@4.0.4, yaml@2.9.0, pagefind@1.5.2, plus
+  @fontsource/ibm-plex-sans + ibm-plex-mono.
+- [ ] `tsconfig.json` extends `astro/tsconfigs/strict`.
+- [ ] `src/styles/global.css` — Tailwind 4 with dual-token system
+  (`@theme` brand tokens, `:root`/`.dark` semantic vars,
+  `@theme inline` bridge). Confium amber palette per plan.
+- [ ] `src/lib/asciidoc.ts` — port of RNP's custom Astro loader.
+  YAML frontmatter split, `asciidoctor.js` render (`safe: 'safe'`,
+  `sectids`, embedded), TOC extraction, internal `.adoc` link rewriting.
+- [ ] `src/lib/events.ts` — typed event bus (`openSearch`, `replayHero`).
+- [ ] `src/content.config.ts` — defines 9 collections (6 hand-written +
+  3 vendor-pulled) per plan.
+- [ ] `src/layouts/BaseLayout.astro` — root HTML, theme detect,
+  View Transitions, mounts SiteHeader + SiteSearch + SiteFooter.
+- [ ] `src/layouts/DocsLayout.astro` — 3-column (sidebar + prose + TOC).
+- [ ] Minimal `src/components/vue/{SiteHeader,SiteSearch,ThemeToggle}.vue`
+  — functional but not yet styled. TODO 035 enhances.
+- [ ] `src/components/astro/{SiteFooter,Prose,TocNav,PageHero}.astro`.
+- [ ] `src/components/brand/{SymbolLogo,Wordmark}.astro` — salvage
+  existing SVG from `assets/symbol.svg`.
+- [ ] `scripts/fetch-sources.mjs` — sparse-checkout of
+  `confium/docs/`, `confium-ruby/docs/`, `specs/specs/` into `vendor/`.
+  Reads `src/content/software/*.md` for repo + ref + subtree metadata.
+- [ ] `scripts/prepare-dev-search.mjs` — copies `dist/pagefind/` to
+  `public/pagefind/` for dev server.
+- [ ] `.github/workflows/deploy.yml` — Node 22, `npm ci`,
+  `npm run fetch-sources`, `npm run build` (prebuild fetch + postbuild
+  pagefind), Pages deploy.
+- [ ] `.github/workflows/links.yml` — lychee against `dist/`.
+- [ ] **Salvage** `assets/symbol.svg`, `assets/nlnet-banner.svg`,
+  `assets/ngi-zeropet-banner.svg` into `public/assets/`.
+- [ ] **Archive** `confium-dot-org/` to `archive/legacy-paneron/` — flag
+  for user sign-off *before* executing.
+- [ ] Delete Jekyll scaffolding: `_config.yml`, `Gemfile`, `index.adoc`,
+  `custom-intro.html`, `nav-links.html`, `project-nav.html`,
+  `about.markdown`, `_pages/`, `_sass/`, `parent-hub/`, `paneron.yaml`,
+  `README.adoc`, `404.html`.
+- [ ] `.gitignore` adds `vendor/`, `node_modules/`, `dist/`,
+  `.astro/`.
+- [ ] `npm install && npm run build` succeeds locally with no content.
+- [ ] Site builds in CI and deploys to GitHub Pages.
+
+## Anti-patterns
+
+- Keeping any Jekyll file "just in case" — full replacement, no shims.
+- Inlining Tailwind via PostCSS instead of `@tailwindcss/vite` — RNP
+  uses the Vite plugin path, follow that.
+- Skipping the dual-token CSS system — semantic vars enable dark mode
+  without per-component overrides.
+- Vendoring RNP's easter-egg / fingerprint playground components —
+  off-brand for a security framework.
+
+## Approach
+
+Single PR. Order: salvage → archive (with user sign-off) → delete →
+scaffold config → scaffold layouts → scaffold minimal components →
+fetch-sources script → workflow. Land with an empty homepage so the
+site is live; TODO 035 fills it in.
+
+## Related
+
+- [035-homepage-vue-islands.md](035-homepage-vue-islands.md) — fills
+  the homepage + adds the interactive Vue islands.
+- [041-software-bindings-specs-pull-through.md](041-software-bindings-specs-pull-through.md)
+  — depends on `fetch-sources.mjs` working.
+- [043-search-cross-link-audit.md](043-search-cross-link-audit.md) —
+  verifies Pagefind end-to-end.

--- a/TODO.completion/035-homepage-vue-islands.md
+++ b/TODO.completion/035-homepage-vue-islands.md
@@ -1,0 +1,74 @@
+# 035 — Homepage + Vue islands
+
+**Category**: Documentation
+**Severity**: Critical (single highest-impact content surface)
+**Effort**: Large (one PR — homepage + 6 Vue islands)
+
+## Problem
+
+The homepage is the front door. After TODO 034 lands the Astro
+scaffolding with a minimal homepage placeholder, this TODO replaces it
+with the seven-section layout from the plan and adds the six
+interactive Vue islands that make the page feel alive.
+
+## Acceptance criteria
+
+- [ ] `src/pages/index.astro` renders seven sections in order:
+  1. Hero (animated tagline + dual CTA)
+  2. Three modes (interactive `ModeSelector.vue`)
+  3. What makes Confium different (5 bullets)
+  4. What Confium is NOT (3 negations)
+  5. Get started (3 install tabs via `InstallTabs.vue`)
+  6. Reference deployments (6 sovereign PKI scenarios; CNML is one)
+  7. Funding band (NLnet NGI Zero PET banner — salvaged SVG)
+- [ ] `src/components/vue/HeroDecrypt.vue` — WAAPI character-decrypt
+  animation on the tagline *"Threshold-native trust infrastructure for
+  a post-quantum world"`. Replays on `replayHero` event.
+- [ ] `src/components/vue/ModeSelector.vue` — three-card picker
+  (Peer-to-Peer TC, PKI Drop-in, Sovereign PKI); selected card expands
+  with a longer description + CTA. Persists selection in URL hash.
+- [ ] `src/components/vue/QuorumPlayground.vue` — interactive T-of-N
+  slider (T and N both adjustable, 1 ≤ T ≤ N ≤ 9). Visualizes "no
+  single party can sign alone" with party dots lighting up as T is
+  reached. Replaces RNP's `FingerprintPlayground.vue`.
+- [ ] `src/components/vue/InstallTabs.vue` — Ruby / Rust / WASM / Source
+  tab switcher with copy button. Each tab shows the canonical install
+  command in a terminal-style block.
+- [ ] `src/components/vue/CopyButton.vue` — clipboard copy with
+  fallback (`navigator.clipboard` → `execCommand`) + success state.
+- [ ] `src/components/vue/Reveal.vue` — IntersectionObserver scroll
+  reveal wrapper with `prefers-reduced-motion` opt-out.
+- [ ] Hero tagline renders server-side as static text (progressive
+  enhancement); the decrypt animation layers on top for capable clients.
+- [ ] Every Vue island is `client:load` or `client:visible` as appropriate
+  (below-the-fold islands use `client:visible`).
+- [ ] Lighthouse: Performance ≥ 90, Accessibility ≥ 95 on the homepage.
+- [ ] Mobile viewport (375px): hero text wraps cleanly, mode cards
+  stack, quorum playground remains usable.
+- [ ] Dark mode: every island respects `.dark` via the semantic token
+  system; no hardcoded colors.
+
+## Anti-patterns
+
+- Marketing fluff — every claim must be backed by a link into `/docs/`
+  or `/concepts/`.
+- "Coming soon" CTAs — only link to live pages.
+- Hardcoding color values inside Vue components — use Tailwind classes
+  derived from `@theme inline` tokens.
+- Auto-playing media — the decrypt animation runs once on load and on
+  explicit replay only.
+
+## Approach
+
+Single PR. Build islands in dependency order: CopyButton → Reveal →
+HeroDecrypt → InstallTabs → ModeSelector → QuorumPlayground. Each
+island gets a quick visual smoke test in `npm run dev` before moving
+on. Final commit wires the homepage sections together.
+
+## Related
+
+- [034-astro-site-scaffolding.md](034-astro-site-scaffolding.md) —
+  establishes the layouts and Vue integration this builds on.
+- [036-docs-pages.md](036-docs-pages.md) — the homepage CTAs link here.
+- [039-use-cases-sovereign-pki.md](039-use-cases-pages.md) — the
+  Sovereign PKI mode card links here.

--- a/TODO.completion/036-docs-pages.md
+++ b/TODO.completion/036-docs-pages.md
@@ -1,0 +1,76 @@
+# 036 — `/docs/` pages
+
+**Category**: Documentation
+**Severity**: High (primary technical content surface)
+**Effort**: Medium (one PR — 10 AsciiDoc files)
+
+## Problem
+
+After the homepage, `/docs/` is where every technical reader lands.
+The plan calls for 10 hand-written `.adoc` pages covering architecture,
+the three modes, components, security model, PQ migration, transparency
+logs, and getting started.
+
+## Acceptance criteria
+
+- [ ] `src/content/docs/architecture.adoc` — system overview, plugin
+  loader, registry, the 10 shipped interfaces, FFI entry points.
+  Adapted from `specs/specs/00-framework-overview.adoc` (light edit).
+- [ ] `src/content/docs/three-modes.adoc` — Peer-to-Peer TC, PKI
+  Drop-in, Sovereign PKI overview. Adapted from
+  `specs/specs/01-three-modes.adoc` (OIML stripped, Sovereign PKI
+  branded).
+- [ ] `src/content/docs/mode1-peer-tc.adoc` — Mode 1 detail. Adapted
+  from `specs/specs/10-mode1-peer-tc.adoc`.
+- [ ] `src/content/docs/mode2-pki-drop-in.adoc` — Mode 2 detail +
+  composite signatures PQ argument. Adapted from
+  `specs/specs/11-mode2-pki-replacement.adoc`.
+- [ ] `src/content/docs/mode3-sovereign-pki.adoc` — Mode 3 detail,
+  branded "Sovereign PKI". **Heavy edit** of
+  `specs/specs/12-mode3-certificate-pki.adoc`: strip all OIML
+  references, genericize examples (CNML, BIPM calibration, accreditation,
+  supply-chain provenance, treaty orgs).
+- [ ] `src/content/docs/components.adoc` — 43-crate workspace map by
+  category. Fresh write.
+- [ ] `src/content/docs/security-model.adoc` — threat model, defense in
+  depth. Adapted from `specs/specs/90-security-model.adoc`.
+- [ ] `src/content/docs/pq-migration.adoc` — composite signatures deep
+  dive, migration path. Synthesizes
+  `confium-ruby/docs/pq-migration/composite-signatures.adoc`.
+- [ ] `src/content/docs/transparency-logs.adoc` — RFC 6962, inclusion
+  proofs, consistency proofs, OTS anchoring, witness gossip. Synthesizes
+  `specs/specs/42-transparency-log.adoc` +
+  `confium/docs/security/transparency-logs.md`.
+- [ ] `src/content/docs/getting-started.adoc` — quickstart hub linking
+  into `/software/rust/docs/installation/`,
+  `/software/ruby/docs/installation/`, the WASM verifier quickstart.
+- [ ] Every page is AsciiDoc with `= Title` H1 + `:toc:` macro.
+- [ ] Every page cross-links to at least one sibling doc and one
+  `/concepts/` page where applicable.
+- [ ] Renders correctly through the custom `adocLoader` (YAML frontmatter
+  + AsciiDoc body, h2/h3 TOC extracted).
+- [ ] No "OIML"; no "TODO"/"coming soon"/"planned"/"roadmap".
+
+## Anti-patterns
+
+- Copying specs verbatim — the docs pages are *oriented* (audience-aware)
+  while specs are normative. Light edit, not dump.
+- Inlining SVG diagrams as base64 — place under `public/assets/` and
+  reference by path.
+- burying the mode-3 Sovereign PKI rebrand — Mode 3 must read as
+  Sovereign PKI consistently across homepage, docs, use cases, blog.
+
+## Approach
+
+Single PR. Work through pages in the order listed above (architecture
+first as it sets vocabulary). For each spec-derived page, lift the
+canonical sections, strip OIML, rebrand mode 3, genericize examples.
+Cross-link audit happens at the end of the PR before merge.
+
+## Related
+
+- [038-concepts-pages.md](038-concepts-pages.md) — pages this docs set
+  cross-links into.
+- [039-use-cases-pages.md](039-use-cases-pages.md) — pages this docs set
+  cross-links into.
+- [040-glossary-page.md](040-glossary-page.md) — term definitions.

--- a/TODO.completion/037-about-meta-pages.md
+++ b/TODO.completion/037-about-meta-pages.md
@@ -1,0 +1,54 @@
+# 037 — About + 404 + meta pages
+
+**Category**: Documentation
+**Severity**: Medium (table-stakes pages, low complexity)
+**Effort**: Small (one PR — 5 simple pages)
+
+## Problem
+
+Every site needs the meta pages: about, 404, contribute, security
+disclosure, funding. They're low-effort but high-trust — a missing
+`/security/` page reads as "this project doesn't take disclosure
+seriously".
+
+## Acceptance criteria
+
+- [ ] `src/pages/about.astro` — governance model (BSD-2-Clause),
+  contributor ladder, funding (NLnet NGI Zero PET, Mozilla MOSS),
+  contributing pointers, who's behind Confium. Replaces existing
+  `about.markdown`. **No OIML.**
+- [ ] `src/pages/404.astro` — on-brand 404 with a quorum-themed joke
+  ("3 of 5 pages could not be found") + link back to homepage and docs.
+- [ ] `src/pages/contribute.astro` — how to contribute: open an issue,
+  open a PR, the BSD-2-Clause contributor ladder, code of conduct link,
+  good-first-issue pointer.
+- [ ] `src/pages/security.astro` — security disclosure policy: how to
+  report a vulnerability, PGP key, SLA for response, scope (in-scope vs
+  out-of-scope), disclosure timeline commitments.
+- [ ] `src/pages/funding.astro` — NLnet NGI Zero PET + Mozilla MOSS
+  funding acknowledgements, what each grant covers, link to funders'
+  pages.
+- [ ] Every page uses `BaseLayout.astro` (not DocsLayout — these are
+  full-bleed, not three-column).
+- [ ] Mobile-responsive; dark mode clean.
+- [ ] No "OIML"; no "TODO"/"coming soon"/"planned".
+
+## Anti-patterns
+
+- Generic 404 ("page not found") — make it on-brand.
+- Boilerplate security page that doesn't list a PGP key or SLA —
+  reviewers will spot it instantly.
+- Burying the license — BSD-2-Clause must appear on About.
+
+## Approach
+
+Single PR, parallel writes possible. About + 404 are the two non-trivial
+writes; the other three are mostly structural. Total: ~250 lines across
+5 files.
+
+## Related
+
+- [034-astro-site-scaffolding.md](034-astro-site-scaffolding.md) —
+  provides the layouts these pages use.
+- [042-seed-blog-posts.md](042-seed-blog-posts.md) — the "Introducing
+  Confium" post can be cross-linked from About.

--- a/TODO.completion/038-concepts-pages.md
+++ b/TODO.completion/038-concepts-pages.md
@@ -1,0 +1,62 @@
+# 038 — `/concepts/` pages
+
+**Category**: Documentation
+**Severity**: High (educational hub — gateway for non-expert readers)
+**Effort**: Medium (one PR — 5 AsciiDoc files)
+
+## Problem
+
+`/docs/` speaks to engineers who already know what threshold crypto is.
+`/concepts/` is the educational on-ramp: an executive or junior dev
+lands here first to build a mental model before tackling the docs.
+Without these pages, the site reads as insider-only.
+
+## Acceptance criteria
+
+- [ ] `src/content/concepts/threshold-crypto-101.adoc` — T-of-N
+  intuition, Shamir secret sharing explained from first principles,
+  Lagrange interpolation (light touch), why T-of-N beats single-key.
+  Includes a worked example: "3-of-5 directors required to sign".
+- [ ] `src/content/concepts/tls-analogy.adoc` — the central analogy:
+  *"Confium is to threshold cryptography what TLS libraries are to
+  transport security — a configurable framework organizations deploy
+  with their own parameters."* Explains the analogy in both directions
+  (what Confium provides vs. what plugins provide).
+- [ ] `src/content/concepts/composite-signatures.adoc` — why hybrid
+  PQ/classical signatures matter, how Confium composes them, migration
+  path without re-issuing every certificate.
+- [ ] `src/content/concepts/transparency-logs.adoc` — RFC 6962 primer:
+  Merkle trees, inclusion proofs, consistency proofs, split-view
+  attacks, witness gossip, OTS anchoring. Lighter than the docs page —
+  intuition first, math second.
+- [ ] `src/content/concepts/attribute-based-threshold.adoc` —
+  predicates, the DSL, "5-of-9 directors from 3 distinct regions",
+  why attribute-based beats fixed-quorum.
+- [ ] Every page cross-links to the deepest `/docs/` page that uses
+  the concept and to relevant `/glossary/` anchors.
+- [ ] Every page renders correctly through the custom `adocLoader`.
+- [ ] No "OIML"; no "TODO"/"coming soon"/"planned".
+
+## Anti-patterns
+
+- Duplicating the docs page content — concepts give *intuition*, docs
+  give *normative detail*. They link to each other, not overlap.
+- Academic tone — concepts should read like a smart blog post, not a
+  textbook chapter.
+- Skipping diagrams — at least one inline SVG or ASCII diagram per
+  concept page where it aids understanding.
+
+## Approach
+
+Single PR. Write in the order above (101 first as it sets vocabulary).
+Each page: 200–400 lines, AsciiDoc, 1–2 diagrams, 2–3 code snippets max.
+The TLS analogy page is the most important — it's the homepage subtitle
+expanded.
+
+## Related
+
+- [036-docs-pages.md](036-docs-pages.md) — the deeper pages these
+  concepts link into.
+- [040-glossary-page.md](040-glossary-page.md) — term definitions.
+- [042-seed-blog-posts.md](042-seed-blog-posts.md) — the "Introducing
+  Confium" post will lean on the TLS analogy.

--- a/TODO.completion/039-use-cases-pages.md
+++ b/TODO.completion/039-use-cases-pages.md
@@ -1,0 +1,59 @@
+# 039 — `/use-cases/` pages
+
+**Category**: Documentation
+**Severity**: High (scenario hub — answers "what's it for?")
+**Effort**: Medium (one PR — 6 Markdown files)
+
+## Problem
+
+Readers who skim the homepage and ask "is this for me?" need concrete
+scenarios. The plan calls for six use-case pages spanning the three
+deployment modes plus PQ migration.
+
+## Acceptance criteria
+
+- [ ] `src/content/use_cases/web-tls.md` — threshold TLS signing via
+  the OpenSSL 3.0 provider. Mode 2 angle.
+- [ ] `src/content/use_cases/code-signing.md` — multi-stakeholder code
+  signing (no single maintainer holds the full key). Mode 2 angle.
+- [ ] `src/content/use_cases/distributed-custody.md` — MPC wallets,
+  threshold key escrow (Thunderbird-style key backup generalized).
+  Mode 1 angle.
+- [ ] `src/content/use_cases/sovereign-pki.md` — institutional PKI
+  without a single trusted party. Mode 3 angle. CNML appears as one
+  of six institutional examples (BIPM calibration, pharma regulator
+  approvals, academic accreditation, supply-chain provenance, treaty
+  organizations). **No OIML branding.**
+- [ ] `src/content/use_cases/pq-migration.md` — HSM-free PQ migration
+  via composite signatures. Cross-mode.
+- [ ] `src/content/use_cases/supply-chain.md` — provenance tracking
+  with transparency logs. Cross-mode.
+- [ ] Every page has: problem statement, how Confium solves it, code
+  snippet (Ruby preferred — most accessible), link into relevant
+  `/docs/` page, "when to choose this" callout.
+- [ ] Every page uses Markdown (not AsciiDoc) per the content config.
+- [ ] Use cases render via `globLoader` with frontmatter
+  `title`, `description`, `mode` (1/2/3/cross), `order`.
+- [ ] `/use-cases/index.astro` lists all six, grouped by mode.
+- [ ] No "OIML"; no "TODO"/"coming soon".
+
+## Anti-patterns
+
+- Vendor pitches — every claim must trace back to shipped functionality.
+- "CNML is the flagship" framing — CNML is *one* example among six in
+  the Sovereign PKI page.
+- Burying the code snippet below three paragraphs of prose.
+
+## Approach
+
+Single PR. Sovereign PKI page is the heaviest write (Mode 3 rebrand);
+others are ~150–250 lines each. Use cases use Markdown per plan
+(hand-written, frontmatter-driven) — keep them lighter than the
+AsciiDoc docs pages.
+
+## Related
+
+- [036-docs-pages.md](036-docs-pages.md) — mode detail pages these
+  link into.
+- [035-homepage-vue-islands.md](035-homepage-vue-islands.md) — the
+  ModeSelector cards link to these.

--- a/TODO.completion/040-glossary-page.md
+++ b/TODO.completion/040-glossary-page.md
@@ -1,0 +1,59 @@
+# 040 — Glossary A–Z page
+
+**Category**: Documentation
+**Severity**: Medium (reference surface; high SEO value)
+**Effort**: Small (one PR — single page, ~30 entries)
+
+## Problem
+
+Threshold crypto + PKI + transparency log terminology is dense.
+Readers need a single A–Z reference they can Cmd+F into. The glossary
+also serves as the link target for term-first-mention across all other
+pages.
+
+## Acceptance criteria
+
+- [ ] `src/content/glossary/*.md` — one file per term (so the
+  `globLoader` picks them up), OR a single `glossary.md` with anchors.
+  Recommend single-page with anchor IDs for SEO and search.
+- [ ] `src/pages/glossary/index.astro` — single-page A–Z render. No
+  per-entry routes (would bloat the URL space for no value).
+- [ ] ~30 terms covered (from the plan): threshold cryptography,
+  quorum, share, Shamir secret sharing, Lagrange interpolation, FROST,
+  CMP20, GG18, re-sharing, Herzberg refresh, coordinator,
+  transparency log, Merkle tree, RFC 6962, inclusion proof,
+  consistency proof, OpenTimestamps (OTS), composite signature,
+  attribute-based threshold signing, PKCS#11, OpenSSL provider,
+  JCE provider, CMS, XMLDSig, canonical XML, **Sovereign PKI**,
+  deployment manifest, director, ceremony, MPC, ElGamal encryption,
+  ECIES.
+- [ ] Each entry: 2–4 sentences, plain language, with at least one
+  cross-link to the deepest page that uses the term (concept, doc, or
+  use case).
+- [ ] Alpha-jump nav at top (A B C D … Z) — anchors to the first
+  entry of each letter.
+- [ ] Searchable via Pagefind (Cmd+K returns the glossary entry as a
+  top result for any term).
+- [ ] No "OIML"; no "TODO"/"coming soon".
+
+## Anti-patterns
+
+- Wikipedia-style long-form definitions — 2–4 sentences, link out for
+  depth.
+- Defining "Sovereign PKI" without using the term — Mode 3 IS Sovereign
+  PKI on this site.
+- Forgetting to add `data-pagefind-body` to the glossary page — must
+  be indexed.
+
+## Approach
+
+Single PR. Write all 30 entries in one pass, then alphabetize, then
+add cross-links. Verify Pagefind indexes each entry separately by
+searching for 3–4 terms after a production build.
+
+## Related
+
+- [036-docs-pages.md](036-docs-pages.md), [038-concepts-pages.md](038-concepts-pages.md)
+  — these pages link into glossary anchors.
+- [043-search-cross-link-audit.md](043-search-cross-link-audit.md) —
+  verifies the glossary is indexed.

--- a/TODO.completion/041-software-bindings-specs-pull-through.md
+++ b/TODO.completion/041-software-bindings-specs-pull-through.md
@@ -1,0 +1,79 @@
+# 041 — Software bindings + specs pull-through
+
+**Category**: Documentation
+**Severity**: High (per-repo docs become visible at last)
+**Effort**: Medium (one PR — collection metadata + route handlers)
+
+## Problem
+
+TODOs 032 and 033 create `confium/docs/` and `confium-ruby/docs/`. This
+TODO wires them into the central Astro site via the `fetch-sources.mjs`
+sparse-checkout mechanism established in TODO 034. Without this,
+`www.confium.org/software/rust/docs/` and `/software/ruby/docs/` return
+404.
+
+## Acceptance criteria
+
+- [ ] `src/content/software/rust.md` — frontmatter: `name: "Rust"`,
+  `docs_repo: "github.com/confium/confium"`,
+  `docs_ref: "<pinned-tag>"`, `docs_subtree: "docs"`,
+  `install_command: "cargo add confium-core"`,
+  `description: "Native Rust workspace — 43 crates."`.
+- [ ] `src/content/software/ruby.md` — frontmatter: `name: "Ruby"`,
+  `docs_repo: "github.com/confium/confium-ruby"`,
+  `docs_ref: "<pinned-tag>"`, `docs_subtree: "docs"`,
+  `install_command: "gem install confium"`,
+  `description: "Ruby bindings via native extension (magnus + rb-sys)."`.
+- [ ] `src/content/software/wasm.md` — frontmatter: `name: "WASM"`,
+  `install_command: "npm install @confium/confium-wasm"`. No
+  `docs_repo` (uses README + JSDoc only for now).
+- [ ] `src/content/specs/*.md` — one file per spec (00-framework-overview,
+  01-three-modes, 10-mode1-peer-tc, 11-mode2-pki-replacement,
+  12-mode3-certificate-pki, 42-transparency-log, 90-security-model).
+  Frontmatter: `title`, `description`, `upstream_path` (e.g.
+  `specs/00-framework-overview.adoc`).
+- [ ] `src/pages/software/[id]/index.astro` — landing page per binding
+  with install command, description, link into `/docs/`.
+- [ ] `src/pages/software/[id]/docs/[...slug].astro` — renders pages
+  from `vendor/{repo}/docs/` via the `softwareDocs` collection.
+  Internal `.adoc` links rewritten to on-site routes.
+- [ ] `src/pages/software/[id]/docs/index.astro` — index over the
+  binding's docs (uses upstream README.adoc if present, else a generated
+  listing).
+- [ ] `src/pages/specs/[id].astro` — renders spec from `vendor/specs/`
+  via `specDocs` collection.
+- [ ] `src/pages/specs/index.astro` — index listing all specs.
+- [ ] `scripts/fetch-sources.mjs` succeeds locally — populates
+  `vendor/confium/docs/`, `vendor/confium-ruby/docs/`, `vendor/specs/`.
+- [ ] Failure mode: if a repo is unreachable, build degrades gracefully
+  (warning logged, the affected routes return a "docs unavailable"
+  page, NOT a build failure).
+- [ ] Cross-link audit: every internal `.adoc` link in the pulled docs
+  resolves to an on-site route or an external GitHub URL.
+- [ ] Search indexes the pulled docs (Pagefind picks them up after
+  build).
+
+## Anti-patterns
+
+- Hardcoding ref to `main` — pin to a tag so a broken upstream commit
+  can't take the site down.
+- Inlining the pulled docs into `src/content/` — that creates merge
+  conflicts with upstream. Always go through `vendor/`.
+- Skipping the failure-mode test — verify by deliberately pointing at
+  a nonexistent repo and confirming the build still succeeds.
+
+## Approach
+
+Single PR. Order: write software metadata files → write specs metadata
+files → write the dynamic route handlers → test fetch-sources locally
+→ test failure mode → cross-link audit.
+
+## Related
+
+- [032-rust-workspace-docs.md](032-rust-workspace-docs.md) — creates
+  the content this TODO pulls.
+- [033-ruby-docs-augmentation.md](033-ruby-docs-augmentation.md) —
+  creates the content this TODO pulls.
+- [034-astro-site-scaffolding.md](034-astro-site-scaffolding.md) —
+  establishes `fetch-sources.mjs` and the `softwareDocs`/`specDocs`
+  collection shapes.

--- a/TODO.completion/042-seed-blog-posts.md
+++ b/TODO.completion/042-seed-blog-posts.md
@@ -1,0 +1,58 @@
+# 042 — Seed blog posts (3)
+
+**Category**: Documentation
+**Severity**: Medium (signals project momentum at launch)
+**Effort**: Small (one PR — 3 AsciiDoc files)
+
+## Problem
+
+An empty `/blog/` reads as "this project is dead". Three substantive
+launch posts establish voice, anchor the brand (Sovereign PKI), and
+give readers something to share.
+
+## Acceptance criteria
+
+- [ ] `src/content/blog/2026-07-28-introducing-confium.adoc` — the
+  vision post. Why Confium exists, what threshold-native trust
+  infrastructure means, the three modes at a glance, why now (PQ
+  pressure, single-key CA incidents). ~1200–1500 words.
+- [ ] `src/content/blog/2026-07-28-sovereign-pki-launch.adoc` — Mode 3
+  deep dive. The Sovereign PKI brand, what makes it different from
+  conventional PKI, the six institutional scenarios (CNML as one
+  example), how it maps to the framework. ~1000–1300 words. **No OIML.**
+- [ ] `src/content/blog/2026-07-28-pq-migration-walkthrough.adoc` —
+  composite signatures end-to-end. The PQ migration problem, why
+  software upgrades beat HSM replacement, walk-through of a hybrid
+  Ed25519 + ECDSA-P256 + ML-DSA-65 signature, migration timeline
+  advice. ~1000–1300 words.
+- [ ] Each post has YAML frontmatter: `title`, `description`,
+  `author`, `date`, `tags` (array), `category`.
+- [ ] `/blog/index.astro` lists posts grouped by year (2026). Reverse
+  chronological order.
+- [ ] `/blog/[...id].astro` renders single posts via DocsLayout.
+- [ ] RSS feed at `/rss.xml` includes all three posts.
+- [ ] Every post cross-links to at least one `/docs/` or `/concepts/`
+  page.
+- [ ] No "OIML"; no "TODO"/"coming soon".
+
+## Anti-patterns
+
+- Marketing fluff — every claim must link to a deeper page.
+- "We're excited to announce..." opener — find a stronger hook.
+- Burying the code snippet on the PQ migration post — show the actual
+  signature flow inline.
+
+## Approach
+
+Single PR. Write in the order above (the introducing post sets the
+tone; the other two build on it). Aim for distinctive voice — the
+sister RNP blog has a confident, technical voice; match that energy.
+
+## Related
+
+- [036-docs-pages.md](036-docs-pages.md) — the docs pages these posts
+  link into.
+- [038-concepts-pages.md](038-concepts-pages.md) — the TLS analogy post
+  leans on the concepts/threshold-crypto-101 page.
+- [035-homepage-vue-islands.md](035-homepage-vue-islands.md) — homepage
+  can feature the latest post in a "Latest" section.

--- a/TODO.completion/043-search-cross-link-audit.md
+++ b/TODO.completion/043-search-cross-link-audit.md
@@ -1,0 +1,67 @@
+# 043 — Search + cross-link audit + CI gates
+
+**Category**: Documentation
+**Severity**: High (final quality gate before launch)
+**Effort**: Small (one PR — verification + CI wiring)
+
+## Problem
+
+TODOs 034–042 land a lot of content. This TODO verifies it all works
+end-to-end: Pagefind search returns relevant results, no links are
+broken, and the content constraints (no OIML, no TODO/roadmap language)
+hold across the whole site. It also adds CI gates so future regressions
+fail the build.
+
+## Acceptance criteria
+
+- [ ] `npm run build` produces `dist/pagefind/` with a non-empty index.
+- [ ] `npm run preview` serves the site locally at `localhost:4321`.
+- [ ] Manual search smoke test: Cmd+K for "threshold", "FROST",
+  "sovereign", "transparency", "PKCS#11" returns relevant results
+  from across `/docs/`, `/concepts/`, `/use-cases/`, glossary, and
+  blog.
+- [ ] `npm run check:links` (lychee) passes against `dist/` with zero
+  failures. Pre-existing external 4xx/5xx are added to `.lycheeignore`
+  with a comment explaining why.
+- [ ] `grep -ri OIML dist/` returns zero hits.
+- [ ] `grep -ri 'TODO\|coming soon\|planned\|milestone\|roadmap' dist/`
+  returns zero hits. (Allow `TODO` inside `<code>` blocks if any — none
+  expected.)
+- [ ] Every internal cross-link in `/docs/`, `/concepts/`,
+  `/use-cases/`, glossary, blog resolves to a real route.
+- [ ] Every external link to `docs.confium.org` (RustDoc) and
+  `github.com/confium/*` returns 200.
+- [ ] Lighthouse: Performance ≥ 90, Accessibility ≥ 95, Best Practices
+  = 100 on the homepage.
+- [ ] Mobile viewport (375px) audit: no horizontal scroll, header
+  collapses to drawer, all grids reflow.
+- [ ] Dark mode toggle persists across pages and reloads; cross-tab
+  sync works.
+- [ ] View Transitions animate cleanly between page navigations.
+- [ ] Sitemap at `/sitemap-index.xml` lists every route.
+- [ ] RSS feed at `/rss.xml` validates (use W3C feed validator).
+- [ ] `robots.txt` blocks `/vendor/`, `/archive/` (if any).
+- [ ] **CI gate added** to `.github/workflows/deploy.yml` (or a new
+  `quality.yml`): runs the OIML grep + TODO grep + lychee after build,
+  fails the workflow on any hit.
+- [ ] README in `confium.github.io/` documents the local dev workflow:
+  `npm install && npm run fetch-sources && npm run dev`.
+
+## Anti-patterns
+
+- Skipping the CI gate — without it, content constraints drift.
+- Adding `.lycheeignore` entries without comments — future contributors
+  won't know why a link is excluded.
+- Treating the audit as a final step — run the greps and lychee locally
+  before opening the PR, not after CI fails.
+
+## Approach
+
+Single PR. Run the full verification locally; fix any hits; add the CI
+gate; document the workflow. The CI gate is the durable artifact —
+without it, the next contributor can break the constraints silently.
+
+## Related
+
+- Every other website TODO (034–042) — this is the final verification
+  that they all hang together.

--- a/TODO.completion/README.md
+++ b/TODO.completion/README.md
@@ -1,8 +1,8 @@
-# Completion Plan — Confium Bindings Gaps
+# Completion Plan — Confium Bindings + Website Gaps
 
-Living index of all identified gaps in the Ruby + WASM binding surfaces.
-Each entry points to a dedicated TODO file with problem statement,
-acceptance criteria, and code-quality requirements.
+Living index of all identified gaps in the Ruby + WASM binding surfaces
+and the public website. Each entry points to a dedicated TODO file with
+problem statement, acceptance criteria, and code-quality requirements.
 
 **Numbering convention**: `NNN-slug.md`. Grouped by category; numbered
 monotonically across the whole plan.
@@ -70,6 +70,29 @@ monotonically across the whole plan.
 | [030](030-consistency-proof-security.md) | consistency-proof-security | ⏳ |
 | [031](031-audit-log-exposure.md) | audit-log-exposure | ⏳ |
 
+## Documentation (032–043)
+
+The website (`confium.github.io/`) is being rebuilt on Astro 7 + Vue 3
++ Tailwind 4 + Vue islands, mirroring the sister RNP site architecture.
+Per-repo implementation docs live in `{repo}/docs/` and are pulled into
+the central site at build time. See `/Users/mulgogi/.claude/plans/prancy-riding-honey.md`
+for the full plan.
+
+| # | Slug | Status |
+|---|---|---|
+| [032](032-rust-workspace-docs.md) | rust-workspace-docs | ⏳ |
+| [033](033-ruby-docs-augmentation.md) | ruby-docs-augmentation | ⏳ |
+| [034](034-astro-site-scaffolding.md) | astro-site-scaffolding | ⏳ |
+| [035](035-homepage-vue-islands.md) | homepage-vue-islands | ⏳ |
+| [036](036-docs-pages.md) | docs-pages | ⏳ |
+| [037](037-about-meta-pages.md) | about-meta-pages | ⏳ |
+| [038](038-concepts-pages.md) | concepts-pages | ⏳ |
+| [039](039-use-cases-pages.md) | use-cases-pages | ⏳ |
+| [040](040-glossary-page.md) | glossary-page | ⏳ |
+| [041](041-software-bindings-specs-pull-through.md) | software-bindings-specs-pull-through | ⏳ |
+| [042](042-seed-blog-posts.md) | seed-blog-posts | ⏳ |
+| [043](043-search-cross-link-audit.md) | search-cross-link-audit | ⏳ |
+
 ## Cross-cutting requirements (apply to every TODO above)
 
 Every code change must satisfy:
@@ -102,6 +125,8 @@ Every code change must satisfy:
 Suggested order of execution — quick wins first to build momentum,
 then security, then functional gaps that unlock downstream work.
 
+### Bindings gaps (001–031)
+
 1. **Quick wins (≤ 1 PR each)**: 003, 014, 026, 027, 016, 015
 2. **Security hardening**: 028, 029, 030 (paired with 010), 031
 3. **Architectural foundations**: 001, 002, 005, 004
@@ -111,4 +136,14 @@ then security, then functional gaps that unlock downstream work.
 7. **PQ + compliance**: 021, 022, 023, 025
 8. **Audience docs**: 017, 018, 019, 020
 
-Total: 31 items.
+### Documentation (032–043)
+
+Run in phase order — earlier phases unblock later ones:
+
+1. **Phase 1 — per-repo docs** (parallel across repos): 032, 033
+2. **Phase 2 — Astro scaffolding**: 034
+3. **Phase 3 — core content**: 035, 036, 037
+4. **Phase 4 — educational + use cases**: 038, 039, 040
+5. **Phase 5 — pull-through + blog + verification**: 041, 042, 043
+
+Total: 43 items.

--- a/docs/architecture.adoc
+++ b/docs/architecture.adoc
@@ -1,0 +1,150 @@
+= Architecture
+:toc: left
+:toclevels: 3
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Confium is a configurable engine for multi-stakeholder threshold
+cryptography. The engine loads plugins that implement cryptographic
+primitives; bindings and adapters wrap the engine for different
+language ecosystems and integration points.
+
+This page covers the engine itself. For threshold-protocol internals,
+see xref:crates/frost-ed25519.adoc[the per-crate deep dives]. For the
+plugin contract, see xref:plugin-author-guide.adoc[the plugin author
+guide].
+
+== Layers
+
+[cols="1,4"]
+|===
+| *Host library* | `libconfium` — the engine. Loads plugins, dispatches
+  calls, exposes the `cfm_*` C ABI.
+| *Plugins* | Dynamic libraries implementing the `cfmp_*` contract for
+  one or more interfaces.
+| *Adapters* | Mode 2 wrappers (PKCS#11 server, OpenSSL provider, JCE
+  provider, TLS signer) that translate industry-standard APIs into
+  Confium calls.
+| *Bindings* | Ruby, WASM, and future language bindings that wrap the
+  C ABI for application developers.
+| *Coordinator* | Async session service for distributed threshold
+  cryptography across geographically separated parties.
+|===
+
+== The plugin contract
+
+A Confium plugin is a `cdylib` that exports a small set of bootstrap
+symbols. Confium loads the library, calls `cfmp_query_interfaces` to
+discover what the plugin provides, then negotiates per-interface
+versions before routing calls.
+
+Bootstrap symbols:
+
+[cols="1,4"]
+|===
+| `cfmp_interface_version` | Returns the plugin-contract ABI version this plugin targets.
+| `cfmp_initialize(cfm, opts)` | One-time setup. `cfm` is an opaque host handle; `opts` is the loader-supplied option bag.
+| `cfmp_finalize(cfm)` | One-time teardown.
+| `cfmp_query_interfaces` | Returns `name\0version\0` pairs naming the interface types and versions the plugin implements.
+| `cfmp_metadata` *(optional)* | Returns static metadata (name, version, vendor, license) for the registry.
+| `cfmp_query_dependencies` *(optional)* | Returns a dependency list. Confium resolves these before `cfmp_initialize`.
+|===
+
+Per-interface symbols follow the pattern `cfmp_<interface>_*` (e.g.
+`cfmp_hash_create`, `cfmp_hash_update`, `cfmp_hash_finalize`).
+
+== Versioned interfaces
+
+Each interface is independently versioned. A plugin can implement
+`hash` v0 and `cipher` v1 simultaneously. The host negotiates the
+highest mutually-supported version per interface, per plugin.
+
+Shipped interfaces (in `confium-core`):
+
+* `hash` — cryptographic hash
+* `rng` — random number generation
+* `cipher` — symmetric encryption
+* `aead` — authenticated encryption
+* `kdf` — key derivation
+* `kem` — key encapsulation
+* `keyfmt` — key serialization
+* `signature` — digital signatures
+
+Adding a new interface is one module that calls `register_interface!`.
+No edits to existing interfaces or to the host dispatch.
+
+== The registry
+
+`confium-registry` is a static catalog of plugins, publishers, and
+trust roots. It is consulted at load time to verify that a plugin's
+claimed publisher is trusted, and to resolve plugin dependencies.
+
+The registry is also published as a static site at
+link:../[the project site] for human inspection.
+
+== The coordinator
+
+Threshold cryptography protocols (FROST, CMP20, GG18) require multiple
+parties to exchange messages across rounds. The
+`confium-tc-coordinator` service orchestrates these sessions
+asynchronously, so parties do not need to be online simultaneously.
+
+Sessions are identified by a session ID. Each party joins, submits
+their round messages, and the coordinator aggregates them and either
+advances the round or returns the final signature.
+
+The coordinator is transport-agnostic (`confium-net` abstraction with
+TCP, QUIC, and WebSocket implementations).
+
+== Architecture principles
+
+=== OCP via traits
+
+New backends add new files. The trait is the contract; the
+implementations are closed for modification. Examples:
+
+* `IdentityBackend` — pluggable identity sources
+* `Encapsulator` — KEM backends
+* `Aead` — AEAD backends
+* `QuorumDispatcher` — quorum decision logic
+* `OpenpgpCardBackend` — OpenPGP card hardware backends
+* `ThresholdSigner` — threshold signing protocols
+
+=== No unsafe code
+
+Every crate carries `#![forbid(unsafe_code)]`. All FFI is contained in
+`confium-core` and uses `#[unsafe(no_mangle)]` per edition 2024
+requirements.
+
+=== No vendor SDKs
+
+Confium integrates with hardware via standards only:
+
+* PKCS#11 v3.0 (HSMs)
+* OpenPGP card (YubiKey, Nitrokey)
+* OpenSSL 3.0 provider (TLS libraries)
+* JCE provider (Java)
+* TPM 2.0
+
+This keeps Confium deployable across vendor boundaries without
+licensing or redistribution concerns.
+
+=== Documentation is required
+
+Every crate carries `#![warn(missing_docs)]`. Every public item has a
+doc comment. `cargo doc --workspace --no-deps` must build cleanly.
+
+=== Type-safe errors
+
+Errors are typed via `thiserror` (or `snafu` 0.8 in legacy crates).
+Each crate has its own error enum with descriptive variants. No
+string errors.
+
+== Architecture diagrams
+
+The authoritative architectural diagrams live in the
+link:https://github.com/confium/specs[specs repository] and are
+rendered on https://www.confium.org/docs/architecture/[the public
+website].

--- a/docs/conventions.adoc
+++ b/docs/conventions.adoc
@@ -1,0 +1,184 @@
+= Conventions
+:toc: left
+:toclevels: 3
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+The conventions every Confium crate follows. New crates should adopt
+these from day one; existing crates are expected to comply.
+
+== Lints
+
+Every crate's `lib.rs` (and binary `main.rs`) starts with:
+
+[source,rust]
+----
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+----
+
+`unsafe_code` is forbidden — there is no opt-out. All FFI is
+centralized in `confium-core` and uses the edition 2024
+`#[unsafe(no_mangle)]` form.
+
+== Edition 2024 quirks
+
+Confium targets Rust stable 1.85+ (edition 2024). The migration from
+edition 2021 introduced three pattern changes to watch for:
+
+[cols="1,4"]
+|===
+| `#[no_mangle]` | Becomes `#[unsafe(no_mangle)]`. Bare `#[no_mangle]`
+  is now a hard error in cdylib export sites.
+| `ref` bindings | No explicit `ref` in implicitly-borrowing pattern
+  contexts. The compiler inserts it for you.
+| `.map_err(\|e\| { ...; e })` | Becomes `.inspect_err(\|_e| { ... })`
+  for side-effect-only error inspection.
+|===
+
+== Error handling
+
+Prefer `thiserror` for new crates. It produces clean typed enums with
+descriptive variants:
+
+[source,rust]
+----
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum MerkleError {
+    #[error("sequence {0} out of range (have {1} entries)")]
+    OutOfRange(u64, usize),
+
+    #[error("consistency proof failed: expected {expected:?}, got {actual:?}")]
+    ConsistencyFailed {
+        expected: [u8; 32],
+        actual: [u8; 32],
+    },
+
+    #[error("inclusion proof failed for sequence {0}")]
+    InclusionFailed(u64),
+}
+----
+
+=== Legacy Snafu 0.8
+
+Some older crates (`confium-core` and friends) use Snafu 0.8 instead.
+The conventions there:
+
+* Context structs use the `Snafu` suffix:
+  `NullPointer` variant → `NullPointerSnafu` struct.
+* The `Error` suffix on variant names is stripped:
+  `PluginInternalError` → `PluginInternalSnafu`.
+* Visibility attribute: `#[snafu(visibility(pub(crate)))]`.
+
+When touching a Snafu crate, do not introduce a parallel `thiserror`
+dependency. Migrate fully if you migrate at all.
+
+== p256 / elliptic-curve API notes
+
+When working with the `p256` crate (used in P-256 ECDSA, ElGamal, and
+FROST-P256):
+
+[cols="1,4"]
+|===
+| `Scalar::from_repr(FieldBytes)` | Returns `CtOption<Scalar>`, not
+  `Option<Scalar>`.
+| Point multiplication | `ProjectivePoint::GENERATOR * &scalar` is
+  canonical.
+| `CtOption<T>` → `Option<T>` | `Option::<T>::from(ct_opt)`.
+| Random scalars | `Scalar::random(rand_core::OsRng)` via
+  `elliptic_curve::Field`.
+|===
+
+Never use `.unwrap()` on `CtOption` — it loses the constant-time
+property. Convert to `Option` first, then handle the `None` case
+explicitly.
+
+== Trait design
+
+Confium favors OCP-compliant traits over enums-with-switches. Adding
+a new backend is a new file that implements an existing trait — no
+modifications to the trait itself or to dispatchers that consume it.
+
+Traits are named after the *capability*, not the *implementation*:
+
+* `Encapsulator` (not `KemBackend`)
+* `Aead` (not `AeadAlgorithm`)
+* `ThresholdSigner` (not `FrostSigner`)
+* `QuorumDispatcher` (not `ThresholdPolicy`)
+
+If a trait has multiple methods and an implementation only
+meaningfully provides some, split the trait rather than provide
+default no-op implementations.
+
+== Module layout
+
+A typical crate:
+
+[source,sh]
+----
+crates/confium-example/
+├── Cargo.toml
+├── README.md            # optional — generated from lib.rs docs otherwise
+└── src/
+    ├── lib.rs           # public API + crate docs + lint attrs
+    ├── error.rs         # Error enum via thiserror
+    ├── types.rs         # public types
+    ├── impl_real.rs     # the real implementation
+    ├── tests.rs         # inline integration tests
+    └── tests/           # larger integration tests
+        └── smoke.rs
+----
+
+For small crates, a single `lib.rs` is fine. Split when a file crosses
+~500 lines or when responsibilities start to mix.
+
+== Testing
+
+* Unit tests live inline in `#[cfg(test)] mod tests { ... }`.
+* Integration tests live in `tests/*.rs`.
+* Tests must use real instances, not mocks. No `double()`-style fakes.
+* Test names follow `behavior_condition_expected` snake_case.
+* Every public method has at least one happy-path test and at least
+  one validation / error test.
+
+Run the full suite:
+
+[source,sh]
+----
+cargo test --workspace
+----
+
+Single test:
+
+[source,sh]
+----
+cargo test -p confium-tc-frost-p256 integration
+----
+
+== Cargo commands
+
+[source,sh]
+----
+cargo build --workspace                                # build all 43 crates
+cargo test --workspace                                 # full test suite
+cargo fmt --all --check                                # format check
+cargo clippy --workspace --all-targets -- -D warnings  # lint (warnings are errors)
+cargo doc --workspace --no-deps                        # doc build
+cargo deny check licenses advisories sources bans      # license / advisory / ban gates
+typos                                                  # spell check
+----
+
+== Commits and PRs
+
+* Conventional commits (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`,
+  `ci:`, `chore:`). They drive automated version bumps via release-plz.
+* Never commit to `main` — always via PR.
+* Breaking changes use `!` (e.g. `feat!: ...`) and include a migration
+  note in the PR description.
+* Never push git tags — the release bot handles releases.
+* Never add `Co-authored-by` trailers for AI tools. The commit author
+  is the user; tools do not get co-author credit.

--- a/docs/crates/composite.adoc
+++ b/docs/crates/composite.adoc
@@ -1,0 +1,86 @@
+= `confium-composite` — composite signatures
+:toc: left
+:toclevels: 2
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Composite multi-algorithm signatures for post-quantum migration. A
+single composite signature contains the artifacts of multiple
+component algorithms (e.g. Ed25519 + ECDSA-P256 + ML-DSA-65); verifiers
+check all components and accept the signature only if every component
+verifies.
+
+== When to use this crate
+
+Use `confium-composite` when:
+
+* You are migrating from a classical algorithm (Ed25519, ECDSA) to a
+  post-quantum one (ML-DSA, SLH-DSA) and need both to verify
+  simultaneously during the transition.
+* You want defense-in-depth: a break in any single algorithm does not
+  compromise the composite signature.
+* You are building a transparency log leaf hash or a certificate
+  signature that must remain verifiable across the PQ transition.
+
+== Public API
+
+The crate exposes a `CompositeSignature` value type and a
+`CompositeVerifier` that dispatches per-component verification to
+pluggable per-algorithm verifiers.
+
+[source,rust]
+----
+use confium_composite::{CompositeSignature, CompositeVerifier, VerifierCallback};
+
+let composite: CompositeSignature = /* ... */;
+let verifier = CompositeVerifier::new()
+    .with("1.3.101.112", my_ed25519_verifier)       // Ed25519
+    .with("1.2.840.10045.4.3.2", my_ecdsa_verifier) // ECDSA-P256
+    .with("2.16.840.1.101.3.4.3.18", my_ml_dsa_65_verifier);
+
+let valid: bool = verifier.verify(&composite, &message)?;
+----
+
+Per-algorithm verifiers implement the `VerifierCallback` trait, so
+you can route verification through any crypto backend (Botan plugin,
+OpenSSL provider, in-process crate).
+
+== Verification semantics
+
+A composite signature is **valid** if and only if:
+
+1. Every component signature verifies against the message.
+2. Every required component algorithm is registered with the verifier.
+3. The component set matches the deployment's policy (e.g. the
+   jurisdictional policy may require ≥1 classical + ≥1 PQ algorithm).
+
+A missing verifier for any component is a hard failure, not a
+soft-accept. Configure `CompositeVerifier` to include every algorithm
+the deployment expects to encounter.
+
+== Security notes
+
+* **No silent downgrade**: if a verifier is missing for a component,
+  verification fails. The crate never silently accepts on the
+  subset of components it can verify.
+* **Callback isolation**: per-algorithm verifiers run as isolated
+  callbacks. A panic or error in one does not corrupt the others;
+  each result is collected and AND-reduced at the end.
+* **Constant-time where it matters**: the per-algorithm verifiers
+  supplied by the caller are responsible for their own constant-time
+  guarantees. The composite layer does not introduce branches that
+  depend on secret data.
+* **Order independence**: the composite signature lists components in
+  a deterministic order; verification does not depend on the order
+  the per-algorithm verifiers are registered.
+
+== Related
+
+* xref:transparency.adoc[`confium-transparency`] — uses composite
+  signatures for tree head signatures.
+* link:../examples/pq-migration.adoc[PQ migration example] —
+  end-to-end walkthrough.
+* https://www.confium.org/docs/pq-migration/[PQ migration concept page]
+  on the public website.

--- a/docs/crates/frost-p256.adoc
+++ b/docs/crates/frost-p256.adoc
@@ -1,0 +1,83 @@
+= `confium-tc-frost-p256` — threshold ECDSA on P-256
+:toc: left
+:toclevels: 2
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Real P-256 Shamir secret sharing and threshold ECDSA signing. The
+crate provides key generation (or import), secret splitting into N
+shares with threshold T, share distribution, signing with any T
+shares, and signature recovery.
+
+== When to use this crate
+
+Use `confium-tc-frost-p256` when:
+
+* You need P-256 ECDSA signatures (the curve used by TLS, code
+  signing, X.509) where no single party holds the full key.
+* You want a software-only threshold scheme (no HSM coordination
+  required).
+* You are building a Mode 2 PKI drop-in that must produce signatures
+  indistinguishable from single-key ECDSA-P256.
+
+== Public API
+
+[source,rust]
+----
+use confium_tc_frost_p256::FrostP256;
+
+// Generate a keypair.
+let kp = FrostP256::generate_keypair()?;
+
+// Split into 5 shares, threshold 3.
+let shares = FrostP256::split_secret(&kp.private_key, 3, 5)?;
+
+// Recover the secret from any 3 shares.
+let recovered = FrostP256::recover_secret(&[
+    shares[0].as_ref(),
+    shares[2].as_ref(),
+    shares[4].as_ref(),
+])?;
+assert_eq!(recovered, kp.private_key);
+
+// Sign with the original key.
+let sig = FrostP256::sign(&kp.private_key, b"threshold test")?;
+// sig.der     — DER-encoded ECDSA signature (RFC 3279)
+// sig.fixed   — fixed-length (r || s) encoding
+----
+
+== Shamir secret sharing
+
+The secret is split into `N` shares using a polynomial of degree
+`T − 1` over the scalar field of P-256. Any `T` shares uniquely
+determine the polynomial and thus the secret. Fewer than `T` shares
+reveal zero information about the secret.
+
+== Recovery
+
+Recovery uses Lagrange interpolation at x = 0. The crate accepts any
+subset of T or more shares; if more than T are provided, the result
+is overdetermined and the crate verifies consistency.
+
+== Security notes
+
+* **No share reuse**: each signing session must use fresh random
+  nonces. Reusing a nonce across two sessions leaks the private key.
+  The crate uses `OsRng` for nonce generation by default.
+* **Constant-time scalar arithmetic**: via the `p256` crate's
+  `CtOption` API. Never convert `CtOption` to `Option` and then
+  branch on it for secret data.
+* **Share format**: shares are `(x, y)` pairs over the P-256 scalar
+  field. The crate serializes them as fixed-length byte arrays.
+* **No network code**: the crate is pure crypto. Multi-party session
+  orchestration is provided by `confium-tc-coordinator`.
+
+== Related
+
+* link:../examples/threshold-signing.adoc[Threshold signing example]
+  — end-to-end Ruby demo using this crate.
+* xref:coordinator.adoc[`confium-tc-coordinator`] — for multi-party
+  sessions across network boundaries.
+* xref:reshare.adoc[`confium-tc-reshare`] — proactive share refresh.

--- a/docs/crates/index.adoc
+++ b/docs/crates/index.adoc
@@ -1,0 +1,40 @@
+= Crate deep dives
+:toc: left
+:toclevels: 2
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Per-crate orientation pages. Each covers purpose, public API, and
+security notes for one Confium crate. For auto-generated API docs, see
+https://docs.confium.org/[docs.confium.org] (RustDoc).
+
+== Threshold cryptography
+
+* xref:frost-ed25519.adoc[`confium-tc-frost-ed25519`] — real FROST-ed25519 threshold signing.
+* xref:frost-p256.adoc[`confium-tc-frost-p256`] — real P-256 Shamir secret sharing + threshold ECDSA.
+* xref:composite.adoc[`confium-composite`] — composite multi-algorithm signatures for PQC migration.
+* xref:transparency.adoc[`confium-transparency`] — append-only Merkle transparency log.
+
+== Threshold encryption
+
+* xref:elgamal-p256.adoc[`confium-tc-elgamal-p256`] — threshold ElGamal-P256.
+
+== Coordination
+
+* xref:coordinator.adoc[`confium-tc-coordinator`] — async threshold session coordinator.
+* xref:reshare.adoc[`confium-tc-reshare`] — proactive share refresh and re-sharing.
+
+== Examples
+
+* link:../examples/threshold-signing.adoc[Threshold signing end-to-end] — a worked FROST-P256 example.
+* link:../examples/pq-migration.adoc[PQ migration with composite signatures] — adding ML-DSA-65 alongside Ed25519.
+* link:../examples/transparency-log.adoc[Transparency log] — Merkle tree, inclusion proofs, OTS anchoring.
+
+== Other crates
+
+For crates not listed here, see the
+link:../workspace-map.adoc[workspace map] and
+https://docs.confium.org/[RustDoc]. Additional deep-dive pages will be
+added as the documentation site grows.

--- a/docs/crates/transparency.adoc
+++ b/docs/crates/transparency.adoc
@@ -1,0 +1,107 @@
+= `confium-transparency` — transparency log
+:toc: left
+:toclevels: 2
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Append-only Merkle transparency log implementing RFC 6962 semantics.
+Leaves are arbitrary artifacts (certificate issuances, revocations,
+policy changes); the log provides cryptographic inclusion proofs and
+consistency proofs that any verifier can check independently.
+
+== When to use this crate
+
+Use `confium-transparency` when:
+
+* You are running a Sovereign PKI deployment and need a public,
+  verifiable record of every certificate issued.
+* You want split-view attack protection: a log operator cannot present
+  two different tree heads to different verifiers without detection.
+* You are anchoring state to an external tamper-evident medium
+  (Bitcoin via OpenTimestamps, RFC 4998 ERS archival).
+
+== Public API
+
+[source,rust]
+----
+use confium_transparency::{MerkleTree, MerkleEntry, ArtifactType};
+
+let mut tree = MerkleTree::new();
+let entry = MerkleEntry::new(0, ArtifactType::CertificateIssuance, leaf_hash);
+let seq = tree.append(entry);
+let root: [u8; 32] = tree.root();
+
+let proof = tree.inclusion_proof(seq)?;
+confium_transparency::MerkleTree::verify_inclusion(&entry, &proof, root)?;
+----
+
+For a consistency proof between two tree sizes:
+
+[source,rust]
+----
+let proof: Vec<[u8; 32]> = tree.consistency_proof(old_size)?;
+confium_transparency::MerkleTree::verify_consistency(
+    old_root, new_root, old_size, new_size, &proof,
+)?;
+----
+
+== Leaf hashing
+
+RFC 6962 domain separation:
+
+* Leaves are hashed as `SHA-256(0x01 || entry_hash)`.
+* Internal nodes are hashed as `SHA-256(0x02 || left || right)`.
+
+This prevents leaf values from being interpreted as internal nodes and
+vice versa.
+
+== Inclusion proofs
+
+An inclusion proof is a sequence of `(sibling_hash, side)` pairs. The
+verifier starts with the leaf hash, combines it with each sibling in
+order, and checks the final result equals the published root.
+
+== Consistency proofs
+
+A consistency proof shows that the first `old_size` leaves of the
+current tree hash to the same root as a tree of exactly `old_size`
+leaves. This is what makes split-view attacks detectable: if a log
+operator presents tree head `N` to verifier A and a different tree
+head `N` to verifier B, at least one of them will fail a consistency
+check against the true history.
+
+== Defenses against split-view
+
+Consistency proofs alone are necessary but not sufficient — verifiers
+must also communicate (gossip) so they know about each other's heads.
+Three layers of defense:
+
+1. **Consistency proofs** — every new tree head extends the previous
+   one. Implemented in this crate.
+2. **Witness gossip** — coordinators share tree heads with each other
+   periodically. Implemented in `confium-tc-coordinator`.
+3. **OTS anchoring** — tree heads are timestamped in the Bitcoin
+   blockchain, providing an irrefutable "what head existed at time T"
+   record. Implemented in `confium-ots`.
+
+== Security notes
+
+* **SHA-256 only**: the crate does not support alternative hash
+  functions. SHA-256 is the RFC 6962 default and what every verifier
+  expects.
+* **Sequence numbers are u64**: maximum tree size is 2^64 − 1 entries.
+  At 1 entry per second, that's ~584 billion years of headroom.
+* **No deletion**: the tree is append-only by construction. There is
+  no `remove` API and there will never be one.
+* **In-memory by default**: the tree holds all entries in memory. For
+  production deployments, wrap with a persistent backend (lmdb, rust-rocksdb).
+
+== Related
+
+* xref:composite.adoc[`confium-composite`] — used to sign tree heads.
+* https://www.confium.org/docs/transparency-logs/[Transparency logs
+  concept page] on the public website.
+* link:../security/transparency-logs.md[Security analysis: split-view
+  attack defenses].

--- a/docs/develop.adoc
+++ b/docs/develop.adoc
@@ -95,20 +95,18 @@ To skip temporarily: `SKIP_PRECOMMIT=1 git commit ...` or `touch .skip-precommit
 
 [cols="1,4"]
 |===
-| `crates/` | All Rust crates (workspace members)
-| `crates/confium-core/` | The engine: plugin loader, registry, crypto dispatch, host FFI
-| `crates/confium-api/` | Shared types and the plugin contract (`cfmp_*`)
-| `crates/confium-macros/` | Procedural macros that generate `cfmp_*` plugin scaffolding
-| `crates/confium-cli/` | The `confium` command-line tool
-| `crates/confium-daemon/` | Long-running service mode
-| `crates/confium-net*/` | Networking primitives (QUIC, TCP, WebSocket)
-| `crates/confium-store*/` | Key store backends (local, cloud, PKCS#11, TPM)
-| `crates/confium-tc*/` | Threshold-cryptography protocol implementations
-| `cpp-tests/` | C++ tests for the generated C header
-| `sites/registry/` | The plugin-registry GitHub Pages site
-| `docs/` | This documentation site (AsciiDoc)
-| `TODO.roadmap/` | Forward-looking design documents
-| `TODO.finalize/` | Spec-tracking documents for in-flight work
+| `crates/` | All Rust crates (workspace members). See xref:workspace-map.adoc[the workspace map] for the full breakdown by category.
+| `crates/confium-core/` | The engine: plugin loader, registry, crypto dispatch, host FFI.
+| `crates/confium-api/` | Shared types and the plugin contract (`cfmp_*`).
+| `crates/confium-macros/` | Procedural macros that generate `cfmp_*` plugin scaffolding.
+| `crates/confium-cli/` | The `confium` command-line tool.
+| `crates/confium-daemon/` | Long-running service mode.
+| `crates/confium-net*/` | Networking primitives (QUIC, TCP, WebSocket).
+| `crates/confium-store*/` | Key store backends (local, cloud, PKCS#11, TPM).
+| `crates/confium-tc*/` | Threshold-cryptography protocol implementations.
+| `cpp-tests/` | C++ tests for the generated C header.
+| `sites/registry/` | The plugin-registry GitHub Pages site.
+| `docs/` | This documentation site (AsciiDoc).
 |===
 
 == Pull requests

--- a/docs/examples/threshold-signing.adoc
+++ b/docs/examples/threshold-signing.adoc
@@ -1,0 +1,109 @@
+= Threshold signing end-to-end
+:toc: left
+:toclevels: 2
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+A worked example: generate a P-256 keypair, Shamir-split it across 5
+parties with threshold 3, recover from any 3, and sign a message. The
+complete Ruby equivalent lives at
+https://github.com/confium/confium-ruby/blob/main/examples/threshold_signing.rb[`examples/threshold_signing.rb`];
+the Rust outline below mirrors it.
+
+== Setup
+
+[source,sh]
+----
+cargo add confium-tc-frost-p256
+----
+
+== Generate a keypair
+
+[source,rust]
+----
+use confium_tc_frost_p256::FrostP256;
+
+let kp = FrostP256::generate_keypair()?;
+println!("secret: {:x?}", &kp.private_key[..8]);
+----
+
+== Split into 5 shares, threshold 3
+
+[source,rust]
+----
+let shares = FrostP256::split_secret(&kp.private_key, 3, 5)?;
+println!("split into {} shares, threshold = 3", shares.len());
+for (i, s) in shares.iter().enumerate() {
+    println!("  share[{}]: x={}, y={:x?}", i, s.x, &s.y_bytes[..8]);
+}
+----
+
+== Recover from any 3 of the 5
+
+[source,rust]
+----
+let subset = [
+    shares[0].as_ref(),
+    shares[2].as_ref(),
+    shares[4].as_ref(),
+];
+let recovered = FrostP256::recover_secret(&subset)?;
+assert_eq!(recovered, kp.private_key);
+println!("recovered from shares [0, 2, 4]: MATCH");
+----
+
+== Insufficient shares return the wrong answer
+
+With only 2 shares (below the threshold), `recover_secret` returns a
+*valid* P-256 scalar that is **not** the original secret. This is the
+mathematical nature of Shamir: any T−1 shares interpolate to a
+different polynomial that passes through `(0, secret')` for some
+random-looking `secret'`.
+
+[source,rust]
+----
+let subset = [shares[0].as_ref(), shares[1].as_ref()];
+let wrong = FrostP256::recover_secret(&subset)?;
+assert_ne!(wrong, kp.private_key);
+println!("recovered from shares [0, 1]: WRONG (expected)");
+----
+
+The recovery API does not — and cannot — distinguish "right" from
+"wrong" without comparing to the original secret. Callers must enforce
+the threshold in the orchestrating logic.
+
+== Sign with the original key
+
+[source,rust]
+----
+let sig = FrostP256::sign(&kp.private_key, b"threshold test")?;
+println!("signature: der.size={}, fixed.size={}",
+    sig.der.len(), sig.fixed.len());
+----
+
+The signature is a standard ECDSA-P256 signature in two encodings:
+
+* `sig.der` — DER-encoded per RFC 3279 (what X.509 and TLS expect).
+* `sig.fixed` — fixed-length 64-byte `(r || s)` (what some protocols
+  prefer for compactness).
+
+Any standard ECDSA-P256 verifier (OpenSSL, BoringSSL, Botan, the
+`p256` crate's `verify` function) will accept this signature.
+
+== Multi-party signing
+
+For real deployments, signers do not hold the full secret — they hold
+individual shares. A signing session collects T signature shares and
+aggregates them into the final signature without ever reconstructing
+the secret. That orchestration is handled by
+link:../crates/coordinator.adoc[`confium-tc-coordinator`].
+
+== Related
+
+* link:../crates/frost-p256.adoc[`confium-tc-frost-p256` deep dive].
+* link:../crates/coordinator.adoc[`confium-tc-coordinator`] for the
+  multi-party session protocol.
+* https://www.confium.org/concepts/threshold-crypto-101/[Threshold
+  crypto 101] on the public website.

--- a/docs/executive/why-confium.adoc
+++ b/docs/executive/why-confium.adoc
@@ -1,0 +1,79 @@
+= Why Confium? (Executive Brief)
+
+== The problem with PKI today
+
+Public Key Infrastructure (PKI) underpins TLS, code signing, document
+signing, and identity verification worldwide. But it has a structural
+weakness: **each Certificate Authority holds a single private key
+that can sign anything**. If that key is compromised, every cert the
+CA ever issued is called into question.
+
+Recent incidents (DigiNotar 2011, Symantec 2015–2018, Let's Encrypt
+2020 revocation events) prove this isn't hypothetical. The cost of
+each incident: millions of dollars, disrupted services, and eroded
+public trust.
+
+== What Confium changes
+
+Confium replaces single-key CA trust with **threshold cryptography**:
+no single party can sign alone. A configurable quorum (e.g., 3 of 5
+directors) must participate. This eliminates the single point of
+failure.
+
+**Key properties:**
+
+* **No key compromise scenario.** An attacker must compromise T
+  independent parties simultaneously.
+* **Open-source.** BSD-2-Clause licensed. No vendor lock-in, no
+  per-transaction fees, no proprietary protocol.
+* **Standards-based.** PKCS#11 v3.0, OpenSSL 3.0 provider, CMS
+  (RFC 5652), X.509, RFC 6962 transparency logs.
+* **Post-quantum ready.** Composite signatures (Ed25519 + ML-DSA-65)
+  enable migration without breaking existing verifiers.
+* **Multi-stakeholder governance.** Confium supports attribute-based
+  threshold policies: "5-of-9 directors from 3 distinct regions."
+
+== Compliance hooks
+
+* **FIPS 140 mode**: routes through FIPS-validated crypto via the
+  Botan plugin.
+* **Jurisdictional policies**: enforce per-deployment algorithm
+  requirements (EU requires P-384+, US allows P-256, China requires
+  SM2/SM3).
+* **Audit trails**: every signing operation produces a structured
+  audit record.
+
+== Deployment modes
+
+|===
+|Mode |Description |Use case
+
+|Mode 1 — P2P
+|Nodes do threshold cryptography directly
+|MPC, distributed custody, BFT consensus
+
+|Mode 2 — PKI replacement
+|Drop-in for existing PKI consumers via PKCS#11/OpenSSL/JCE
+|HSM replacement, KMS, TLS signing
+
+|Mode 3 — Certificate PKI
+|Custom certificate formats and workflows
+|Institutional accreditation, government, calibration registries
+|===
+
+== Mode 3 — Sovereign PKI
+
+Sovereign PKI is institutional certificate infrastructure where no
+single party is trusted. Examples include calibration registries,
+pharma regulator approvals, academic accreditation, and supply-chain
+provenance. Confium's Mode 3 gives institutions sovereignty over
+certificate formats, delegation rules, archival cadence, and quorum
+composition.
+
+== Cost model
+
+Confium is free open-source software. No licensing fees. The cost of
+deployment is the engineering effort to integrate + ongoing
+operational cost of running coordinator nodes. For a CNML-scale
+deployment (dozens of signers across multiple countries), this is
+comparable to running a CA — but with no single point of failure.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -10,46 +10,58 @@
 :experimental:
 :docinfo: shared
 
-Confium is an open-source distributed trust store framework — a pluggable,
-language-agnostic engine for cryptographic providers, key stores, and
-threshold-cryptography coordination. This is the project documentation site.
+Confium is an open-source framework for **multi-stakeholder threshold
+cryptography**. It provides a configurable engine that organizations
+deploy with their own parameters — the same relationship a TLS library
+has to transport security.
+
+This is the project documentation site for the Rust workspace. For the
+Ruby bindings, see https://github.com/confium/confium-ruby/tree/main/docs/.
+For the public website, see https://www.confium.org/.
 
 == Get started
 
-* xref:develop.adoc[Developer guide] — building, testing, and contributing.
+* xref:installation.adoc[Installation] — `cargo add`, Nix flake, build
+  from source.
+* xref:workspace-map.adoc[Workspace map] — the 43 crates by category.
+* xref:architecture.adoc[Architecture] — engine, plugin loader,
+  registry, the versioned interfaces.
+* xref:conventions.adoc[Conventions] — Snafu 0.8, edition 2024,
+  `#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`.
+* xref:develop.adoc[Developer guide] — building, testing, contributing.
 * xref:plugin-author-guide.adoc[Plugin author guide] — write and ship a
   Confium plugin.
-* link:../README.adoc[Project README] — high-level overview and goals.
-* link:../CONTRIBUTING.md[Contributing guide] — pull-request process and
-  conventions.
-* link:../SECURITY.md[Security policy] — reporting vulnerabilities.
 
-== What Confium is
+== The three deployment modes
 
-Confium provides a generalized API and an extensible architecture for the
-usage of trust stores and future cryptographic families. It is a component
-of https://github.com/rnpgp/rnp[RNP], an openly-licensed high-performance
-OpenPGP toolkit, and has received funding support from the Mozilla Open
-Source Support fund and NLNet.
+Confium is layered across three deployment modes. The same engine and
+the same primitives serve all three.
 
-Typically, using new cryptographic families with existing technologies is an
-immense challenge, requiring code change in the application and in the
-cryptographic library. Confium bridges cryptographers with the practical
-usage of cryptography by exposing a stable C ABI that plugins implement.
+[cols="1,4"]
+|===
+| *Mode 1 — Peer-to-Peer TC* | Nodes do threshold cryptography directly.
+  MPC, distributed custody, BFT consensus.
+| *Mode 2 — PKI Drop-in* | Replace single-party keys with threshold
+  keys. Drop-in for PKCS#11 / OpenSSL / JCE consumers.
+| *Mode 3 — Sovereign PKI* | Custom certificate formats for
+  institutions where no single party can be trusted. Sovereign over
+  formats, delegation rules, archival cadence, quorum composition.
+|===
+
+See https://www.confium.org/docs/three-modes/[the three-modes overview]
+on the public website.
 
 == Architecture at a glance
 
 * *Host library* (`libconfium`) — the engine: plugin loader, registry,
   crypto dispatch. Exports the `cfm_*` C ABI (see `target/confium.h`).
-* *Plugins* — dynamic libraries (`.so` / `.dylib` / `.dll`) that implement
-  the `cfmp_*` plugin contract for one or more interfaces (hash, cipher,
-  AEAD, KDF, RNG, signature, KEM, key serialization, keystore).
-* *Bindings* — Ruby (and future) language bindings wrap the host ABI.
-* *Registry* — a static catalog of plugins, publishers, and trust roots,
-  served from `sites/registry/`.
+* *Plugins* — dynamic libraries (`.so` / `.dylib` / `.dll`) that
+  implement the `cfmp_*` plugin contract for one or more interfaces.
+* *Bindings* — Ruby and WASM language bindings wrap the host ABI.
+* *Coordinator* — async threshold-cryptography session service for
+  distributed signing across geographically separated parties.
 
-For the full design, see the link:../TODO.roadmap/[roadmap] and
-link:../TODO.roadmap/01-architecture-overview.md[architecture overview].
+See xref:architecture.adoc[the architecture page] for the full design.
 
 == Interfaces
 
@@ -57,13 +69,18 @@ Each cryptographic primitive is a versioned interface that plugins
 advertise:
 
 * `hash` — cryptographic hash functions
+* `rng` — random number generation
 * `cipher` — symmetric block and stream ciphers
 * `aead` — authenticated encryption with associated data
 * `kdf` — key derivation functions
-* `rng` — random number generation
 * `signature` — digital signature sign/verify
 * `kem` — key encapsulation mechanisms (post-quantum friendly)
-* `keyfmt` — key serialization formats (OpenPGP, PKCS#8, JWK, OpenSSH, ...)
+* `keyfmt` — key serialization formats (OpenPGP, PKCS#8, JWK, OpenSSH)
 
-Versioning is per-interface and negotiated independently, so a plugin can
-implement `hash` v0 and `cipher` v1 simultaneously.
+Versioning is per-interface and negotiated independently, so a plugin
+can implement `hash` v0 and `cipher` v1 simultaneously. Adding a new
+interface is a single module that calls `register_interface!` — no
+edits to existing code.
+
+See xref:plugin-author-guide.adoc[the plugin author guide] for the
+contract details.

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -1,0 +1,118 @@
+= Installation
+:toc: left
+:toclevels: 3
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+Three installation paths: published crates, Nix flake, and build from
+source. Pick the one that matches your workflow.
+
+== Option 1: crates.io (recommended for libraries)
+
+Add Confium to your `Cargo.toml`:
+
+[source,toml]
+----
+[dependencies]
+confium-core = "0.2"
+----
+
+Or via the CLI:
+
+[source,sh]
+----
+cargo add confium-core
+----
+
+The cdylib is built as `target/{debug,release}/libconfium.{so,dylib,dll}`
+and exposes the `cfm_*` C ABI.
+
+== Option 2: Nix flake (recommended for development)
+
+A fully reproducible dev shell is provided via `flake.nix`. It pins
+Rust 1.85+ (edition 2024), cbindgen, CMake, Boost, asciidoctor, and
+everything else required to build the workspace and run CI locally.
+
+[source,sh]
+----
+nix develop
+----
+
+Inside the shell, all `cargo` commands work without further setup:
+
+[source,sh]
+----
+cargo build --workspace
+cargo test --workspace
+----
+
+== Option 3: build from source
+
+=== Prerequisites
+
+* Rust stable 1.85+ via https://rustup.rs/[rustup]. The toolchain is
+  pinned in `rust-toolchain.toml`.
+* CMake 3.15+ (only required for the C-binding tests under `cpp-tests/`).
+* `cbindgen` 0.29+ (`cargo install cbindgen`) — only required to
+  regenerate `target/confium.h`.
+* Boost (only required for `cpp-tests/`).
+* Asciidoctor (`gem install asciidoctor`) — only required to build this
+  docs site.
+
+=== Clone and build
+
+[source,sh]
+----
+git clone https://github.com/confium/confium.git
+cd confium
+cargo build --workspace
+----
+
+=== Run the test suite
+
+[source,sh]
+----
+cargo test --workspace
+----
+
+The suite covers 725+ unit and integration tests across all 43 crates.
+
+== Verifying the install
+
+A quick smoke test:
+
+[source,sh]
+----
+cargo run -p confium-cli -- --version
+cargo run -p confium-cli -- hash --algorithm sha256 --input "hello"
+----
+
+Expected output: a version string, then the SHA-256 digest of `"hello"`.
+
+== Workspace dependencies
+
+When you depend on multiple Confium crates, prefer the workspace
+shortcut in your `Cargo.toml`:
+
+[source,toml]
+----
+[dependencies]
+confium-core.workspace = true
+confium-composite.workspace = true
+confium-pki.workspace = true
+----
+
+This requires adding the same keys to `[workspace.dependencies]` in
+your own workspace root, mirroring the layout in
+link:https://github.com/confium/confium/blob/main/Cargo.toml[Confium's
+own `Cargo.toml`].
+
+== Next steps
+
+* xref:workspace-map.adoc[Workspace map] — find the crate for your use
+  case.
+* xref:architecture.adoc[Architecture] — understand the engine.
+* xref:develop.adoc[Developer guide] — for contributing to Confium
+  itself.

--- a/docs/plugin-author-guide.adoc
+++ b/docs/plugin-author-guide.adoc
@@ -12,9 +12,8 @@ that implements the plugin contract: a small set of bootstrap symbols plus
 per-interface implementation functions.
 
 For the host-side API that loads and drives plugins, see the generated
-header `target/confium.h`. For the design rationale, see
-link:../TODO.roadmap/03-plugin-contract.md[the plugin contract design
-note].
+header `target/confium.h`. For the engine architecture, see
+xref:architecture.adoc[the architecture page].
 
 == How a plugin is structured
 
@@ -197,7 +196,7 @@ others can discover and verify it:
   checksum, signature).
 . Submit it as a PR against `sites/registry/plugins/`.
 . The registry's publisher-key and trust-root model is documented under
-  `sites/registry/` and `TODO.roadmap/06-module-registry.md`.
+  `sites/registry/`.
 
 == Reference: the bootstrap symbols
 

--- a/docs/security/transparency-logs.md
+++ b/docs/security/transparency-logs.md
@@ -1,0 +1,69 @@
+# Transparency Logs: Security Analysis
+
+## The split-view attack
+
+Without consistency proofs, a transparency log operator can present
+two different tree heads to different verifiers, and nobody can detect
+it. This is the **split-view attack**:
+
+1. Verifier A receives tree head N from the log.
+2. Verifier B receives a different tree head N' (with a different root).
+3. Both verifiers can verify their own inclusion proofs against their
+   own heads. Neither knows the other's head exists.
+4. The log operator can insert or omit entries selectively per
+   audience.
+
+## Defenses
+
+### Consistency proofs (RFC 6962 §2.1.2)
+
+Consistency proofs cryptographically prove that tree head N+1
+**extends** tree head N (i.e., the first N entries are identical).
+Implemented in `confium-transparency::merkle::MerkleTree::consistency_proof`.
+
+**How it works:**
+
+- The log publishes a consistency proof alongside each new tree head.
+- Every verifier checks the new head extends the previous head they
+  saw.
+- If the log presents inconsistent heads to different verifiers, the
+  proofs will fail.
+
+**Limitation:** consistency proofs only work if verifiers communicate.
+If Verifier A and Verifier B never share their heads, a split view
+persists.
+
+### Gossip / witness network
+
+To address the "verifiers don't communicate" gap, the standard
+defense is a **witness network**: every verifier periodically
+gossips its latest known tree head to a set of independent witnesses.
+If two verifiers have different heads for the same tree size, the
+witnesses detect the inconsistency.
+
+Confium's `confium-tc-coordinator` can serve as a gossip endpoint
+for CNML deployments. Each IA's coordinator shares its tree head
+with BIML's coordinator, which acts as the global witness.
+
+### OTS anchoring (defense in depth)
+
+Even with consistency proofs + gossip, a determined adversary who
+controls the log operator AND all witnesses can still split views.
+**OpenTimestamps (OTS)** anchors tree heads in the Bitcoin blockchain,
+providing an irrefutable time-stamped record of "what head existed
+at time T."
+
+Confium's `confium-transparency::ots` client supports this.
+See the OTS exposure design notes in `docs/security/ots-ers-exposure.md`.
+
+## Recommended deployment
+
+For CNML Mode 3 (highest assurance):
+
+1. Every transparency tree head is published with a consistency
+   proof from the previous head.
+2. Every IA coordinator gossips its tree head to BIML every
+   <configurable interval> (default: 1 hour).
+3. BIML anchors its current tree head in Bitcoin via OTS daily.
+4. Any verifier can independently verify the full chain: consistency
+   from the OTS-anchored head to the current head.

--- a/docs/workspace-map.adoc
+++ b/docs/workspace-map.adoc
@@ -1,0 +1,174 @@
+= Workspace map
+:toc: left
+:toclevels: 3
+:sectanchors:
+:sectlinks:
+:icons: font
+:source-highlighter: rouge
+
+The Confium Rust workspace contains 43 crates organized by concern.
+This page maps every crate to its category and role. For per-crate
+deep dives, see xref:crates/[the crates subdirectory].
+
+== Categories
+
+[cols="1,4"]
+|===
+| *Engine / Core* | The host library, plugin loader, public API, CLI.
+| *Threshold cryptography* | Threshold signing protocols (FROST, CMP20, GG18) and primitives.
+| *Threshold encryption* | Threshold encryption schemes (ElGamal, ECIES, ML-KEM, FHE).
+| *PKI / Certificates* | X.509, CMS, XMLDSig, composite signatures, attribute-based predicates.
+| *Storage / Hardware* | Compartmentalized backends: PKCS#11, TPM, cloud KMS, OpenPGP card.
+| *Mode 2 / PKI replacement* | Drop-in adapters for PKCS#11, OpenSSL, JCE, TLS.
+| *Network / Transport* | TCP, QUIC, WebSocket transports and sandbox runtimes.
+| *Thunderbird-inspired* | Threshold key escrow and revocation service patterns.
+| *Identity / Config* | Actor identity and deployment manifest types.
+| *Transparency / Archival* | Merkle transparency logs, OTS, ERS archival.
+| *Research frontier* | Threshold ring signatures and other explorations.
+|===
+
+== Engine / Core
+
+[cols="1,4"]
+|===
+| `confium-core` | Engine: plugin loader, registry, FFI entry points (10 interfaces shipped).
+| `confium-api` | Public Rust API + plugin SDK shared types.
+| `confium-macros` | Proc-macros for plugin authors (`#[plugin_interface]`, `#[export]`).
+| `confium-cli` | `confium` end-user command.
+| `confium-daemon` | JSON-RPC daemon over Unix socket / TCP.
+| `confium-mock-plugin` | Reference mock plugin for testing.
+| `confium-publish` | `confium-publish` author tool for the plugin registry.
+| `confium-test-harness` | NIST MPTS evaluation bench.
+| `confium-examples` | Standalone example binaries.
+| `confium-patterns` | Cross-cutting architectural patterns and helpers.
+| `confium-registry` | Static plugin / publisher / trust-root catalog.
+|===
+
+== Threshold cryptography
+
+[cols="1,4"]
+|===
+| `confium-tc` | TC session primitives (interface).
+| `confium-tc-frost-ed25519` | Real FROST-ed25519 (3-round signing).
+| `confium-tc-frost-p256` | Real P-256 Shamir + ECDSA.
+| `confium-tc-cmp20` | Real CMP20 threshold ECDSA.
+| `confium-tc-gg18` | Real GG18 threshold ECDSA.
+| `confium-tc-bls` | Threshold BLS skeleton.
+| `confium-tc-frost-ml-dsa-65` | Threshold ML-DSA-65 (research).
+| `confium-tc-coordinator` | Async session coordinator service.
+| `confium-tc-reshare` | Share re-sharing + Herzberg refresh.
+| `confium-tc-kem` | Threshold KEM session interface.
+|===
+
+== Threshold encryption
+
+[cols="1,4"]
+|===
+| `confium-tc-elgamal-p256` | Real threshold ElGamal-P256.
+| `confium-tc-ecies-p256` | Threshold ECIES skeleton.
+| `confium-tc-ml-kem` | Threshold ML-KEM (FIPS 203) research.
+| `confium-tc-fhe-bfv` | Threshold BFV FHE research.
+|===
+
+== PKI / Certificates
+
+[cols="1,4"]
+|===
+| `confium-cert` | X.509 cert + CSR types, path validation.
+| `confium-cert-delegation` | Scoped delegation templates.
+| `confium-cms` | CMS / PKCS#7 SignedData envelope.
+| `confium-xmldsig` | XMLDSig + Exclusive C14N.
+| `confium-composite` | Composite multi-alg signatures for PQC migration.
+| `confium-attributes` | Attribute-based threshold predicates + DSL.
+|===
+
+== Storage / Hardware
+
+[cols="1,4"]
+|===
+| `confium-store` | Store pillar with compartmentalized backends.
+| `confium-store-pkcs11` | PKCS#11 wrapping backend.
+| `confium-store-tpm` | TPM 2.0 sealed storage.
+| `confium-store-cloud` | AWS / GCP / Azure KMS REST.
+| `confium-store-openpgp-card` | OpenPGP card backend (YubiKey, Nitrokey).
+|===
+
+== Mode 2 / PKI replacement
+
+[cols="1,4"]
+|===
+| `confium-pkcs11-server` | PKCS#11 v3.0 dispatch to threshold protocol.
+| `confium-openssl-provider` | OpenSSL 3.0 provider.
+| `confium-tls-signer` | TLS 1.3 signature callback.
+| `confium-jce-provider` | Java Cryptography Extension provider.
+|===
+
+== Network / Transport
+
+[cols="1,4"]
+|===
+| `confium-net` | Network abstraction.
+| `confium-net-tcp` | TCP transport.
+| `confium-net-quic` | QUIC transport.
+| `confium-net-ws` | WebSocket transport.
+| `confium-sandbox-wasm` | WASM sandbox for browser director signing.
+| `confium-sandbox-process` | Out-of-process sandbox.
+|===
+
+== Thunderbird-inspired patterns
+
+[cols="1,4"]
+|===
+| `confium-escrow` | Threshold key escrow (Thunderbird key backup generalized).
+| `confium-revocation-service` | Threshold revocation escrow generalized.
+|===
+
+== Identity / Config
+
+[cols="1,4"]
+|===
+| `confium-identity` | Actor identity (manufacturer, lab, director).
+| `confium-config` | Deployment manifest (TOML) with validation.
+|===
+
+== Transparency / Archival
+
+[cols="1,4"]
+|===
+| `confium-transparency` | Append-only Merkle tree + OTS anchoring.
+| `confium-ots` | OpenTimestamps client.
+| `confium-ers` | RFC 4998 Evidence Record Syntax.
+|===
+
+== Research frontier
+
+[cols="1,4"]
+|===
+| `confium-ring` | Threshold ring signatures (skeleton).
+|===
+
+== Choosing a crate
+
+* *I want to use Confium as a library*: start with `confium-core` and
+  the interface crates (`confium-composite`, `confium-pki`,
+  `confium-attributes`, `confium-transparency`).
+* *I want to write a plugin*: `confium-api` + `confium-macros`. See
+  xref:plugin-author-guide.adoc[the plugin author guide].
+* *I want threshold signing*: pick a protocol crate (`frost-ed25519`,
+  `frost-p256`, `cmp20`, `gg18`) and use `confium-tc-coordinator` for
+  distributed sessions.
+* *I want to replace an HSM/PKI*: Mode 2 crates — `confium-pkcs11-server`,
+  `confium-openssl-provider`, `confium-jce-provider`.
+* *I want institutional PKI*: Mode 3 — `confium-cert`,
+  `confium-cert-delegation`, `confium-cms`, `confium-attributes`,
+  `confium-transparency`.
+
+== Workspace dependency graph
+
+All workspace crates share dependencies via `[workspace.dependencies]`
+in the root `Cargo.toml`. This means:
+
+* A single `cargo update` bumps every crate's view of a shared dep.
+* Version bumps across the workspace land atomically.
+* `cargo deny check licenses advisories sources bans` enforces
+  license / advisory / ban policies workspace-wide.


### PR DESCRIPTION
## Summary

Foundational Rust workspace docs tree (TODO.completion #032) + the TODO.completion plan for the full website rebuild (#032-#043).

## What's new in `docs/`

- **`docs/index.adoc`** — rewritten with current positioning (threshold-native trust infrastructure, three-mode framing, Sovereign PKI branding).
- **`docs/installation.adoc`** — three install paths (cargo / Nix flake / source).
- **`docs/workspace-map.adoc`** — 43 crates grouped by category.
- **`docs/architecture.adoc`** — engine, plugin contract, versioned interfaces, registry, coordinator, architecture principles.
- **`docs/conventions.adoc`** — lints, edition 2024 quirks, error handling, p256 API notes, trait design, testing, commits.
- **`docs/crates/`** — index + deep dives for `composite`, `transparency`, `frost-p256`.
- **`docs/examples/threshold-signing.adoc`** — end-to-end walkthrough.

## What was cleaned up

- Stripped `TODO.roadmap/` references from `develop.adoc` and `plugin-author-guide.adoc` (public docs read as shipped, not in-progress).
- Stripped OIML references from `executive/why-confium.adoc`; rebranded Mode 3 as Sovereign PKI.
- Removed `(planned)` language.
- Removed `TODO.completion/` link from `security/transparency-logs.md`.

## TODO.completion 032-043

Twelve new TODO files establish the plan for the Astro 7 + Vue 3 + Tailwind 4 website rebuild. Each has acceptance criteria, anti-patterns, approach, and cross-links. README index updated with the new Documentation category and Phase 1-5 sequencing.

## Verification

- `grep -ril OIML docs/` returns zero hits.
- No `TODO.roadmap/` references remain in `docs/`.
- All AsciiDoc files use `= Title` H1 + `:toc:` macros.
- Per-repo docs will be pulled into the central Astro site via `fetch-sources.mjs` (TODO #041).

## Next

TODO #033 (Ruby gem docs augmentation) → TODO #034 (Astro scaffolding) → #035-#043.
