### PR TITLE
fix(tests): 3 test failures + Python maturin metadata

### DIFF
--- a/crates/confium-pki/tests/integration.rs
+++ b/crates/confium-pki/tests/integration.rs
@@ -51,7 +51,12 @@ fn delegation_scope_can_reference_cert_types() {
 }
 
 #[test]
-fn cms_signed_data_has_unified_verification_result() {
+fn cms_signed_data_reports_failure_on_unresolvable_cert() {
+    // Since per-signer cert resolution, the verifier resolves each
+    // signer's certificate before calling the callback. A fake
+    // all-zero cert won't parse as DER, so resolution fails and
+    // all_verified is false — even though the callback would
+    // return Ok(()). This is correct behavior.
     let sd = build_detached_signature(
         vec![0u8; 32],
         "1.2.840.113549.1.1.11",
@@ -60,8 +65,9 @@ fn cms_signed_data_has_unified_verification_result() {
     )
     .unwrap();
     let result = verify_signed_data(&sd, b"payload", |_, _, _, _| Ok(())).unwrap();
-    assert!(result.all_verified);
+    assert!(!result.all_verified);
     assert_eq!(result.per_signer.len(), 1);
+    assert!(result.per_signer[0].error.is_some());
 }
 
 #[test]

--- a/crates/confium-python/python/__init__.py
+++ b/crates/confium-python/python/__init__.py
@@ -1,0 +1,5 @@
+# Confium Python bindings.
+#
+# The native extension is built by maturin from the Rust source in src/.
+# This __init__.py ensures the python/ directory exists for maturin's
+# python-source metadata.

--- a/crates/confium-tc/src/coordinator/client.rs
+++ b/crates/confium-tc/src/coordinator/client.rs
@@ -14,8 +14,8 @@
 //!
 //! let mut client = SignerClient::connect("127.0.0.1:18432").unwrap();
 //! client.register("director-1", "biml-root").unwrap();
-//! client.submit_commitment("session-1", "director-1", &commitment_bytes).unwrap();
-//! client.submit_share("session-1", "director-1", &share_bytes).unwrap();
+//! client.submit_commitment("session-1", "director-1", &[0u8; 32]).unwrap();
+//! client.submit_share("session-1", "director-1", &[0u8; 32]).unwrap();
 //! ```
 
 use std::io;


### PR DESCRIPTION
Fixes: (1) CMS test assertion inverted to match per-signer cert resolution behavior; (2) confium-tc doctest undefined variables replaced with literals; (3) Python maturin python/ dir created.