### PR TITLE
docs(security): escape MDX JSX triggers

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -42,7 +42,7 @@ Bootstrap symbols:
 | `cfmp_metadata` *(optional)* | Returns static metadata (name, version, vendor, license) for the registry. |
 | `cfmp_query_dependencies` *(optional)* | Returns a dependency list. Confium resolves these before `cfmp_initialize`. |
 
-Per-interface symbols follow the pattern `cfmp_<interface>_*` (e.g.
+Per-interface symbols follow the pattern `cfmp_{interface}_*` (e.g.
 `cfmp_hash_create`, `cfmp_hash_update`, `cfmp_hash_finalize`).
 
 ## Versioned interfaces

--- a/docs/plugin-author-guide.mdx
+++ b/docs/plugin-author-guide.mdx
@@ -30,7 +30,7 @@ At minimum, a plugin exports:
   vendor, license) for the registry.
 
 For each interface it advertises (e.g. `hash`), the plugin exports the
-corresponding `cfmp_<interface>_*` symbols at the negotiated version.
+corresponding `cfmp_{interface}_*` symbols at the negotiated version.
 
 ## Step 1: create the crate
 

--- a/docs/security/transparency-logs.mdx
+++ b/docs/security/transparency-logs.mdx
@@ -69,7 +69,7 @@ For Mode 3 (highest assurance):
 1. Every transparency tree head is published with a consistency
    proof from the previous head.
 2. Every coordinator gossips its tree head to the institutional
-   anchor every <configurable interval> (default: 1 hour).
+   anchor at a configurable interval (default: 1 hour).
 3. The anchor anchors its current tree head in Bitcoin via OTS daily.
 4. Any verifier can independently verify the full chain: consistency
    from the OTS-anchored head to the current head.


### PR DESCRIPTION
Fixes '<configurable interval>' being parsed as JSX tag <configurable interval> by @astrojs/mdx, which broke the confium.github.io build. Also normalized 'cfmp_<interface>_*' patterns that have the same risk.