### PR TITLE
fix(ci): typos, dead-code, rustfmt drift on main

### DIFF
--- a/TODO.roadmap/02-workspace-layout.md
+++ b/TODO.roadmap/02-workspace-layout.md
@@ -35,7 +35,7 @@ confium/
 │   ├── confium-macros/                 # proc-macros: #[plugin_interface], etc.
 │   └── confium-test-harness/           # mock plugins, fuzzing harness, NIST vectors
 ├── plugins/                            # in-repo mock/example plugins
-│   ├── mock-hash/                      # determinstic hash for tests
+│   ├── mock-hash/                      # deterministic hash for tests
 │   ├── mock-cipher/                    # XOR cipher for tests
 │   └── mock-rng/                       # seeded RNG for deterministic tests
 ├── sites/

--- a/crates/confium-attributes/src/evaluate.rs
+++ b/crates/confium-attributes/src/evaluate.rs
@@ -18,7 +18,10 @@ impl SignerAttributes {
 
     /// Add a value to an attribute.
     pub fn add(&mut self, key: impl Into<String>, value: impl Into<String>) {
-        self.attrs.entry(key.into()).or_default().insert(value.into());
+        self.attrs
+            .entry(key.into())
+            .or_default()
+            .insert(value.into());
     }
 
     /// Does this signer have attribute `key`?

--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -63,7 +63,10 @@ impl CompositeSignature {
 
     /// List the algorithm identifiers.
     pub fn algorithms(&self) -> Vec<&str> {
-        self.components.iter().map(|c| c.algorithm.as_str()).collect()
+        self.components
+            .iter()
+            .map(|c| c.algorithm.as_str())
+            .collect()
     }
 
     /// Verify all components. Caller provides the verifier function:
@@ -161,9 +164,7 @@ mod tests {
         ]);
         assert_eq!(composite.component_count(), 2);
 
-        let result = composite
-            .verify(b"hello", |_, _, _, _| Ok(()))
-            .unwrap();
+        let result = composite.verify(b"hello", |_, _, _, _| Ok(())).unwrap();
         assert!(result.all_verified);
     }
 
@@ -240,11 +241,10 @@ pub fn p256_verifier(
     if algorithm != ECDSA_P256 && algorithm != "ECDSA" {
         return Err(format!("not ECDSA-P256: {algorithm}"));
     }
-    use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+    use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
     let vk = VerifyingKey::from_sec1_bytes(public_key)
         .map_err(|e| format!("invalid P-256 public key: {e}"))?;
-    let sig = Signature::from_der(signature)
-        .map_err(|e| format!("invalid DER signature: {e}"))?;
+    let sig = Signature::from_der(signature).map_err(|e| format!("invalid DER signature: {e}"))?;
     vk.verify(message, &sig).map_err(|e| format!("verify: {e}"))
 }
 
@@ -298,7 +298,7 @@ mod real_ed25519_tests {
 
     #[test]
     fn real_p256_round_trip() {
-        use p256::ecdsa::{SigningKey, signature::Signer, Signature};
+        use p256::ecdsa::{Signature, SigningKey, signature::Signer};
         let signing = SigningKey::random(&mut OsRng);
         let verifying = signing.verifying_key();
         let message = b"composite p256 test message";
@@ -312,7 +312,7 @@ mod real_ed25519_tests {
 
     #[test]
     fn real_p256_rejects_wrong_message() {
-        use p256::ecdsa::{SigningKey, signature::Signer, Signature};
+        use p256::ecdsa::{Signature, SigningKey, signature::Signer};
         let signing = SigningKey::random(&mut OsRng);
         let verifying = signing.verifying_key();
         let sig: Signature = signing.sign(b"original");

--- a/crates/confium-daemon/src/methods/composite.rs
+++ b/crates/confium-daemon/src/methods/composite.rs
@@ -8,7 +8,7 @@
 //! Stateless and self-contained — no handle store, no plugin loading.
 //! This is the shape we want for every "verifier" JSON-RPC method.
 
-use base64::{engine::general_purpose, Engine as _};
+use base64::{Engine as _, engine::general_purpose};
 use serde::Deserialize;
 use serde_json::{Value, json};
 
@@ -39,11 +39,10 @@ pub async fn composite_verify(
     _cfm: SharedConfium,
     params: Value,
 ) -> std::result::Result<Value, RpcError> {
-    let req: CompositeVerifyRequest = serde_json::from_value(params).map_err(|e| {
-        RpcError::InvalidParams {
+    let req: CompositeVerifyRequest =
+        serde_json::from_value(params).map_err(|e| RpcError::InvalidParams {
             detail: format!("composite_verify params: {e}"),
-        }
-    })?;
+        })?;
 
     let message = general_purpose::STANDARD
         .decode(req.message.as_bytes())
@@ -52,8 +51,8 @@ pub async fn composite_verify(
         })?;
 
     let composite_json = serde_json::to_string(&req.composite).unwrap_or_else(|_| "{}".into());
-    let composite: confium_composite::CompositeSignature =
-        serde_json::from_str(&composite_json).map_err(|e| RpcError::InvalidParams {
+    let composite: confium_composite::CompositeSignature = serde_json::from_str(&composite_json)
+        .map_err(|e| RpcError::InvalidParams {
             detail: format!("composite: invalid envelope: {e}"),
         })?;
 
@@ -93,7 +92,7 @@ pub async fn composite_verify(
 mod tests {
     use super::*;
     use crate::test_util::test_confium;
-    use base64::{engine::general_purpose, Engine as _};
+    use base64::{Engine as _, engine::general_purpose};
     use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
     use rand_core::OsRng;
 

--- a/crates/confium-daemon/src/protocol.rs
+++ b/crates/confium-daemon/src/protocol.rs
@@ -111,7 +111,7 @@ impl RpcResponse {
 
     /// Build an error response carrying the given [`RpcError`].
     /// `id` is the value from the matching request (or `Value::Null`
-    /// if the request was unparseable).
+    /// if the request was unparsable).
     pub fn err(id: Value, err: RpcError) -> Self {
         RpcResponse::Err(RpcErrorBody {
             jsonrpc: "2.0",

--- a/crates/confium-deployment/src/identity/actor.rs
+++ b/crates/confium-deployment/src/identity/actor.rs
@@ -163,10 +163,16 @@ impl ActorIdentityBuilder {
     /// Build the identity.
     pub fn build(self) -> Result<ActorIdentity, IdentityError> {
         Ok(ActorIdentity {
-            actor_id: self.actor_id.ok_or(IdentityError::MissingField("actor_id"))?,
-            actor_type: self.actor_type.ok_or(IdentityError::MissingField("actor_type"))?,
+            actor_id: self
+                .actor_id
+                .ok_or(IdentityError::MissingField("actor_id"))?,
+            actor_type: self
+                .actor_type
+                .ok_or(IdentityError::MissingField("actor_type"))?,
             quorum_id: self.quorum_id,
-            signing_key: self.signing_key.ok_or(IdentityError::MissingField("signing_key"))?,
+            signing_key: self
+                .signing_key
+                .ok_or(IdentityError::MissingField("signing_key"))?,
             encryption_key: self.encryption_key,
             certificate_chain_der: self.certificate_chain_der,
             hardware_token: self.hardware_token,

--- a/crates/confium-deployment/src/identity/store.rs
+++ b/crates/confium-deployment/src/identity/store.rs
@@ -30,7 +30,9 @@ impl MemoryIdentityBackend {
     }
 
     fn lock(&self) -> Result<MutexGuard<'_, HashMap<String, ActorIdentity>>, IdentityError> {
-        self.inner.lock().map_err(|_| IdentityError::NotFound("lock poisoned".into()))
+        self.inner
+            .lock()
+            .map_err(|_| IdentityError::NotFound("lock poisoned".into()))
     }
 }
 

--- a/crates/confium-deployment/src/lib.rs
+++ b/crates/confium-deployment/src/lib.rs
@@ -14,10 +14,10 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+pub mod identity;
 pub mod manifest;
 pub mod mode;
 pub mod validate;
-pub mod identity;
 
 pub use manifest::*;
 pub use mode::*;

--- a/crates/confium-deployment/src/validate.rs
+++ b/crates/confium-deployment/src/validate.rs
@@ -23,9 +23,10 @@ pub fn validate_manifest(manifest: &Manifest) -> ValidationReport {
     };
 
     if manifest.deployment.manifest_version != 1 {
-        report
-            .errors
-            .push(format!("unsupported manifest version {}", manifest.deployment.manifest_version));
+        report.errors.push(format!(
+            "unsupported manifest version {}",
+            manifest.deployment.manifest_version
+        ));
     }
 
     match manifest.mode {
@@ -68,8 +69,7 @@ pub fn validate_manifest(manifest: &Manifest) -> ValidationReport {
 }
 
 fn validate_tier_chain(tiers: &[crate::manifest::Tier], report: &mut ValidationReport) {
-    let names: std::collections::HashSet<&str> =
-        tiers.iter().map(|t| t.name.as_str()).collect();
+    let names: std::collections::HashSet<&str> = tiers.iter().map(|t| t.name.as_str()).collect();
 
     for tier in tiers {
         if let Some(parent) = &tier.delegated_by {

--- a/crates/confium-patterns/src/escrow/service.rs
+++ b/crates/confium-patterns/src/escrow/service.rs
@@ -123,12 +123,7 @@ impl EscrowService {
         shared_secret: &[u8],
         aead: &dyn Aead,
     ) -> Result<Vec<u8>, EscrowError> {
-        aead.decrypt(
-            shared_secret,
-            &blob.ciphertext,
-            &blob.nonce,
-            &blob.aad,
-        )
+        aead.decrypt(shared_secret, &blob.ciphertext, &blob.nonce, &blob.aad)
     }
 }
 
@@ -151,7 +146,10 @@ mod tests {
     /// 32 zero bytes as shared secret.
     struct MockEncapsulator;
     impl Encapsulator for MockEncapsulator {
-        fn encapsulate(&self, recipient: &QuorumPublicKey) -> Result<(Vec<u8>, Vec<u8>), EscrowError> {
+        fn encapsulate(
+            &self,
+            recipient: &QuorumPublicKey,
+        ) -> Result<(Vec<u8>, Vec<u8>), EscrowError> {
             Ok((recipient.bytes.clone(), vec![0u8; 32]))
         }
     }

--- a/crates/confium-patterns/src/revocation/revocation_service.rs
+++ b/crates/confium-patterns/src/revocation/revocation_service.rs
@@ -79,19 +79,18 @@ impl RevocationService {
 
     /// Service-side: process first confirmation for a submission.
     pub fn confirm_first(&mut self, submission_id: &str) -> Result<(), RevocationError> {
-        let sub = self
-            .submissions
-            .get_mut(submission_id)
-            .ok_or_else(|| RevocationError::Malformed(format!("unknown submission {submission_id}")))?;
-        sub.confirm_first().map_err(|e| RevocationError::EmailVerificationFailed(e))
+        let sub = self.submissions.get_mut(submission_id).ok_or_else(|| {
+            RevocationError::Malformed(format!("unknown submission {submission_id}"))
+        })?;
+        sub.confirm_first()
+            .map_err(|e| RevocationError::EmailVerificationFailed(e))
     }
 
     /// Service-side: process second confirmation (after 24h delay).
     pub fn confirm_second(&mut self, submission_id: &str) -> Result<(), RevocationError> {
-        let sub = self
-            .submissions
-            .get_mut(submission_id)
-            .ok_or_else(|| RevocationError::Malformed(format!("unknown submission {submission_id}")))?;
+        let sub = self.submissions.get_mut(submission_id).ok_or_else(|| {
+            RevocationError::Malformed(format!("unknown submission {submission_id}"))
+        })?;
         sub.confirm_second()
             .map_err(|e| RevocationError::EmailVerificationFailed(e))
     }
@@ -102,7 +101,8 @@ impl RevocationService {
         let mut count = 0;
         for sub in self.submissions.values_mut() {
             if sub.state == SubmissionState::SecondConfirmed {
-                sub.mark_decrypted().map_err(|e| RevocationError::ThresholdDecryption(e))?;
+                sub.mark_decrypted()
+                    .map_err(|e| RevocationError::ThresholdDecryption(e))?;
                 count += 1;
             }
         }
@@ -111,10 +111,9 @@ impl RevocationService {
 
     /// Service-side: publish a processed submission to keyservers.
     pub fn publish(&mut self, submission_id: &str) -> Result<(), RevocationError> {
-        let sub = self
-            .submissions
-            .get_mut(submission_id)
-            .ok_or_else(|| RevocationError::Malformed(format!("unknown submission {submission_id}")))?;
+        let sub = self.submissions.get_mut(submission_id).ok_or_else(|| {
+            RevocationError::Malformed(format!("unknown submission {submission_id}"))
+        })?;
         sub.mark_published()
             .map_err(|e| RevocationError::Publish(e))
     }
@@ -123,7 +122,12 @@ impl RevocationService {
     pub fn pending_count(&self) -> usize {
         self.submissions
             .values()
-            .filter(|s| !matches!(s.state, SubmissionState::Published | SubmissionState::Cancelled))
+            .filter(|s| {
+                !matches!(
+                    s.state,
+                    SubmissionState::Published | SubmissionState::Cancelled
+                )
+            })
             .count()
     }
 
@@ -178,7 +182,10 @@ mod tests {
         assert_eq!(processed, 1);
         service.publish(&id).unwrap();
 
-        assert_eq!(service.submission(&id).unwrap().state, SubmissionState::Published);
+        assert_eq!(
+            service.submission(&id).unwrap().state,
+            SubmissionState::Published
+        );
     }
 
     #[test]

--- a/crates/confium-pkcs11-server/src/dispatch.rs
+++ b/crates/confium-pkcs11-server/src/dispatch.rs
@@ -54,12 +54,7 @@ impl Pkcs11Server {
     }
 
     /// Register a slot for a Confium quorum.
-    pub fn register_quorum(
-        &mut self,
-        slot: SlotId,
-        slot_info: SlotInfo,
-        token_info: TokenInfo,
-    ) {
+    pub fn register_quorum(&mut self, slot: SlotId, slot_info: SlotInfo, token_info: TokenInfo) {
         self.slots.insert(slot.clone(), slot_info);
         self.tokens.insert(slot, token_info);
     }

--- a/crates/confium-pki/src/cert.rs
+++ b/crates/confium-pki/src/cert.rs
@@ -78,7 +78,11 @@ impl Certificate {
 
     /// Not-before validity bound (raw `der::DateTime`).
     pub fn not_before(&self) -> der::DateTime {
-        self.inner.tbs_certificate.validity.not_before.to_date_time()
+        self.inner
+            .tbs_certificate
+            .validity
+            .not_before
+            .to_date_time()
     }
 
     /// Not-after validity bound (raw `der::DateTime`).

--- a/crates/confium-pki/src/cms/signed_data.rs
+++ b/crates/confium-pki/src/cms/signed_data.rs
@@ -111,7 +111,8 @@ impl SignedData {
         // Add the digest algorithm to digest_algorithms if not present.
         let oid = &signer_info.digest_algorithm.oid;
         if !self.digest_algorithms.iter().any(|a| &a.oid == oid) {
-            self.digest_algorithms.push(signer_info.digest_algorithm.clone());
+            self.digest_algorithms
+                .push(signer_info.digest_algorithm.clone());
         }
         self.signer_infos.push(signer_info);
     }

--- a/crates/confium-pki/src/cms/verify.rs
+++ b/crates/confium-pki/src/cms/verify.rs
@@ -2,7 +2,7 @@
 
 use crate::cert::Certificate as RustCert;
 use crate::cms::envelope::CmsError;
-use crate::cms::signed_data::{SignerIdentifier, SignedData};
+use crate::cms::signed_data::{SignedData, SignerIdentifier};
 
 /// Result of CMS verification.
 #[derive(Debug, Clone, Default)]
@@ -76,7 +76,7 @@ pub fn resolve_signer_certificate(
 }
 
 /// Extract the SubjectKeyIdentifier extension value from a DER-encoded
-/// certificate. Returns None if the extension is absent or unparseable.
+/// certificate. Returns None if the extension is absent or unparsable.
 fn extract_ski_extension(cert_der: &[u8]) -> Option<Vec<u8>> {
     let cert = match RustCert::from_der(cert_der) {
         Ok(c) => c,

--- a/crates/confium-pki/src/delegation/constraint.rs
+++ b/crates/confium-pki/src/delegation/constraint.rs
@@ -57,16 +57,19 @@ impl Constraint {
             (Constraint::NameBound { name_pattern }, ScopeValue::Name(actual)) => {
                 glob_match(name_pattern, actual)
             }
-            (Constraint::TimeBound { not_before, not_after }, ScopeValue::Time(when)) => {
-                when >= not_before && when <= not_after
-            }
+            (
+                Constraint::TimeBound {
+                    not_before,
+                    not_after,
+                },
+                ScopeValue::Time(when),
+            ) => when >= not_before && when <= not_after,
             (Constraint::CountBound { max_issuances }, ScopeValue::Count(used)) => {
                 *used <= *max_issuances
             }
-            (
-                Constraint::GeographicBound { regions },
-                ScopeValue::Region(actual),
-            ) => regions.iter().any(|r| r == actual),
+            (Constraint::GeographicBound { regions }, ScopeValue::Region(actual)) => {
+                regions.iter().any(|r| r == actual)
+            }
             (Constraint::SubjectBound { subjects }, ScopeValue::Subject(actual)) => {
                 subjects.iter().any(|s| s == actual)
             }
@@ -96,9 +99,7 @@ pub enum ScopeValue<'a> {
 fn glob_match(pattern: &str, value: &str) -> bool {
     fn helper(p: &[u8], v: &[u8]) -> bool {
         match (p.first(), v.first()) {
-            (Some(b'*'), _) => {
-                helper(&p[1..], v) || (v.first().is_some() && helper(p, &v[1..]))
-            }
+            (Some(b'*'), _) => helper(&p[1..], v) || (v.first().is_some() && helper(p, &v[1..])),
             (Some(b'?'), Some(_)) => helper(&p[1..], &v[1..]),
             (Some(pc), Some(vc)) if pc == vc => helper(&p[1..], &v[1..]),
             (None, None) => true,

--- a/crates/confium-pki/src/path.rs
+++ b/crates/confium-pki/src/path.rs
@@ -56,10 +56,7 @@ pub fn validate_path(path: &CertPath<'_>, now: DateTime<Utc>) -> VerificationRes
 /// Hook for signature verification — caller provides a verifier function.
 /// The verifier receives (parent_pubkey, signed_cert_der) and returns Ok(())
 /// if the signature is valid.
-pub fn verify_path_signatures<F>(
-    path: &CertPath<'_>,
-    verifier: F,
-) -> VerificationResult
+pub fn verify_path_signatures<F>(path: &CertPath<'_>, verifier: F) -> VerificationResult
 where
     F: Fn(&[u8], &[u8]) -> Result<(), String>,
 {

--- a/crates/confium-pki/src/xmldsig/mod.rs
+++ b/crates/confium-pki/src/xmldsig/mod.rs
@@ -61,7 +61,9 @@ impl SignatureAlgorithm {
     /// Algorithm identifier.
     pub fn algorithm_id(&self) -> &'static str {
         match self {
-            SignatureAlgorithm::EcdsaSha256 => "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256",
+            SignatureAlgorithm::EcdsaSha256 => {
+                "http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256"
+            }
             SignatureAlgorithm::Ed25519 => "http://www.w3.org/2021/04/xmldsig-more#eddsa-ed25519",
             SignatureAlgorithm::RsaSha256 => "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256",
         }
@@ -101,7 +103,9 @@ impl Transform {
         match self {
             Transform::ExclusiveC14N => "http://www.w3.org/2001/10/xml-exc-c14n#",
             Transform::InclusiveC14N => "http://www.w3.org/TR/2001/REC-xml-c14n-20010315",
-            Transform::EnvelopedSignature => "http://www.w3.org/2000/09/xmldsig#enveloped-signature",
+            Transform::EnvelopedSignature => {
+                "http://www.w3.org/2000/09/xmldsig#enveloped-signature"
+            }
             Transform::Base64Decode => "http://www.w3.org/2000/09/xmldsig#base64",
         }
     }

--- a/crates/confium-pki/tests/integration.rs
+++ b/crates/confium-pki/tests/integration.rs
@@ -3,21 +3,27 @@
 //! Verifies that all four submodules (cert, delegation, cms, xmldsig)
 //! work together via the public API.
 
+use chrono::Utc;
 use confium_pki::{
+    PathFailure,
+    // Result
+    VerificationResult,
     // Cert
-    cert::{Certificate, CertificateSigningRequest, CertError},
-    // Delegation
-    delegation::{Constraint, DelegationScope, Operation, ScopeValue, SignCertSpec, validate_delegation},
+    cert::{CertError, Certificate, CertificateSigningRequest},
     // CMS
     cms::{SignedData, SignedDataBuilder, build_detached_signature, verify_signed_data},
-    // Result
-    VerificationResult, PathFailure,
+    // Delegation
+    delegation::{
+        Constraint, DelegationScope, Operation, ScopeValue, SignCertSpec, validate_delegation,
+    },
 };
-use chrono::Utc;
 
 #[test]
 fn verification_result_aggregates_across_concerns() {
-    let r1 = VerificationResult { valid: true, checks: vec![] };
+    let r1 = VerificationResult {
+        valid: true,
+        checks: vec![],
+    };
     let r2 = VerificationResult {
         valid: false,
         checks: vec![PathFailure::Expired],
@@ -32,7 +38,9 @@ fn delegation_scope_can_reference_cert_types() {
     // Build a delegation scope that authorizes SignCert for instance certs.
     let scope = DelegationScope::new()
         .allow_operation(Operation::SignCert(SignCertSpec::default()))
-        .constrain(Constraint::ModelBound { model_id: "FM-2026-A".into() })
+        .constrain(Constraint::ModelBound {
+            model_id: "FM-2026-A".into(),
+        })
         .constrain(Constraint::TimeBound {
             not_before: Utc::now(),
             not_after: Utc::now() + chrono::Duration::days(365),
@@ -72,7 +80,9 @@ fn cms_signed_data_reports_failure_on_unresolvable_cert() {
 
 #[test]
 fn der_encode_round_trips_through_signed_data_construction() {
-    use confium_pki::cms::{encode_signed_data_der, AlgorithmIdentifier, EncapContentInfo, SignerIdentifier, SignerInfo};
+    use confium_pki::cms::{
+        AlgorithmIdentifier, EncapContentInfo, SignerIdentifier, SignerInfo, encode_signed_data_der,
+    };
     let sd = SignedData {
         version: 1,
         digest_algorithms: vec![AlgorithmIdentifier {

--- a/crates/confium-registry/src/install.rs
+++ b/crates/confium-registry/src/install.rs
@@ -104,13 +104,9 @@ impl Default for HttpDownloader {
 
 impl Downloader for HttpDownloader {
     fn download(&self, url: &str) -> Result<Vec<u8>> {
-        let response = self
-            .agent
-            .get(url)
-            .call()
-            .map_err(|e| Error::Download {
-                message: format!("HTTP request to {url} failed: {e}"),
-            })?;
+        let response = self.agent.get(url).call().map_err(|e| Error::Download {
+            message: format!("HTTP request to {url} failed: {e}"),
+        })?;
 
         let mut bytes = Vec::with_capacity(1024 * 64);
         response

--- a/crates/confium-store-openpgp-card/src/backend.rs
+++ b/crates/confium-store-openpgp-card/src/backend.rs
@@ -49,11 +49,7 @@ pub trait OpenpgpCardBackend {
     ) -> Result<Vec<u8>, CardError>;
 
     /// Import a keypair into the given slot (rare; usually generated in-card).
-    fn import_keypair(
-        &mut self,
-        slot: OpenpgpSlot,
-        private_key: &[u8],
-    ) -> Result<(), CardError>;
+    fn import_keypair(&mut self, slot: OpenpgpSlot, private_key: &[u8]) -> Result<(), CardError>;
 
     /// Get the public key from a slot.
     fn public_key(&self, slot: OpenpgpSlot) -> Result<Vec<u8>, CardError>;
@@ -112,11 +108,7 @@ impl OpenpgpCardBackend for MockOpenpgpCardBackend {
         Ok(vec![slot as u8; 32])
     }
 
-    fn import_keypair(
-        &mut self,
-        _slot: OpenpgpSlot,
-        _private_key: &[u8],
-    ) -> Result<(), CardError> {
+    fn import_keypair(&mut self, _slot: OpenpgpSlot, _private_key: &[u8]) -> Result<(), CardError> {
         if !self.admin_verified {
             return Err(CardError::VerificationRequired("admin PIN".into()));
         }

--- a/crates/confium-store-openpgp-card/src/rnp_backend.rs
+++ b/crates/confium-store-openpgp-card/src/rnp_backend.rs
@@ -13,8 +13,7 @@
 //! See `tests/rnp_integration.rs` for the end-to-end sign+verify round trip.
 
 use rnp::{
-    context::Context, key::KeyIdentifier, Algorithm, Hash, KeyBuilder, KeyUsage,
-    PasswordProvider,
+    Algorithm, Hash, KeyBuilder, KeyUsage, PasswordProvider, context::Context, key::KeyIdentifier,
 };
 
 use crate::backend::{CardError, CardId, OpenpgpCardBackend};
@@ -27,11 +26,7 @@ struct StaticPasswordProvider {
 }
 
 impl PasswordProvider for StaticPasswordProvider {
-    fn get_password(
-        &self,
-        _key: Option<&rnp::key::Key>,
-        _ctx: &str,
-    ) -> Option<Cow<'_, str>> {
+    fn get_password(&self, _key: Option<&rnp::key::Key>, _ctx: &str) -> Option<Cow<'_, str>> {
         Some(Cow::Owned(self.pin.clone()))
     }
 }
@@ -56,10 +51,7 @@ pub struct RnpOpenpgpCardBackend {
 impl RnpOpenpgpCardBackend {
     /// Construct a new backend. The `pin` is what would be the user/admin
     /// PINs on a physical OpenPGP card.
-    pub fn new(
-        card_id: impl Into<String>,
-        pin: impl Into<String>,
-    ) -> Result<Self, CardError> {
+    pub fn new(card_id: impl Into<String>, pin: impl Into<String>) -> Result<Self, CardError> {
         let mut ctx = Context::new().map_err(|e| CardError::Io(e.to_string()))?;
         let pin = pin.into();
         ctx.set_password_provider(Box::new(StaticPasswordProvider { pin: pin.clone() }));
@@ -146,15 +138,15 @@ impl OpenpgpCardBackend for RnpOpenpgpCardBackend {
             .map_err(|e| CardError::Io(e.to_string()))
     }
 
-    fn import_keypair(
-        &mut self,
-        slot: OpenpgpSlot,
-        private_key: &[u8],
-    ) -> Result<(), CardError> {
+    fn import_keypair(&mut self, slot: OpenpgpSlot, private_key: &[u8]) -> Result<(), CardError> {
         self.require_admin()?;
         let userid = self.slot_userid(slot);
         self.ctx
-            .load_keys(rnp::context::KeyringFormat::Gpg, private_key, rnp::key::LoadSaveFlags::SECRET)
+            .load_keys(
+                rnp::context::KeyringFormat::Gpg,
+                private_key,
+                rnp::key::LoadSaveFlags::SECRET,
+            )
             .map_err(|e| CardError::Io(e.to_string()))?;
         *self.slot_userid_mut(slot) = Some(userid);
         Ok(())
@@ -209,14 +201,18 @@ impl OpenpgpCardBackend for RnpOpenpgpCardBackend {
 
     fn verify_pin(&self, pin: &str) -> Result<(), CardError> {
         if pin != self.pin {
-            return Err(CardError::WrongPin { attempts_remaining: 2 });
+            return Err(CardError::WrongPin {
+                attempts_remaining: 2,
+            });
         }
         Ok(())
     }
 
     fn verify_admin_pin(&self, admin_pin: &str) -> Result<(), CardError> {
         if admin_pin != self.pin {
-            return Err(CardError::WrongPin { attempts_remaining: 2 });
+            return Err(CardError::WrongPin {
+                attempts_remaining: 2,
+            });
         }
         Ok(())
     }

--- a/crates/confium-store-openpgp-card/tests/rnp_integration.rs
+++ b/crates/confium-store-openpgp-card/tests/rnp_integration.rs
@@ -13,7 +13,7 @@
 use confium_store_openpgp_card::{
     CardError, OpenpgpCardBackend, OpenpgpSlot, RnpOpenpgpCardBackend,
 };
-use rnp::{Context, Hash, KeyBuilder, KeyUsage, Algorithm};
+use rnp::{Algorithm, Context, Hash, KeyBuilder, KeyUsage};
 
 const PIN: &str = "12345678";
 
@@ -30,7 +30,9 @@ fn sign_verify_round_trip_via_rnp_backend() {
 
     // Admin verifies → can generate SIG slot key.
     card.verify_admin_pin_session(PIN).unwrap();
-    let pub_key = card.generate_keypair(OpenpgpSlot::Signature, "RSA-2048").unwrap();
+    let pub_key = card
+        .generate_keypair(OpenpgpSlot::Signature, "RSA-2048")
+        .unwrap();
     assert!(!pub_key.is_empty(), "public key export must be non-empty");
 
     // User verifies → can sign.
@@ -67,7 +69,8 @@ fn sign_verify_round_trip_via_rnp_backend() {
 fn factory_reset_clears_session_state() {
     let mut card = RnpOpenpgpCardBackend::new("YubiKey-Test-002", PIN).unwrap();
     card.verify_admin_pin_session(PIN).unwrap();
-    card.generate_keypair(OpenpgpSlot::Signature, "RSA-2048").unwrap();
+    card.generate_keypair(OpenpgpSlot::Signature, "RSA-2048")
+        .unwrap();
     card.verify_pin_session(PIN).unwrap();
 
     card.factory_reset().unwrap();

--- a/crates/confium-tc-bls/src/lib.rs
+++ b/crates/confium-tc-bls/src/lib.rs
@@ -57,7 +57,9 @@ pub enum BlsError {
 /// Mock: XORs all signature bytes together.
 pub fn aggregate_signatures(signatures: &[Signature]) -> Result<Signature, BlsError> {
     if signatures.is_empty() {
-        return Err(BlsError::AggregationFailed("no signatures to aggregate".into()));
+        return Err(BlsError::AggregationFailed(
+            "no signatures to aggregate".into(),
+        ));
     }
     let mut combined = signatures[0].bytes.clone();
     for sig in &signatures[1..] {
@@ -76,8 +78,12 @@ mod tests {
 
     #[test]
     fn aggregate_two_signatures() {
-        let s1 = Signature { bytes: vec![0xFF; 96] };
-        let s2 = Signature { bytes: vec![0xFF; 96] };
+        let s1 = Signature {
+            bytes: vec![0xFF; 96],
+        };
+        let s2 = Signature {
+            bytes: vec![0xFF; 96],
+        };
         let combined = aggregate_signatures(&[s1, s2]).unwrap();
         // XOR of two identical = all zeros
         assert!(combined.bytes.iter().all(|b| *b == 0));

--- a/crates/confium-tc-ecies-p256/src/lib.rs
+++ b/crates/confium-tc-ecies-p256/src/lib.rs
@@ -33,7 +33,7 @@ use p256::{AffinePoint, EncodedPoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 
 pub use keys::generate_keypair;
-pub use shamir::{recover_secret, split_secret, Share};
+pub use shamir::{Share, recover_secret, split_secret};
 
 /// Algorithm identifier.
 pub const ALGORITHM: &str = "ECIES-P256-threshold";
@@ -120,7 +120,11 @@ fn decode_point(bytes: &[u8]) -> Result<ProjectivePoint, EciesError> {
 }
 
 fn encode_point(point: &ProjectivePoint) -> Vec<u8> {
-    point.to_affine().to_encoded_point(false).as_bytes().to_vec()
+    point
+        .to_affine()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec()
 }
 
 fn decode_scalar(bytes: &[u8]) -> Result<Scalar, EciesError> {

--- a/crates/confium-tc-elgamal-p256/src/lib.rs
+++ b/crates/confium-tc-elgamal-p256/src/lib.rs
@@ -24,7 +24,7 @@ use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 
 pub use keys::generate_keypair;
-pub use shamir::{recover_secret, split_secret, Share};
+pub use shamir::{Share, recover_secret, split_secret};
 
 /// Algorithm identifier.
 pub const ALGORITHM: &str = "ElGamal-P256-threshold";
@@ -105,7 +105,11 @@ fn decode_point(bytes: &[u8]) -> Result<ProjectivePoint, ElGamalError> {
 }
 
 fn encode_point(point: &ProjectivePoint) -> Vec<u8> {
-    point.to_affine().to_encoded_point(false).as_bytes().to_vec()
+    point
+        .to_affine()
+        .to_encoded_point(false)
+        .as_bytes()
+        .to_vec()
 }
 
 fn decode_scalar(bytes: &[u8]) -> Result<Scalar, ElGamalError> {
@@ -132,7 +136,9 @@ fn decode_scalar(bytes: &[u8]) -> Result<Scalar, ElGamalError> {
 ///
 /// The receiver threshold-decrypts to recover the same c2 point, then
 /// takes its X-coordinate as the shared secret.
-pub fn encapsulate(recipient_public_key: &PublicKey) -> Result<(Ciphertext, Vec<u8>), ElGamalError> {
+pub fn encapsulate(
+    recipient_public_key: &PublicKey,
+) -> Result<(Ciphertext, Vec<u8>), ElGamalError> {
     use p256::elliptic_curve::rand_core::RngCore;
 
     let recipient_pt = decode_point(&recipient_public_key.bytes)?;

--- a/crates/confium-tc-frost-p256/src/keys.rs
+++ b/crates/confium-tc-frost-p256/src/keys.rs
@@ -2,9 +2,9 @@
 
 use crate::scalar;
 use p256::{
+    AffinePoint, ProjectivePoint, Scalar,
     ecdsa::{SigningKey, VerifyingKey},
     elliptic_curve::sec1::ToEncodedPoint,
-    AffinePoint, ProjectivePoint, Scalar,
 };
 
 /// A P-256 keypair.

--- a/crates/confium-tc-frost-p256/src/lib.rs
+++ b/crates/confium-tc-frost-p256/src/lib.rs
@@ -59,7 +59,7 @@ mod integration_tests {
         let signature = sign::sign_message(&keypair, message).expect("sign");
 
         // 4. Verify under the public key using standard p256::ecdsa.
-        use p256::ecdsa::{signature::Verifier, Signature};
+        use p256::ecdsa::{Signature, signature::Verifier};
         let verifying = keypair.to_verifying_key();
         let sig = Signature::from_der(&signature.der_bytes).expect("parse sig");
         verifying.verify(message, &sig).expect("verify");

--- a/crates/confium-tc-frost-p256/src/scalar.rs
+++ b/crates/confium-tc-frost-p256/src/scalar.rs
@@ -90,4 +90,3 @@ mod tests {
         assert!(scalar_from_bytes(&[0u8; 16]).is_none());
     }
 }
-

--- a/crates/confium-tc-frost-p256/src/shamir.rs
+++ b/crates/confium-tc-frost-p256/src/shamir.rs
@@ -5,8 +5,8 @@
 //! interpolation.
 
 use crate::scalar;
-use p256::elliptic_curve::PrimeField;
 use p256::Scalar;
+use p256::elliptic_curve::PrimeField;
 
 /// A Shamir share: (x, y) where x is the party index and y is a scalar.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,10 +83,7 @@ fn u32_to_scalar(v: u32) -> Scalar {
 /// `t` shares via Lagrange interpolation.
 pub fn recover_secret(shares: &[&Share]) -> Result<Scalar, ShamirError> {
     if shares.is_empty() {
-        return Err(ShamirError::InsufficientShares {
-            have: 0,
-            need: 1,
-        });
+        return Err(ShamirError::InsufficientShares { have: 0, need: 1 });
     }
 
     // Check for duplicate x values
@@ -157,7 +154,10 @@ mod tests {
     #[test]
     fn empty_shares_fail() {
         let result = recover_secret(&[]);
-        assert!(matches!(result, Err(ShamirError::InsufficientShares { .. })));
+        assert!(matches!(
+            result,
+            Err(ShamirError::InsufficientShares { .. })
+        ));
     }
 
     #[test]

--- a/crates/confium-tc-frost-p256/src/sign.rs
+++ b/crates/confium-tc-frost-p256/src/sign.rs
@@ -5,7 +5,7 @@
 //! threshold ECDSA workflow for testing and integration.
 
 use crate::keys::Keypair;
-use p256::ecdsa::{signature::Signer, Signature};
+use p256::ecdsa::{Signature, signature::Signer};
 use thiserror::Error;
 
 /// Result of signing: DER-encoded signature bytes plus the raw signature object.
@@ -41,7 +41,7 @@ pub fn sign_message(keypair: &Keypair, message: &[u8]) -> Result<Signed, SignErr
 mod tests {
     use super::*;
     use crate::keys::generate_keypair;
-    use p256::ecdsa::{signature::Verifier, VerifyingKey};
+    use p256::ecdsa::{VerifyingKey, signature::Verifier};
 
     #[test]
     fn sign_and_verify_round_trip() {

--- a/crates/confium-tc-frost-p256/tests/integration.rs
+++ b/crates/confium-tc-frost-p256/tests/integration.rs
@@ -10,10 +10,10 @@
 use confium_tc_frost_p256::{
     keys::{generate_keypair, public_key_for},
     scalar,
-    shamir::{recover_secret, split_secret, Share},
+    shamir::{Share, recover_secret, split_secret},
     sign::sign_message,
 };
-use p256::ecdsa::{signature::Verifier, Signature};
+use p256::ecdsa::{Signature, signature::Verifier};
 
 #[test]
 fn integration_full_threshold_lifecycle_3_of_5() {

--- a/crates/confium-tc-ml-kem/src/lib.rs
+++ b/crates/confium-tc-ml-kem/src/lib.rs
@@ -113,7 +113,11 @@ mod tests {
 
     #[test]
     fn shared_secret_always_32() {
-        for params in [ParameterSet::MlKem512, ParameterSet::MlKem768, ParameterSet::MlKem1024] {
+        for params in [
+            ParameterSet::MlKem512,
+            ParameterSet::MlKem768,
+            ParameterSet::MlKem1024,
+        ] {
             assert_eq!(params.shared_secret_size(), 32);
         }
     }

--- a/crates/confium-tc/src/coordinator/audit.rs
+++ b/crates/confium-tc/src/coordinator/audit.rs
@@ -108,7 +108,9 @@ mod tests {
         );
         log.append(
             "session-1",
-            AuditEvent::CommitmentReceived { signer: "alice".into() },
+            AuditEvent::CommitmentReceived {
+                signer: "alice".into(),
+            },
         );
         log.append(
             "session-2",
@@ -127,10 +129,7 @@ mod tests {
     #[test]
     fn jsonl_round_trips() {
         let mut log = AuditLog::new();
-        log.append(
-            "session-1",
-            AuditEvent::Aggregated,
-        );
+        log.append("session-1", AuditEvent::Aggregated);
         let jsonl = log.to_jsonl().unwrap();
         assert!(jsonl.contains("session-1"));
         assert!(jsonl.contains("aggregated"));

--- a/crates/confium-tc/src/coordinator/client.rs
+++ b/crates/confium-tc/src/coordinator/client.rs
@@ -21,7 +21,7 @@
 use std::io;
 use std::net::TcpStream;
 
-use crate::coordinator::net::{send_message, recv_message, ProtocolMessage};
+use crate::coordinator::net::{ProtocolMessage, recv_message, send_message};
 
 /// TCP signer client.
 pub struct SignerClient {
@@ -47,7 +47,10 @@ impl SignerClient {
         let resp = recv_message(&mut self.stream)?;
         match resp {
             ProtocolMessage::Registered { signer_id: sid } if sid == signer_id => Ok(()),
-            _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unexpected register response")),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected register response",
+            )),
         }
     }
 
@@ -77,7 +80,10 @@ impl SignerClient {
                 io::ErrorKind::Other,
                 format!("coordinator error: {message}"),
             )),
-            _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unexpected response")),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected response",
+            )),
         }
     }
 
@@ -98,7 +104,8 @@ impl SignerClient {
             },
         )?;
         // Wait for Ack or Error
-        self.stream.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
+        self.stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
         match recv_message(&mut self.stream) {
             Ok(ProtocolMessage::Ack { .. }) => Ok(()),
             Ok(ProtocolMessage::Error { message }) => Err(io::Error::new(
@@ -130,7 +137,8 @@ impl SignerClient {
 
         // Set a short read timeout — if coordinator doesn't respond (threshold
         // not met), the client gets WouldBlock instead of blocking forever.
-        self.stream.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
+        self.stream
+            .set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
 
         match recv_message(&mut self.stream) {
             Ok(ProtocolMessage::Signature { bytes, .. }) => Ok(Some(bytes)),
@@ -140,7 +148,11 @@ impl SignerClient {
                 format!("coordinator error: {message}"),
             )),
             Ok(_) => Ok(None),
-            Err(ref e) if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut => Ok(None),
+            Err(ref e)
+                if e.kind() == io::ErrorKind::WouldBlock || e.kind() == io::ErrorKind::TimedOut =>
+            {
+                Ok(None)
+            }
             Err(e) => Err(e),
         }
     }
@@ -156,7 +168,10 @@ impl SignerClient {
         let resp = recv_message(&mut self.stream)?;
         match resp {
             ProtocolMessage::Status { state, .. } => Ok(state),
-            _ => Err(io::Error::new(io::ErrorKind::InvalidData, "unexpected status response")),
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "unexpected status response",
+            )),
         }
     }
 }

--- a/crates/confium-tc/src/coordinator/coordinator.rs
+++ b/crates/confium-tc/src/coordinator/coordinator.rs
@@ -10,6 +10,12 @@ use chrono::{DateTime, Duration, Utc};
 
 /// A single signing session managed by the coordinator.
 pub struct CoordinatorSession {
+    // The session id is currently only surfaced in diagnostic output;
+    // production callers retrieve it via the surrounding coordinator's
+    // session map. Retained on the struct so future per-session APIs
+    // (audit correlation, retry idempotency) can use it without a
+    // breaking change.
+    #[allow(dead_code)]
     pub(crate) id: SessionId,
     pub(crate) request: SessionRequest,
     pub(crate) state: SessionState,
@@ -90,7 +96,8 @@ impl Coordinator {
 
         if !session.is_unlocked(Utc::now()) {
             session.state = SessionState::Expired;
-            self.audit_log.append(session_id.to_string(), AuditEvent::Expired);
+            self.audit_log
+                .append(session_id.to_string(), AuditEvent::Expired);
             return Err(SessionError::Expired(session_id.into()));
         }
 
@@ -128,11 +135,7 @@ impl Coordinator {
     }
 
     /// Submit a share to a session.
-    pub fn submit_share(
-        &mut self,
-        session_id: &str,
-        share: Share,
-    ) -> Result<(), SessionError> {
+    pub fn submit_share(&mut self, session_id: &str, share: Share) -> Result<(), SessionError> {
         let session = self
             .sessions
             .get_mut(session_id)
@@ -140,7 +143,8 @@ impl Coordinator {
 
         if !session.is_unlocked(Utc::now()) {
             session.state = SessionState::Expired;
-            self.audit_log.append(session_id.to_string(), AuditEvent::Expired);
+            self.audit_log
+                .append(session_id.to_string(), AuditEvent::Expired);
             return Err(SessionError::Expired(session_id.into()));
         }
 
@@ -154,7 +158,11 @@ impl Coordinator {
             });
         }
 
-        if session.shares.iter().any(|s| s.signer_id == share.signer_id) {
+        if session
+            .shares
+            .iter()
+            .any(|s| s.signer_id == share.signer_id)
+        {
             return Err(SessionError::DuplicateSubmission {
                 signer: share.signer_id.clone(),
                 session: session_id.into(),
@@ -206,7 +214,8 @@ impl Coordinator {
 
         session.state = SessionState::Completed;
         session.completed_at = Some(Utc::now());
-        self.audit_log.append(session_id.to_string(), AuditEvent::Aggregated);
+        self.audit_log
+            .append(session_id.to_string(), AuditEvent::Aggregated);
         Ok(sig)
     }
 
@@ -242,7 +251,9 @@ impl Coordinator {
 
     /// Get the message for a session.
     pub fn session_message(&self, session_id: &str) -> Option<&[u8]> {
-        self.sessions.get(session_id).map(|s| s.request.message.as_slice())
+        self.sessions
+            .get(session_id)
+            .map(|s| s.request.message.as_slice())
     }
 }
 
@@ -292,9 +303,14 @@ mod tests {
         let id = coord.create_session(sample_request()).unwrap();
         assert_eq!(coord.session_state(&id), Some(SessionState::Pending));
 
-        coord.submit_commitment(&id, commitment_for("alice")).unwrap();
+        coord
+            .submit_commitment(&id, commitment_for("alice"))
+            .unwrap();
         coord.submit_commitment(&id, commitment_for("bob")).unwrap();
-        assert_eq!(coord.session_state(&id), Some(SessionState::CommitmentsCollected));
+        assert_eq!(
+            coord.session_state(&id),
+            Some(SessionState::CommitmentsCollected)
+        );
 
         coord.submit_share(&id, share_for("alice")).unwrap();
         coord.submit_share(&id, share_for("bob")).unwrap();
@@ -309,9 +325,14 @@ mod tests {
     fn duplicate_commitment_rejected() {
         let mut coord = Coordinator::new();
         let id = coord.create_session(sample_request()).unwrap();
-        coord.submit_commitment(&id, commitment_for("alice")).unwrap();
+        coord
+            .submit_commitment(&id, commitment_for("alice"))
+            .unwrap();
         let result = coord.submit_commitment(&id, commitment_for("alice"));
-        assert!(matches!(result, Err(SessionError::DuplicateSubmission { .. })));
+        assert!(matches!(
+            result,
+            Err(SessionError::DuplicateSubmission { .. })
+        ));
     }
 
     #[test]
@@ -326,7 +347,9 @@ mod tests {
     fn audit_log_records_full_lifecycle() {
         let mut coord = Coordinator::new();
         let id = coord.create_session(sample_request()).unwrap();
-        coord.submit_commitment(&id, commitment_for("alice")).unwrap();
+        coord
+            .submit_commitment(&id, commitment_for("alice"))
+            .unwrap();
         coord.submit_commitment(&id, commitment_for("bob")).unwrap();
         coord.submit_share(&id, share_for("alice")).unwrap();
         coord.submit_share(&id, share_for("bob")).unwrap();

--- a/crates/confium-tc/src/coordinator/net.rs
+++ b/crates/confium-tc/src/coordinator/net.rs
@@ -8,7 +8,7 @@
 //! - Client → Coordinator: CreateSession, GetStatus
 //! - Coordinator → Client: SessionCreated, Signature, Error
 
-use crate::coordinator::session::{SignerId};
+use crate::coordinator::session::SignerId;
 use serde::{Deserialize, Serialize};
 use std::io::{self, Read, Write};
 use std::net::TcpStream;
@@ -162,7 +162,10 @@ mod tests {
         assert!(json.len() > 10);
         let recovered: ProtocolMessage = serde_json::from_slice(&json).unwrap();
         match recovered {
-            ProtocolMessage::Register { signer_id, quorum_id } => {
+            ProtocolMessage::Register {
+                signer_id,
+                quorum_id,
+            } => {
                 assert_eq!(signer_id, "alice");
                 assert_eq!(quorum_id, "test");
             }

--- a/crates/confium-tc/src/coordinator/net_server.rs
+++ b/crates/confium-tc/src/coordinator/net_server.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 use crate::coordinator::coordinator::Coordinator;
-use crate::coordinator::net::{send_message, recv_message, ProtocolMessage};
+use crate::coordinator::net::{ProtocolMessage, recv_message, send_message};
 use crate::coordinator::session::{Commitment, Share};
 use chrono::Utc;
 
@@ -62,10 +62,7 @@ impl CoordinatorServer {
     }
 }
 
-fn handle_connection(
-    mut stream: TcpStream,
-    coordinator: SharedCoordinator,
-) -> io::Result<()> {
+fn handle_connection(mut stream: TcpStream, coordinator: SharedCoordinator) -> io::Result<()> {
     loop {
         let msg = match recv_message(&mut stream) {
             Ok(m) => m,
@@ -88,11 +85,12 @@ fn process_message(
     coordinator: &SharedCoordinator,
 ) -> Option<ProtocolMessage> {
     match msg {
-        ProtocolMessage::Register { signer_id, quorum_id: _ } => {
-            Some(ProtocolMessage::Registered {
-                signer_id: signer_id.clone(),
-            })
-        }
+        ProtocolMessage::Register {
+            signer_id,
+            quorum_id: _,
+        } => Some(ProtocolMessage::Registered {
+            signer_id: signer_id.clone(),
+        }),
 
         ProtocolMessage::CreateSession {
             quorum_id,
@@ -112,11 +110,7 @@ fn process_message(
                 requested_by: "tcp-client".into(),
             };
             match coord.create_session(request) {
-                Ok(session_id) => {
-                    Some(ProtocolMessage::SessionCreated {
-                        session_id,
-                    })
-                }
+                Ok(session_id) => Some(ProtocolMessage::SessionCreated { session_id }),
                 Err(e) => Some(ProtocolMessage::Error {
                     message: format!("{e:?}"),
                 }),

--- a/crates/confium-tc/src/kem/session.rs
+++ b/crates/confium-tc/src/kem/session.rs
@@ -4,7 +4,7 @@
 //! Each party holds a share; T-of-N collaborate via the coordinator to
 //! decapsulate a shared secret that can then AEAD-decrypt the ciphertext.
 
-use crate::kem::encapsulate::{EncapsulatedKey, EncapsulateError};
+use crate::kem::encapsulate::{EncapsulateError, EncapsulatedKey};
 use crate::kem::share::ThresholdShare;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -123,8 +123,7 @@ impl KemSession {
 
     /// Submit a partial decryption from another party.
     pub fn submit_partial(&mut self, partial: PartialDecryption) -> Result<(), KemError> {
-        if self.state != KemSessionState::Pending && self.state != KemSessionState::Round1Complete
-        {
+        if self.state != KemSessionState::Pending && self.state != KemSessionState::Round1Complete {
             return Err(KemError::InvalidState {
                 current: self.state,
                 expected: "pending or round1_complete",

--- a/crates/confium-tc/src/lib.rs
+++ b/crates/confium-tc/src/lib.rs
@@ -28,8 +28,8 @@ pub mod session;
 pub mod share;
 
 pub mod coordinator;
-pub mod reshare;
 pub mod kem;
+pub mod reshare;
 
 pub use error::Error;
 pub use error::Result;

--- a/crates/confium-tc/src/reshare/session.rs
+++ b/crates/confium-tc/src/reshare/session.rs
@@ -57,6 +57,10 @@ pub enum ReshareState {
 pub struct ReshareSession {
     params: ReshareParams,
     state: ReshareState,
+    // Populated by `complete()`. Kept on the struct so a follow-up
+    // accessor (e.g. `new_shares()` returning the post-reshare share
+    // set per party) doesn't require an API break.
+    #[allow(dead_code)]
     new_shares: Vec<(u32, FieldElement)>,
     created_at: DateTime<Utc>,
 }
@@ -203,7 +207,10 @@ mod tests {
         params.old_threshold = 5;
         let mut session = ReshareSession::new(params);
         let result = session.mark_contributions_computed();
-        assert!(matches!(result, Err(ReshareError::InsufficientOldShares { .. })));
+        assert!(matches!(
+            result,
+            Err(ReshareError::InsufficientOldShares { .. })
+        ));
     }
 
     #[test]

--- a/crates/confium-tc/tests/e2e_network.rs
+++ b/crates/confium-tc/tests/e2e_network.rs
@@ -30,12 +30,11 @@ use std::time::Duration;
 
 use confium_tc::coordinator::{
     client::SignerClient,
-    net::{recv_message, send_message, ProtocolMessage},
+    net::{ProtocolMessage, recv_message, send_message},
     net_server::CoordinatorServer,
 };
 use confium_tc_frost_p256::{keys, scalar, shamir, sign};
-use p256::ecdsa::{signature::Verifier, Signature};
-
+use p256::ecdsa::{Signature, signature::Verifier};
 
 #[test]
 fn network_e2e_full_3_of_5_signing_ceremony() {
@@ -163,7 +162,9 @@ fn network_e2e_protocol_round_trip() {
 
     // Connect and register
     let mut client = SignerClient::connect(&addr).expect("connect");
-    client.register("test-signer", "test-quorum").expect("register");
+    client
+        .register("test-signer", "test-quorum")
+        .expect("register");
 
     // Create session
     let session_id = client
@@ -174,7 +175,10 @@ fn network_e2e_protocol_round_trip() {
 
     // Query status
     let state = client.get_status(&session_id).expect("status");
-    assert!(state.contains("Pending"), "new session should be Pending, got: {state}");
+    assert!(
+        state.contains("Pending"),
+        "new session should be Pending, got: {state}"
+    );
 
     println!("Protocol round-trip verified over real TCP");
 }
@@ -194,7 +198,9 @@ fn network_e2e_concurrent_connections() {
         let handle = thread::spawn(move || {
             let mut client = SignerClient::connect(&addr_clone).expect("connect");
             let signer_id = format!("concurrent-{i}");
-            client.register(&signer_id, "test-quorum").expect("register");
+            client
+                .register(&signer_id, "test-quorum")
+                .expect("register");
             signer_id
         });
         handles.push(handle);
@@ -228,13 +234,19 @@ fn network_e2e_session_lifecycle_over_tcp() {
     let msg_clone = message.to_vec();
     let handle1 = thread::spawn(move || {
         let mut client = SignerClient::connect(&addr1).expect("connect");
-        client.register("signer-1", "lifecycle-quorum").expect("register");
+        client
+            .register("signer-1", "lifecycle-quorum")
+            .expect("register");
         let sid = client
             .create_session("lifecycle-quorum", "FROST-P256", &msg_clone, 2, 3)
             .expect("create");
-        client.submit_commitment(&sid, "signer-1", &share1).expect("commitment");
+        client
+            .submit_commitment(&sid, "signer-1", &share1)
+            .expect("commitment");
         thread::sleep(Duration::from_millis(200));
-        client.submit_share(&sid, "signer-1", &share1).expect("share");
+        client
+            .submit_share(&sid, "signer-1", &share1)
+            .expect("share");
         sid
     });
 
@@ -243,9 +255,13 @@ fn network_e2e_session_lifecycle_over_tcp() {
     let share2 = scalar::scalar_to_bytes(&shares[1].y).to_vec();
     let handle2 = thread::spawn(move || {
         let mut client = SignerClient::connect(&addr2).expect("connect");
-        client.register("signer-2", "lifecycle-quorum").expect("register");
+        client
+            .register("signer-2", "lifecycle-quorum")
+            .expect("register");
         thread::sleep(Duration::from_millis(100)); // wait for session creation
-        client.submit_commitment("session-0", "signer-2", &share2).expect("commitment");
+        client
+            .submit_commitment("session-0", "signer-2", &share2)
+            .expect("commitment");
         thread::sleep(Duration::from_millis(200));
         // This submit_share should trigger aggregation (2nd share for T=2)
         let result = client.submit_share("session-0", "signer-2", &share2);

--- a/crates/confium-tc/tests/e2e_threshold_signing.rs
+++ b/crates/confium-tc/tests/e2e_threshold_signing.rs
@@ -23,19 +23,14 @@
 //! - Threshold enforcement (3-of-5, not 2-of-5)
 //! - Real P-256 ECDSA signature production and verification
 
+use chrono::Utc;
 use confium_tc::coordinator::{
+    Commitment, Coordinator, Share,
     audit::AuditEvent,
     session::{SessionRequest, SessionState},
-    Coordinator, Commitment, Share,
 };
-use confium_tc_frost_p256::{
-    keys,
-    shamir,
-    sign,
-    scalar,
-};
-use chrono::Utc;
-use p256::ecdsa::{signature::Verifier, Signature};
+use confium_tc_frost_p256::{keys, scalar, shamir, sign};
+use p256::ecdsa::{Signature, signature::Verifier};
 
 /// Simulate a distributed signer. Each signer:
 /// 1. Holds a Shamir share
@@ -70,7 +65,9 @@ impl SimulatedSigner {
             signer_signature: vec![0u8; 64], // Real protocol: signed by YubiKey identity key
             submitted_at: Utc::now(),
         };
-        coordinator.submit_commitment(session_id, commitment).unwrap();
+        coordinator
+            .submit_commitment(session_id, commitment)
+            .unwrap();
     }
 
     /// Simulate the signer submitting their signature share.
@@ -118,7 +115,10 @@ fn e2e_full_threshold_signing_ceremony_3_of_5() {
         requested_by: "e2e-test-harness".into(),
     };
     let session_id = coordinator.create_session(request).unwrap();
-    assert_eq!(coordinator.session_state(&session_id), Some(SessionState::Pending));
+    assert_eq!(
+        coordinator.session_state(&session_id),
+        Some(SessionState::Pending)
+    );
 
     // ================================================================
     // Phase 4: Simulate 5 distributed signers
@@ -158,7 +158,10 @@ fn e2e_full_threshold_signing_ceremony_3_of_5() {
     // Phase 7: Coordinator aggregates into final signature
     // ================================================================
     let aggregated = coordinator.aggregate(&session_id).unwrap();
-    assert_eq!(coordinator.session_state(&session_id), Some(SessionState::Completed));
+    assert_eq!(
+        coordinator.session_state(&session_id),
+        Some(SessionState::Completed)
+    );
     assert_eq!(aggregated.contributing_signers.len(), 3);
 
     // ================================================================
@@ -182,9 +185,9 @@ fn e2e_full_threshold_signing_ceremony_3_of_5() {
     );
 
     // Verify specific event types are present
-    let has_session_created = audit_entries.iter().any(|e| {
-        matches!(&e.event, AuditEvent::SessionCreated { .. })
-    });
+    let has_session_created = audit_entries
+        .iter()
+        .any(|e| matches!(&e.event, AuditEvent::SessionCreated { .. }));
     assert!(has_session_created, "audit log must contain SessionCreated");
 
     let commitment_count = audit_entries
@@ -272,12 +275,18 @@ fn e2e_async_participation_pattern() {
     // Signer 1 participates immediately
     let s1 = SimulatedSigner::new(0, shares[0].clone(), true);
     s1.submit_commitment(&mut coordinator, &session_id);
-    assert_eq!(coordinator.session_state(&session_id), Some(SessionState::Pending));
+    assert_eq!(
+        coordinator.session_state(&session_id),
+        Some(SessionState::Pending)
+    );
 
     // ... hours pass ... (signer 2 in different time zone)
     let s2 = SimulatedSigner::new(1, shares[1].clone(), true);
     s2.submit_commitment(&mut coordinator, &session_id);
-    assert_eq!(coordinator.session_state(&session_id), Some(SessionState::Pending));
+    assert_eq!(
+        coordinator.session_state(&session_id),
+        Some(SessionState::Pending)
+    );
 
     // ... more hours pass ... (signer 3 finally available)
     let s3 = SimulatedSigner::new(2, shares[2].clone(), true);
@@ -295,7 +304,10 @@ fn e2e_async_participation_pattern() {
 
     let aggregated = coordinator.aggregate(&session_id).unwrap();
     assert_eq!(aggregated.contributing_signers.len(), 3);
-    assert_eq!(coordinator.session_state(&session_id), Some(SessionState::Completed));
+    assert_eq!(
+        coordinator.session_state(&session_id),
+        Some(SessionState::Completed)
+    );
 }
 
 #[test]

--- a/crates/confium-tc/tests/integration.rs
+++ b/crates/confium-tc/tests/integration.rs
@@ -3,12 +3,12 @@
 //! Verifies that all four areas (session primitives, coordinator, reshare,
 //! kem) work together via the public API.
 
-use confium_tc::coordinator::{
-    session::{SessionRequest, SessionState, SignerId},
-    Coordinator, Commitment, Share,
-};
-use confium_tc::reshare::{lagrange, RefreshContribution};
 use chrono::Utc;
+use confium_tc::coordinator::{
+    Commitment, Coordinator, Share,
+    session::{SessionRequest, SessionState, SignerId},
+};
+use confium_tc::reshare::{RefreshContribution, lagrange};
 
 fn sample_session_request() -> SessionRequest {
     SessionRequest {
@@ -31,9 +31,16 @@ fn coordinator_full_session_lifecycle() {
     let alice: SignerId = "alice".into();
     let bob: SignerId = "bob".into();
 
-    coord.submit_commitment(&id, sample_commitment(&alice)).unwrap();
-    coord.submit_commitment(&id, sample_commitment(&bob)).unwrap();
-    assert_eq!(coord.session_state(&id), Some(SessionState::CommitmentsCollected));
+    coord
+        .submit_commitment(&id, sample_commitment(&alice))
+        .unwrap();
+    coord
+        .submit_commitment(&id, sample_commitment(&bob))
+        .unwrap();
+    assert_eq!(
+        coord.session_state(&id),
+        Some(SessionState::CommitmentsCollected)
+    );
 
     coord.submit_share(&id, sample_share(&alice)).unwrap();
     coord.submit_share(&id, sample_share(&bob)).unwrap();
@@ -47,10 +54,18 @@ fn coordinator_full_session_lifecycle() {
 fn coordinator_audit_records_lifecycle() {
     let mut coord = Coordinator::new();
     let id = coord.create_session(sample_session_request()).unwrap();
-    coord.submit_commitment(&id, sample_commitment(&"alice".into())).unwrap();
-    coord.submit_commitment(&id, sample_commitment(&"bob".into())).unwrap();
-    coord.submit_share(&id, sample_share(&"alice".into())).unwrap();
-    coord.submit_share(&id, sample_share(&"bob".into())).unwrap();
+    coord
+        .submit_commitment(&id, sample_commitment(&"alice".into()))
+        .unwrap();
+    coord
+        .submit_commitment(&id, sample_commitment(&"bob".into()))
+        .unwrap();
+    coord
+        .submit_share(&id, sample_share(&"alice".into()))
+        .unwrap();
+    coord
+        .submit_share(&id, sample_share(&"bob".into()))
+        .unwrap();
     coord.aggregate(&id).unwrap();
 
     let entries = coord.audit_log().entries_for(&id);
@@ -61,17 +76,19 @@ fn coordinator_audit_records_lifecycle() {
 fn reshare_lagrange_interpolates_correctly() {
     // Integer arithmetic helpers for testing
     let points = vec![
-        (1u64, lagrange::FieldElement::new(5i128.to_be_bytes().to_vec())),
-        (2u64, lagrange::FieldElement::new(7i128.to_be_bytes().to_vec())),
+        (
+            1u64,
+            lagrange::FieldElement::new(5i128.to_be_bytes().to_vec()),
+        ),
+        (
+            2u64,
+            lagrange::FieldElement::new(7i128.to_be_bytes().to_vec()),
+        ),
     ];
-    let result = lagrange::interpolate_at(
-        &points,
-        0,
-        &|x| x,
-        &|a, b| a * b,
-        &|a, b| a + b,
-        &|a, b| if b == 0 { i128::MAX } else { a / b },
-    );
+    let result =
+        lagrange::interpolate_at(&points, 0, &|x| x, &|a, b| a * b, &|a, b| a + b, &|a, b| {
+            if b == 0 { i128::MAX } else { a / b }
+        });
     let recovered = i128::from_be_bytes(result.0[..16].try_into().unwrap());
     assert_eq!(recovered, 3); // y = 2x + 3, at x=0 y=3
 }

--- a/crates/confium-tls-signer/src/lib.rs
+++ b/crates/confium-tls-signer/src/lib.rs
@@ -67,7 +67,12 @@ pub enum TlsSignerError {
 /// Signer hook — caller provides concrete threshold signing backend.
 pub trait ThresholdSigner {
     /// Sign `data` using the quorum's threshold key.
-    fn sign(&self, quorum_id: &str, scheme: SignatureScheme, data: &[u8]) -> Result<Vec<u8>, String>;
+    fn sign(
+        &self,
+        quorum_id: &str,
+        scheme: SignatureScheme,
+        data: &[u8],
+    ) -> Result<Vec<u8>, String>;
 }
 
 /// The TLS signer.

--- a/crates/confium-transparency/src/entry.rs
+++ b/crates/confium-transparency/src/entry.rs
@@ -44,11 +44,7 @@ pub struct MerkleEntry {
 
 impl MerkleEntry {
     /// Construct a new entry with the current timestamp.
-    pub fn new(
-        sequence: u64,
-        artifact_type: ArtifactType,
-        artifact_hash: [u8; 32],
-    ) -> Self {
+    pub fn new(sequence: u64, artifact_type: ArtifactType, artifact_hash: [u8; 32]) -> Self {
         Self {
             sequence,
             timestamp: Utc::now(),

--- a/crates/confium-transparency/src/ers/mod.rs
+++ b/crates/confium-transparency/src/ers/mod.rs
@@ -157,19 +157,8 @@ mod tests {
 
     #[test]
     fn renew_adds_sequence() {
-        let mut r = build_initial_evidence_record(
-            [1u8; 32],
-            HashAlgorithm::Sha256,
-            "tsa",
-            vec![],
-        );
-        renew_evidence_record(
-            &mut r,
-            HashAlgorithm::Sha384,
-            [2u8; 32],
-            "tsa2",
-            vec![],
-        );
+        let mut r = build_initial_evidence_record([1u8; 32], HashAlgorithm::Sha256, "tsa", vec![]);
+        renew_evidence_record(&mut r, HashAlgorithm::Sha384, [2u8; 32], "tsa2", vec![]);
         assert_eq!(renewal_count(&r), 2);
         assert_eq!(r.digest_algorithms.len(), 2);
     }

--- a/crates/confium-transparency/src/lib.rs
+++ b/crates/confium-transparency/src/lib.rs
@@ -18,9 +18,9 @@
 #![warn(missing_docs)]
 
 pub mod entry;
+pub mod ers;
 pub mod merkle;
 pub mod ots;
-pub mod ers;
 pub mod proof;
 
 pub use entry::*;

--- a/crates/confium-transparency/src/merkle.rs
+++ b/crates/confium-transparency/src/merkle.rs
@@ -187,10 +187,7 @@ impl MerkleTree {
             level = next;
             idx /= 2;
         }
-        Ok(InclusionProof {
-            sequence,
-            steps,
-        })
+        Ok(InclusionProof { sequence, steps })
     }
 
     /// Verify an inclusion proof (RFC 6962 §2.1.1).
@@ -330,7 +327,8 @@ mod consistency_tests {
     fn build_tree(n: usize) -> MerkleTree {
         let mut tree = MerkleTree::new();
         for i in 0..n {
-            let entry = MerkleEntry::new(i as u64, ArtifactType::CertificateIssuance, [i as u8; 32]);
+            let entry =
+                MerkleEntry::new(i as u64, ArtifactType::CertificateIssuance, [i as u8; 32]);
             tree.append(entry);
         }
         tree
@@ -382,11 +380,27 @@ mod tests {
         let mut tree1 = MerkleTree::new();
         let mut tree2 = MerkleTree::new();
 
-        tree1.append(MerkleEntry::new(0, ArtifactType::CertificateIssuance, [1u8; 32]));
-        tree1.append(MerkleEntry::new(1, ArtifactType::CertificateIssuance, [2u8; 32]));
+        tree1.append(MerkleEntry::new(
+            0,
+            ArtifactType::CertificateIssuance,
+            [1u8; 32],
+        ));
+        tree1.append(MerkleEntry::new(
+            1,
+            ArtifactType::CertificateIssuance,
+            [2u8; 32],
+        ));
 
-        tree2.append(MerkleEntry::new(0, ArtifactType::CertificateIssuance, [1u8; 32]));
-        tree2.append(MerkleEntry::new(1, ArtifactType::CertificateIssuance, [3u8; 32]));
+        tree2.append(MerkleEntry::new(
+            0,
+            ArtifactType::CertificateIssuance,
+            [1u8; 32],
+        ));
+        tree2.append(MerkleEntry::new(
+            1,
+            ArtifactType::CertificateIssuance,
+            [3u8; 32],
+        ));
 
         assert_ne!(tree1.root(), tree2.root());
     }
@@ -438,8 +452,7 @@ mod tests {
         let root = tree.root();
         for i in 0..8 {
             let proof = tree.inclusion_proof(i).unwrap();
-            MerkleTree::verify_inclusion(&entries[i as usize], &proof, root)
-                .expect("must verify");
+            MerkleTree::verify_inclusion(&entries[i as usize], &proof, root).expect("must verify");
         }
     }
 

--- a/crates/confium-transparency/src/ots/client.rs
+++ b/crates/confium-transparency/src/ots/client.rs
@@ -121,10 +121,7 @@ mod tests {
         let client = OtsClient::new();
         let hash = [1u8; 32];
         let proof = OtsProof::new(hash, 800_000);
-        let result = client
-            .verify(&proof, |_| Ok([0u8; 32]))
-            .await
-            .unwrap();
+        let result = client.verify(&proof, |_| Ok([0u8; 32])).await.unwrap();
         assert!(result.valid);
     }
 }

--- a/crates/confium-transparency/tests/integration.rs
+++ b/crates/confium-transparency/tests/integration.rs
@@ -9,8 +9,7 @@ use confium_transparency::{
 fn make_entry(seq: u64, hash_byte: u8) -> MerkleEntry {
     let mut e = MerkleEntry::new(seq, ArtifactType::CertificateIssuance, [hash_byte; 32]);
     // Make timestamps deterministic for tests that compare roots.
-    e.timestamp = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 1, 1, 0, 0, 0)
-        .unwrap();
+    e.timestamp = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 1, 1, 0, 0, 0).unwrap();
     e
 }
 

--- a/crates/confium-wasm/src/attributes.rs
+++ b/crates/confium-wasm/src/attributes.rs
@@ -1,7 +1,8 @@
 //! `Predicate` — attribute-based threshold policy DSL, browser-side evaluate-only.
 
-use confium_attributes::{evaluate, parse as dsl_parse, Predicate as RustPredicate,
-    SignerAttributes};
+use confium_attributes::{
+    Predicate as RustPredicate, SignerAttributes, evaluate, parse as dsl_parse,
+};
 use wasm_bindgen::prelude::*;
 
 /// Parsed DSL predicate. Construct via [`Predicate::parse`] and evaluate

--- a/crates/confium-wasm/src/composite.rs
+++ b/crates/confium-wasm/src/composite.rs
@@ -76,11 +76,10 @@ impl CompositeSignature {
 /// key (compressed 33 bytes or uncompressed 65 bytes). `signature` is
 /// DER-encoded. SHA-256 is used as the digest.
 fn p256_verifier(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), String> {
-    use p256::ecdsa::{signature::Verifier, Signature, VerifyingKey};
+    use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
     let vk = VerifyingKey::from_sec1_bytes(public_key)
         .map_err(|e| format!("invalid P-256 public key: {e}"))?;
-    let sig = Signature::from_der(signature)
-        .map_err(|e| format!("invalid DER signature: {e}"))?;
+    let sig = Signature::from_der(signature).map_err(|e| format!("invalid DER signature: {e}"))?;
     vk.verify(message, &sig).map_err(|e| format!("verify: {e}"))
 }
 
@@ -112,7 +111,10 @@ impl CompositeVerificationResult {
             .map(|c| {
                 let alg = serde_json::to_string(&c.algorithm).unwrap_or_else(|_| "\"\"".into());
                 let err = match &c.error {
-                    Some(e) => format!(",\"error\":{}", serde_json::to_string(e).unwrap_or_else(|_| "null".into())),
+                    Some(e) => format!(
+                        ",\"error\":{}",
+                        serde_json::to_string(e).unwrap_or_else(|_| "null".into())
+                    ),
                     None => String::new(),
                 };
                 format!(

--- a/crates/confium-wasm/src/lib.rs
+++ b/crates/confium-wasm/src/lib.rs
@@ -23,8 +23,8 @@ mod transparency;
 
 #[cfg(feature = "verify-transparency")]
 pub use transparency::{
-    compute_artifact_hash, compute_leaf_hash, tree_head_from_json, verify_inclusion_with_head,
-    InclusionProof, MerkleTree,
+    InclusionProof, MerkleTree, compute_artifact_hash, compute_leaf_hash, tree_head_from_json,
+    verify_inclusion_with_head,
 };
 
 #[cfg(feature = "verify-attributes")]

--- a/crates/confium-wasm/src/pki.rs
+++ b/crates/confium-wasm/src/pki.rs
@@ -1,10 +1,7 @@
 //! `Certificate` + `CMS::SignedData` — PKI verifiers for the browser/Node.js
 //! surface.
 
-use confium_pki::{
-    cert::Certificate as RustCert,
-    cms::SignedData as RustSignedData,
-};
+use confium_pki::{cert::Certificate as RustCert, cms::SignedData as RustSignedData};
 use wasm_bindgen::prelude::*;
 
 /// Parsed X.509 v3 certificate. Construct via [`Certificate::from_der`] or

--- a/crates/confium-wasm/src/transparency.rs
+++ b/crates/confium-wasm/src/transparency.rs
@@ -119,12 +119,8 @@ impl InclusionProof {
         let mut current = self.leaf_hash;
         for step in &self.inner.steps {
             current = match step.side {
-                confium_transparency::merkle::Side::Left => {
-                    hash_internal(step.sibling, current)
-                }
-                confium_transparency::merkle::Side::Right => {
-                    hash_internal(current, step.sibling)
-                }
+                confium_transparency::merkle::Side::Left => hash_internal(step.sibling, current),
+                confium_transparency::merkle::Side::Right => hash_internal(current, step.sibling),
             };
         }
         Ok(current == root_arr)
@@ -185,11 +181,7 @@ pub fn compute_artifact_hash(artifact_bytes: &[u8]) -> Vec<u8> {
 ///
 /// 32-byte leaf hash as `Uint8Array`.
 #[wasm_bindgen]
-pub fn compute_leaf_hash(
-    sequence: u64,
-    timestamp_ms: f64,
-    artifact_bytes: &[u8],
-) -> Vec<u8> {
+pub fn compute_leaf_hash(sequence: u64, timestamp_ms: f64, artifact_bytes: &[u8]) -> Vec<u8> {
     use sha2::{Digest, Sha256};
     // entry_hash = SHA-256(sequence_le || timestamp_micros_le || artifact_hash)
     let artifact_hash = {

--- a/crates/confium-wasm/tests/wasm_smoke.rs
+++ b/crates/confium-wasm/tests/wasm_smoke.rs
@@ -60,7 +60,10 @@ fn merkle_inclusion_proof_round_trip() {
     for seq in seqs {
         let proof = tree.inclusion_proof(seq).unwrap();
         assert_eq!(proof.sequence(), seq);
-        assert!(proof.verify(&root).unwrap(), "inclusion proof for seq {seq} must verify");
+        assert!(
+            proof.verify(&root).unwrap(),
+            "inclusion proof for seq {seq} must verify"
+        );
     }
 }
 
@@ -123,9 +126,9 @@ fn compute_artifact_hash_is_sha256() {
     let h = compute_artifact_hash(b"hello");
     // SHA-256("hello") = 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824
     let expected = [
-        0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0x0e, 0x26, 0xe8, 0x3b, 0x2a, 0xc5, 0xb9,
-        0xe2, 0x9e, 0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7, 0x42, 0x5e, 0x73, 0x04, 0x33, 0x62, 0x93,
-        0x8b, 0x98, 0x24,
+        0x2c, 0xf2, 0x4d, 0xba, 0x5f, 0xb0, 0xa3, 0x0e, 0x26, 0xe8, 0x3b, 0x2a, 0xc5, 0xb9, 0xe2,
+        0x9e, 0x1b, 0x16, 0x1e, 0x5c, 0x1f, 0xa7, 0x42, 0x5e, 0x73, 0x04, 0x33, 0x62, 0x93, 0x8b,
+        0x98, 0x24,
     ];
     assert_eq!(h, expected);
 }
@@ -147,7 +150,11 @@ fn compute_leaf_hash_round_trips_through_inclusion_proof() {
     let proof_json = format!(r#"{{"sequence":{seq},"steps":[]}}"#);
     let head_json = format!(
         r#"{{"size":1,"root":[{}]}}"#,
-        tree.root().iter().map(|b| format!("{b}")).collect::<Vec<_>>().join(",")
+        tree.root()
+            .iter()
+            .map(|b| format!("{b}"))
+            .collect::<Vec<_>>()
+            .join(",")
     );
     // For a 1-leaf tree, root == hash_leaf(entry_hash) == leaf_hash.
     // So verify_inclusion_with_head(leaf_hash, proof, head) should be true.

--- a/typos.toml
+++ b/typos.toml
@@ -26,3 +26,19 @@ botan = "botan"
 adoc = "adoc"
 asciidoc = "asciidoc"
 AsciiDoc = "AsciiDoc"
+
+# Compound-word forms that typos splits into incorrect parts.
+hashicorpvault = "hashicorpvault"
+certificat = "certificat"
+cose = "cose"
+gost = "gost"
+
+[default.extend-identifiers]
+# PascalCase / camelCase forms that typos' word segmentation heuristic
+# splits into bogus parts (e.g. "HashiCorp" → "Hashi" + "Corp", then
+# flags "Hashi" as a typo of "Hash"). Listing the full identifier
+# here tells typos to skip segmentation for these tokens.
+HashiCorp  = "HashiCorp"
+Certificat = "Certificat"
+COSE       = "COSE"
+GOST       = "GOST"


### PR DESCRIPTION
## Summary

Unblocks every PR currently requiring `--admin` to merge. Three orthogonal fixes:

1. **Real typos** — `determinstic` and `unparseable` in source comments + TODO.roadmap files.
2. **Proper-name allowlist** — `_typos.toml` so `HashiCorp` (brand) and `Certificat` (French in CNML proper name) stop firing false positives on every PR.
3. **Dead-code allow** — the two fields `confium-tc` flags (`id` on `CoordinatorSession`, `new_shares` on `ReshareSession`) are documented API surface for future per-session APIs. Annotated with `#[allow(dead_code)]` plus an explanatory comment.
4. **rustfmt drift** — `cargo fmt --all` across 59 files (no semantics change).

## Test plan

- [x] `cargo fmt --all --check` clean.
- [x] `cargo build --workspace` clean (no warnings).
- [x] `cargo test --workspace --no-fail-fast` passes (modulo the pre-existing `librnp.0.dylib` environment issue in `confium-store-openpgp-card`, which is unrelated).
- [x] `typos` passes locally with the new `_typos.toml`.

## Why this matters

Without this fix, every Python/Ruby/WASM binding PR lands via `--admin` merge with red CI, masking real regressions. This PR gets CI back to green on main so future PRs can be reviewed normally.
