### PR TITLE
feat(python): composite sign + CMS build/sign + DER encode

### DIFF
--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -263,6 +263,28 @@ pub fn build_ed25519_component(
     })
 }
 
+/// Build a real ECDSA-P256 component signature (NIST P-256 over SHA-256).
+/// The signature is DER-encoded per RFC 5480; the public key is SEC1
+/// (uncompressed, 65 bytes).
+///
+/// Sibling to [`build_ed25519_component`]. Use both to construct a
+/// hybrid classical-classical composite, or pair either with an
+/// ML-DSA component for PQ migration.
+pub fn build_p256_component(
+    signing_key: &p256::ecdsa::SigningKey,
+    message: &[u8],
+) -> Result<ComponentSignature, CompositeError> {
+    use p256::ecdsa::signature::Signer;
+    let verifying = signing_key.verifying_key();
+    let sig: p256::ecdsa::Signature = signing_key.sign(message);
+    let sig_der = sig.to_der();
+    Ok(ComponentSignature {
+        algorithm: ECDSA_P256.into(),
+        public_key: verifying.to_sec1_bytes().to_vec(),
+        signature: sig_der.to_bytes().to_vec(),
+    })
+}
+
 #[cfg(test)]
 mod real_ed25519_tests {
     use super::*;

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 confium-core = "0.2"
-confium-composite = "0.3.1"
+confium-composite = { path = "../confium-composite", version = "0.3.1" }
 confium-transparency = "0.3.1"
 confium-pki = { version = "0.3.1", features = ["cms"] }
 confium-attributes = "0.3.1"
@@ -27,6 +27,8 @@ serde_json = "1"
 sha2 = "0.10"
 chrono = "0.4"
 hex = "0.4"
+ed25519-dalek = "2"
+p256 = { version = "0.13", features = ["ecdsa"] }
 
 [package.metadata.maturin]
 python-source = "python"

--- a/crates/confium-python/src/composite.rs
+++ b/crates/confium-python/src/composite.rs
@@ -100,6 +100,70 @@ impl CompositeSignature {
         })
     }
 
+    /// Sign `message` with an Ed25519 private key (32 raw bytes).
+    ///
+    /// Returns a fresh `CompositeSignature` containing a single
+    /// Ed25519 component. Use `sign_p256` for ECDSA-P256, or compose
+    /// the components manually for a hybrid.
+    #[staticmethod]
+    fn sign_ed25519<'py>(
+        py: Python<'py>,
+        private_key: &Bound<'py, PyBytes>,
+        message: &Bound<'py, PyBytes>,
+    ) -> PyResult<Self> {
+        let pk_bytes = private_key.as_bytes();
+        if pk_bytes.len() != 32 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "Ed25519 private key must be 32 bytes (got {})",
+                pk_bytes.len()
+            )));
+        }
+        let mut seed = [0u8; 32];
+        seed.copy_from_slice(pk_bytes);
+        let signing = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let msg = message.as_bytes().to_vec();
+        let component = py
+            .allow_threads(move || {
+                confium_composite::build_ed25519_component(&signing, &msg)
+            })
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self {
+            inner: confium_composite::CompositeSignature::new(vec![component]),
+        })
+    }
+
+    /// Sign `message` with an ECDSA-P256 private key (32 raw bytes).
+    ///
+    /// Returns a fresh `CompositeSignature` with one P-256 component
+    /// (DER-encoded signature, SEC1 uncompressed public key).
+    #[staticmethod]
+    fn sign_p256<'py>(
+        py: Python<'py>,
+        private_key: &Bound<'py, PyBytes>,
+        message: &Bound<'py, PyBytes>,
+    ) -> PyResult<Self> {
+        let pk_bytes = private_key.as_bytes();
+        if pk_bytes.len() != 32 {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "P-256 private key must be 32 bytes (got {})",
+                pk_bytes.len()
+            )));
+        }
+        let signing = p256::ecdsa::SigningKey::from_bytes(pk_bytes.into())
+            .map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("invalid P-256 key: {e}"))
+            })?;
+        let msg = message.as_bytes().to_vec();
+        let component = py
+            .allow_threads(move || {
+                confium_composite::build_p256_component(&signing, &msg)
+            })
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self {
+            inner: confium_composite::CompositeSignature::new(vec![component]),
+        })
+    }
+
     /// Parse a composite signature from a JSON string.
     ///
     /// The JSON shape mirrors the on-the-wire composite envelope:

--- a/crates/confium-python/src/pki.rs
+++ b/crates/confium-python/src/pki.rs
@@ -16,7 +16,10 @@ use pyo3::Bound;
 
 use confium_pki::{
     cert::{Certificate as RustCert, CertificateSigningRequest as RustCsr, CertError},
-    cms::{verify_signed_data, SignerVerification, SignedData as RustSignedData},
+    cms::{
+        build_detached_signature, encode_signed_data_der, verify_signed_data, SignerVerification,
+        SignedData as RustSignedData,
+    },
 };
 
 fn map_cert_err(e: CertError) -> PyErr {
@@ -176,6 +179,42 @@ impl PySignedData {
             pyo3::exceptions::PyValueError::new_err(format!("invalid SignedData JSON: {e}"))
         })?;
         Ok(Self { inner })
+    }
+
+    /// Build a detached CMS SignedData with one signer.
+    ///
+    /// Args:
+    ///     signature:     bytes — pre-computed signature over the payload.
+    ///     algorithm:     str   — signature algorithm OID
+    ///                          (Ed25519 = "1.3.101.112",
+    ///                           ECDSA-P256 = "1.2.840.10045.4.3.2").
+    ///     certificates:  list[bytes] — DER cert bytes per signer.
+    ///
+    /// The caller signs the payload separately (typically via
+    /// `composite.CompositeSignature.sign_ed25519`) and passes the
+    /// resulting signature bytes here. The first certificate's first
+    /// 20 bytes become the SubjectKeyIdentifier per RFC 5652 §5.3.
+    #[staticmethod]
+    fn build_detached(
+        signature: Vec<u8>,
+        algorithm: String,
+        certificates: Vec<Vec<u8>>,
+    ) -> PyResult<Self> {
+        let inner =
+            build_detached_signature(Vec::new(), &algorithm, signature, certificates)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(Self { inner })
+    }
+
+    /// Encode as RFC 5652 ContentInfo DER bytes.
+    ///
+    /// Output is parseable by `openssl cms` / `openssl pkcs7` and any
+    /// standards-compliant CMS consumer.
+    fn to_der<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyBytes>> {
+        let der = py
+            .allow_threads(|| encode_signed_data_der(&self.inner))
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        Ok(PyBytes::new_bound(py, &der))
     }
 
     /// Serialize back to a JSON string.

--- a/crates/confium-python/tests/test_binding.py
+++ b/crates/confium-python/tests/test_binding.py
@@ -331,6 +331,99 @@ def test_builtin_ecdsa_p256_verifier_function() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Composite signing (sign_ed25519 + sign_p256)
+# ---------------------------------------------------------------------------
+
+def test_sign_ed25519_round_trip() -> None:
+    seed = b"\x42" * 32
+    msg = b"composite sign round-trip"
+    cs = composite.CompositeSignature.sign_ed25519(seed, msg)
+    assert cs.component_count() == 1
+    assert cs.algorithms() == ["Ed25519"]
+    assert cs.verify(msg).all_verified is True
+
+
+def test_sign_ed25519_rejects_short_key() -> None:
+    with pytest.raises(ValueError, match="32 bytes"):
+        composite.CompositeSignature.sign_ed25519(b"\x00" * 10, b"msg")
+
+
+def test_sign_ed25519_tampered_message_fails() -> None:
+    seed = b"\x99" * 32
+    cs = composite.CompositeSignature.sign_ed25519(seed, b"original")
+    assert cs.verify(b"tampered").all_verified is False
+
+
+def test_sign_ed25519_pubkey_matches_seed() -> None:
+    """The seed-derived verifying key matches what the cryptography lib expects."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.serialization import (
+        Encoding,
+        PublicFormat,
+    )
+    import json as _json
+
+    seed = b"\x55" * 32
+    cs = composite.CompositeSignature.sign_ed25519(seed, b"msg")
+    expected_pk = Ed25519PrivateKey.from_private_bytes(seed).public_key().public_bytes(
+        Encoding.Raw, PublicFormat.Raw
+    )
+    component = _json.loads(cs.to_json())["components"][0]
+    assert bytes(component["public_key"]) == expected_pk
+
+
+def test_sign_p256_round_trip() -> None:
+    seed = b"\x33" * 32
+    msg = b"p256 sign round-trip"
+    cs = composite.CompositeSignature.sign_p256(seed, msg)
+    assert cs.component_count() == 1
+    assert cs.algorithms() == ["ECDSA-P256"]
+    assert cs.verify(msg).all_verified is True
+
+
+def test_sign_p256_rejects_short_key() -> None:
+    with pytest.raises(ValueError, match="32 bytes"):
+        composite.CompositeSignature.sign_p256(b"\x00" * 16, b"msg")
+
+
+def test_sign_p256_signature_is_der_encoded() -> None:
+    """ECDSA-P256 components must DER-encode the signature (RFC 5480)."""
+    import json as _json
+
+    seed = b"\x22" * 32
+    cs = composite.CompositeSignature.sign_p256(seed, b"der check")
+    component = _json.loads(cs.to_json())["components"][0]
+    sig_bytes = bytes(component["signature"])
+    assert sig_bytes[0] == 0x30  # DER SEQUENCE
+
+
+def test_hybrid_ed25519_plus_p256_via_sign() -> None:
+    """End-to-end: build a hybrid from two sign() calls."""
+    import json as _json
+
+    ed_seed = b"\x10" * 32
+    p256_seed = b"\x20" * 32
+    msg = b"hybrid via sign + manual compose"
+
+    ed_cs = composite.CompositeSignature.sign_ed25519(ed_seed, msg)
+    p256_cs = composite.CompositeSignature.sign_p256(p256_seed, msg)
+
+    ed_comp = _json.loads(ed_cs.to_json())["components"][0]
+    p256_comp = _json.loads(p256_cs.to_json())["components"][0]
+    hybrid = composite.CompositeSignature.from_json(
+        _json.dumps({"components": [ed_comp, p256_comp]})
+    )
+
+    assert hybrid.component_count() == 2
+    result = hybrid.verify(msg)
+    assert result.all_verified is True
+    algs = sorted(c["algorithm"] for c in result.per_component)
+    assert algs == ["ECDSA-P256", "Ed25519"]
+
+
+# ---------------------------------------------------------------------------
 # Transparency log
 # ---------------------------------------------------------------------------
 
@@ -679,6 +772,81 @@ def test_signed_data_rejects_bad_json() -> None:
         pki.SignedData.from_json("not json")
     with pytest.raises(ValueError):
         pki.SignedData.from_json('{"wrong": "shape"}')
+
+
+# ---------------------------------------------------------------------------
+# CMS build/sign + DER encode
+# ---------------------------------------------------------------------------
+
+FAKE_CERT_DER = b"\x30\x82\x01\x00" + b"C" * 256  # ≥20 bytes for SKI extraction
+
+
+def _ed25519_signature_for(seed: bytes, message: bytes) -> bytes:
+    """Sign message with Ed25519 seed via CompositeSignature.sign_ed25519."""
+    cs = composite.CompositeSignature.sign_ed25519(seed, message)
+    return bytes(json.loads(cs.to_json())["components"][0]["signature"])
+
+
+def test_cms_build_detached_creates_one_signer() -> None:
+    sig = _ed25519_signature_for(b"\x42" * 32, b"payload")
+    sd = pki.SignedData.build_detached(sig, "1.3.101.112", [FAKE_CERT_DER])
+    assert sd.signer_count == 1
+    assert sd.certificate_count == 1
+
+
+def test_cms_build_detached_to_der_is_content_info() -> None:
+    sig = _ed25519_signature_for(b"\x42" * 32, b"payload")
+    sd = pki.SignedData.build_detached(sig, "1.3.101.112", [FAKE_CERT_DER])
+    der = sd.to_der()
+    assert der[0] == 0x30  # outer SEQUENCE per RFC 5652 §3
+    assert len(der) > 300
+
+
+def test_cms_build_detached_round_trips_json() -> None:
+    sig = _ed25519_signature_for(b"\x55" * 32, b"payload")
+    sd = pki.SignedData.build_detached(sig, "1.3.101.112", [FAKE_CERT_DER])
+    parsed = pki.SignedData.from_json(sd.to_json())
+    assert parsed.signer_count == 1
+
+
+def test_cms_build_detached_accepts_ecdsa_oid() -> None:
+    sig = _ed25519_signature_for(b"\x33" * 32, b"payload")
+    # The algorithm OID is just stored on the SignerInfo; sign() doesn't
+    # check that the signature matches the algorithm.
+    sd = pki.SignedData.build_detached(sig, "1.2.840.10045.4.3.2", [FAKE_CERT_DER])
+    assert sd.signer_count == 1
+
+
+def test_cms_build_detached_accepts_multiple_certs() -> None:
+    sig = _ed25519_signature_for(b"\x44" * 32, b"payload")
+    sd = pki.SignedData.build_detached(
+        sig, "1.3.101.112", [FAKE_CERT_DER, FAKE_CERT_DER, FAKE_CERT_DER]
+    )
+    assert sd.certificate_count == 3
+
+
+def test_cms_to_der_to_json_preserves_signatures() -> None:
+    """DER encode → parse via JSON → signer_infos signature unchanged."""
+    sig = _ed25519_signature_for(b"\x77" * 32, b"payload")
+    sd = pki.SignedData.build_detached(sig, "1.3.101.112", [FAKE_CERT_DER])
+    sd2 = pki.SignedData.from_json(sd.to_json())
+    sig2 = bytes(json.loads(sd2.to_json())["signer_infos"][0]["signature"])
+    assert sig2 == sig
+
+
+def test_cms_sign_then_anchor_in_transparency_log() -> None:
+    """End-to-end: sign Ed25519 → wrap in CMS → anchor in transparency log."""
+    seed = b"\x88" * 32
+    msg = b"end-to-end cms + transparency"
+    sig = _ed25519_signature_for(seed, msg)
+    sd = pki.SignedData.build_detached(sig, "1.3.101.112", [FAKE_CERT_DER])
+    der = sd.to_der()
+    artifact_hash = hashlib.sha256(der).digest()
+
+    tree = transparency.MerkleTree()
+    seq = tree.append("threshold_signature", artifact_hash)
+    proof = tree.inclusion_proof(seq)
+    tree.verify_inclusion(seq, proof, tree.root)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the v0.2 Python binding sign-side gap. Ruby has had this since v0.1.0; Python was verifier-only.

## New Python API

- `composite.CompositeSignature.sign_ed25519(seed_bytes, message)` — classmethod returning a fresh 1-component composite. Releases the GIL during crypto.
- `composite.CompositeSignature.sign_p256(seed_bytes, message)` — classmethod returning a fresh ECDSA-P256 composite (DER-encoded signature, SEC1 uncompressed public key).
- `pki.SignedData.build_detached(signature, algorithm, certificates)` — classmethod delegating to `confium_pki::cms::build_detached_signature`.
- `pki.SignedData#to_der()` — delegating to `encode_signed_data_der` (RFC 5652 ContentInfo).

## Upstream

`confium-composite` gains `build_p256_component` as a sibling to `build_ed25519_component` (OCP: new function, no existing code modified).

## Test plan

- [x] 78 pytest cases (up from 63).
- [x] Real Ed25519 + ECDSA-P256 sign round-trips.
- [x] DER encoding sanity check (0x30 SEQUENCE).
- [x] Hybrid composite assembly via two sign calls.
- [x] End-to-end sign → CMS → DER → transparency log anchor.
- [x] Seed-derived Ed25519 public key matches the `cryptography` library.
- [x] 32-byte key length enforced (ValueError on short keys).
