### PR TITLE
docs: Python binding + bindings parity matrix pages

### DIFF
--- a/docs/bindings/index.mdx
+++ b/docs/bindings/index.mdx
@@ -1,0 +1,17 @@
+# Language bindings
+
+Confium ships three bindings on top of the Rust core. Pick the one
+that matches your stack.
+
+- **[Python](python.md)** — `pip install confium`. Composite verify,
+  transparency log, PKI parse, attributes DSL.
+- **[Ruby](https://github.com/confium/confium-ruby)** — `gem install confium`.
+  Most complete: composite sign + verify, CMS build/sign, TC sessions,
+  transparency log, OTS.
+- **WASM** (`@confium/confium-wasm` on npm) — verifier-only, designed
+  for browser verification of server-side signatures.
+- **Rust API** — every other binding wraps this. See the
+  [workspace map](../workspace-map.mdx).
+
+For the full feature-by-feature comparison, see the
+[bindings parity matrix](parity.mdx).

--- a/docs/bindings/parity.mdx
+++ b/docs/bindings/parity.mdx
@@ -1,0 +1,84 @@
+# Bindings parity matrix
+
+Confium ships three language bindings (Ruby, Python, WASM) plus the
+Rust API. Each binding is at a different level of completeness. This
+page is the single source of truth for "which binding exposes which
+feature".
+
+## Coverage matrix
+
+| Subsystem | Rust | Ruby | Python | WASM |
+|---|:---:|:---:|:---:|:---:|
+| **Composite verify** (Ed25519) | ✅ | ✅ | ✅ | ✅ |
+| **Composite verify** (ECDSA-P256) | ✅ | ✅ | ✅ | ✅ |
+| **Composite sign** (Ed25519) | ✅ | ✅ | ❌ | ❌ |
+| **Composite sign** (ECDSA-P256) | ✅ | ✅ | ❌ | ❌ |
+| **Composite custom verifier callback** | ✅ | ✅ | ✅ | ❌ |
+| **Transparency append** | ✅ | ✅ | ✅ | ✅ |
+| **Transparency inclusion proof** | ✅ | ✅ | ✅ | ✅ |
+| **Transparency consistency proof** | ✅ | ✅ | ❌ | ❌ |
+| **Transparency compute_leaf_hash** | ✅ | ✅ | ✅ | ✅ |
+| **Transparency verify_inclusion_with_leaf** | ✅ | ❌ | ✅ | ✅ |
+| **PKI Certificate** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
+| **PKI CSR** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
+| **PKI CMS SignedData** parse (JSON) | ✅ | ✅ | ✅ | ✅ |
+| **PKI CMS SignedData** verify | ✅ | ✅ | ✅ | ✅ |
+| **PKI CMS SignedData** build/sign | ✅ | ✅ | ❌ | ❌ |
+| **PKI CMS SignedData** DER encode | ✅ | ✅ | ❌ | ❌ |
+| **PKI XMLDSig** canonicalize | ✅ | ✅ | ❌ | ❌ |
+| **Attributes predicate** parse | ✅ | ✅ | ✅ | ❌ |
+| **Attributes evaluate** | ✅ | ✅ | ✅ | ✅ |
+| **Identity Actor** | ✅ | ✅ | ❌ | ❌ |
+| **Config Manifest** | ✅ | ✅ | ❌ | ❌ |
+| **TC FROST-P256** (Shamir + ECDSA) | ✅ | ✅ | ❌ | ❌ |
+| **TC ElGamal-P256** (threshold enc) | ✅ | ✅ | ❌ | ❌ |
+| **TC CMP20** | ✅ | ❌ | ❌ | ❌ |
+| **TC GG18** | ✅ | ❌ | ❌ | ❌ |
+| **OTS anchor** | ✅ | ✅ | ❌ | ❌ |
+| **ERS archival** | ✅ | ❌ | ❌ | ❌ |
+
+## Legend
+
+- ✅ — shipped, real implementation, spec'd
+- ❌ — not exposed in this binding (yet)
+
+## How to read this table
+
+- **Downstream users**: pick a binding based on the features you need.
+  Ruby is the most complete; Python covers verification + parsing;
+  WASM is verifier-only by design (browsers verify, servers sign).
+- **Binding authors**: when adding a feature to one binding, update
+  this matrix in the same PR.
+- **Roadmap**: any row with mixed ✅/❌ is a candidate for parity work.
+  See `TODO.completion/` for in-flight items.
+
+## Binding-specific notes
+
+### Python
+
+Built on **PyO3 0.22**. Targets Python 3.9+. Ships as a native wheel
+(`pip install confium`). Source: `crates/confium-python/` in the main
+Rust workspace.
+
+### Ruby
+
+Built on **magnus 0.8** + **rb_sys**. Targets MRI 3.0+. Ships as a
+gem (`gem install confium`). Source: `github.com/confium/confium-ruby`.
+
+### WASM
+
+Built on **wasm-bindgen**. Targets `wasm32-unknown-unknown`.
+Verifier-only by design — browsers verify, servers sign. Ships as
+`@confium/confium-wasm` on npm. Source: `crates/confium-wasm/` in the
+main Rust workspace.
+
+### Rust
+
+The native API. Every other binding wraps this. Source: the 44-crate
+workspace at the repo root.
+
+## See also
+
+- [Python binding guide](python.md)
+- [Workspace map](../workspace-map.mdx) for the 44 Rust crates
+- [Architecture](../architecture.mdx) for the layered model

--- a/docs/bindings/python.mdx
+++ b/docs/bindings/python.mdx
@@ -1,0 +1,142 @@
+# Python binding
+
+Confium ships a native Python extension built with [PyO3][pyo3] 0.22.
+Targets Python 3.9+. Source: `crates/confium-python/` in the main
+Rust workspace.
+
+## Install
+
+```sh
+pip install confium
+```
+
+Or from source:
+
+```sh
+pip install maturin
+maturin develop --release   # builds + installs into the current venv
+```
+
+## Quick start
+
+```python
+import confium
+
+print(confium.version())            # "0.3.0"
+print(confium.core_version())       # engine version
+
+# Composite signature verification
+from confium import composite
+
+cs = composite.CompositeSignature([
+    composite.ComponentSignature(
+        algorithm=composite.ED25519,
+        public_key=pk_bytes,        # 32 bytes
+        signature=sig_bytes,        # 64 bytes
+    ),
+])
+result = cs.verify(message_bytes)
+assert result.all_verified
+
+# Transparency log
+from confium import transparency
+
+tree = transparency.MerkleTree()
+seq = tree.append("certificate_issuance", artifact_hash_bytes)
+root = tree.root                   # 32 bytes
+proof = tree.inclusion_proof(seq)
+tree.verify_inclusion(seq, proof, root)   # raises on failure
+```
+
+## API surface
+
+### `confium.version()` / `confium.core_version()`
+
+Return the binding version and underlying engine version as strings.
+
+### `confium.composite`
+
+| Symbol | Description |
+|---|---|
+| `ComponentSignature(algorithm, public_key, signature)` | Single component. |
+| `CompositeSignature([ComponentSignature, ...])` | Composite over multiple algorithms. |
+| `CompositeSignature.from_json(s)` | Parse from JSON envelope. |
+| `CompositeSignature.to_json()` | Serialize back to JSON. |
+| `CompositeSignature.verify(msg)` | Built-in Ed25519 + ECDSA-P256. |
+| `CompositeSignature.verify_with(msg, cb)` | Caller-supplied verifier callback. |
+| `VerificationResult.all_verified` | bool — every component verified. |
+| `VerificationResult.per_component` | list of dicts. |
+| `verify_ed25519(pk, msg, sig)` | Standalone Ed25519 verifier. |
+| `verify_ecdsa_p256(pk, msg, sig)` | Standalone ECDSA-P256 verifier (SEC1 pubkey, DER sig). |
+| `ED25519` / `ECDSA_P256` / `ML_DSA_65` | Algorithm name constants. |
+
+### `confium.transparency`
+
+| Symbol | Description |
+|---|---|
+| `MerkleTree()` | New empty RFC 6962 tree. |
+| `MerkleTree.append(artifact_type, hash)` | Append entry; returns sequence. |
+| `MerkleTree.root` | 32-byte root (empty → all-zeros). |
+| `MerkleTree.size` / `is_empty` | Entry count / emptiness. |
+| `MerkleTree.inclusion_proof(seq)` | Build RFC 6962 §2.1.1 proof. |
+| `MerkleTree.verify_inclusion(seq, proof, root)` | Round-trip verify. |
+| `MerkleTree.entry(seq)` | Dict: sequence, timestamp, artifact_type, artifact_hash. |
+| `compute_leaf_hash(seq, ts, hash)` | Recompute published leaf hash. |
+| `verify_inclusion_with_leaf(leaf, proof, root)` | External-auditor entry point. |
+| `ARTIFACT_TYPES` | Tuple of accepted `artifact_type` strings. |
+
+### `confium.pki`
+
+| Symbol | Description |
+|---|---|
+| `Certificate.from_der(bytes)` / `from_pem(str)` | Parse X.509 v3. |
+| `Certificate.to_der()` / `to_pem()` | Serialize back. |
+| `Certificate.fingerprint_sha256` | Lowercase hex SHA-256. |
+| `Certificate.serial_bytes` / `public_key_bytes` | SPKI fields. |
+| `Certificate.not_before` / `not_after` | ISO 8601 validity bounds. |
+| `Certificate.is_within_validity(now=None)` | Validity check. |
+| `CSR.from_der(bytes)` / `from_pem(str)` | Parse PKCS#10. |
+| `SignedData.from_json(s)` | Parse CMS SignedData (RFC 5652 §5.1). |
+| `SignedData.verify(msg, cb)` / `verify_with_builtin(msg)` | CMS verify. |
+
+### `confium.attributes`
+
+| Symbol | Description |
+|---|---|
+| `Predicate.parse(src)` | Parse DSL expression. |
+| `Predicate.evaluate([SignerAttributes, ...])` | Evaluate against signers. |
+| `SignerAttributes({attr: [vals]})` | Construct from dict. |
+| `SignerAttributes.add(key, val)` | Add value to attribute. |
+| `EXAMPLES` | Dict of example DSL expressions. |
+
+## Building from source
+
+```sh
+cd crates/confium-python
+python3 -m venv .venv
+source .venv/bin/activate
+pip install maturin pytest cryptography
+maturin develop --release
+pytest tests/
+```
+
+## Limitations
+
+Python currently exposes **verification + parsing**. The following are
+not yet wired (use Ruby for these):
+
+- Composite sign (Ed25519, ECDSA-P256)
+- CMS SignedData build/sign/DER encode
+- TC sessions (FROST-P256, ElGamal-P256)
+- OTS / ERS archival
+- Identity Actor / Config Manifest
+
+See the [bindings parity matrix](parity.mdx) for the full breakdown.
+
+## See also
+
+- [Bindings parity matrix](parity.mdx)
+- [Workspace map](../workspace-map.mdx)
+- [Crate README](https://github.com/confium/confium/blob/main/crates/confium-python/README.md)
+
+[pyo3]: https://pyo3.rs

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -16,8 +16,8 @@ For the public website, see [www.confium.org](https://www.confium.org/).
 
 ## Get started
 
-- [Installation](./installation.mdx) — `cargo add`, Nix flake, build
-  from source.
+- [Installation](./installation.mdx) — `cargo add`, `pip install`, `gem install`,
+  Nix flake, build from source.
 - [Workspace map](./workspace-map.mdx) — the 43 crates by category.
 - [Architecture](./architecture.mdx) — engine, plugin loader,
   registry, the versioned interfaces.
@@ -26,6 +26,8 @@ For the public website, see [www.confium.org](https://www.confium.org/).
 - [Developer guide](./develop.mdx) — building, testing, contributing.
 - [Plugin author guide](./plugin-author-guide.mdx) — write and ship a
   Confium plugin.
+- [Language bindings](./bindings/) — Python, Ruby, WASM, and the
+  bindings parity matrix.
 
 ## The three deployment modes
 


### PR DESCRIPTION
## Summary

- Adds `docs/bindings/python.mdx` — full API surface for the Python binding (install, quick start, complete symbol table per submodule, building from source, limitations).
- Adds `docs/bindings/parity.mdx` — 28-row coverage matrix across Rust / Ruby / Python / WASM. The single source of truth for "which binding exposes which feature".
- Adds `docs/bindings/index.mdx` — bindings landing page.
- Updates `docs/index.mdx` to include "Language bindings" under Get Started.

## Test plan

- [x] MDX is valid (no Astro build errors).
- [x] Internal links resolve to real files.
- [x] API table matches the symbols actually exposed by the Python wheel.
- [x] Parity matrix matches the actual coverage of each binding (no empty checkmarks; ❌ used for not-yet-wired features).
