### PR TITLE
release(transparency): 0.3.1 -> 0.4.0 (breaking API change)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ confium-tc-gg18 = { path = "crates/confium-tc-gg18", version = "0.3.0" }
 confium-tc-ml-kem = { path = "crates/confium-tc-ml-kem", version = "0.3.0" }
 confium-test-harness = { path = "crates/confium-test-harness", version = "0.3.0" }
 confium-tls-signer = { path = "crates/confium-tls-signer", version = "0.3.0" }
-confium-transparency = { path = "crates/confium-transparency", version = "0.3.1" }
+confium-transparency = { path = "crates/confium-transparency", version = "0.4.0" }
 confium-wasm = { path = "crates/confium-wasm", version = "0.3.0" }
 
 libloading = "0.8"

--- a/crates/confium-benchmarks/Cargo.toml
+++ b/crates/confium-benchmarks/Cargo.toml
@@ -14,7 +14,7 @@ publish = false
 
 [dependencies]
 confium-composite = { path = "../confium-composite", version = "0.3.1" }
-confium-transparency = { path = "../confium-transparency", version = "0.3.1" }
+confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
 criterion = { workspace = true }
 ed25519-dalek = { workspace = true }
 p256 = { workspace = true }

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib"]
 [dependencies]
 confium-core = "0.2"
 confium-composite = { path = "../confium-composite", version = "0.3.1" }
-confium-transparency = { path = "../confium-transparency", version = "0.3.1" }
+confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
 confium-pki = { version = "0.3.1", features = ["cms"] }
 confium-attributes = "0.3.1"
 pyo3 = { version = "0.22", features = ["extension-module"] }

--- a/crates/confium-transparency/Cargo.toml
+++ b/crates/confium-transparency/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-transparency"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Releases `confium-transparency` 0.4.0 with the consistency proof fix from PR #87.

### Breaking change

`MerkleTree::verify_consistency` is now a **method** instead of an associated function:

```rust
// Old (0.3.x)
MerkleTree::verify_consistency(old_root, new_root, old_size, new_size, proof)?;

// New (0.4.0)
tree.verify_consistency(old_root, new_root, old_size, new_size, proof)?;
```

The proof parameter is accepted for forward compatibility but currently unused — verification is done by direct recomputation via `tree.root_at_size(old_size)` + `tree.root()`. External proof-only verification (no `&self`) is tracked as TODO 067.

### Why a breaking change

The proof-based verifier algorithm (RFC 6962 §2.1.2 with non-pow2 `old_size`) requires the verifier to know the implicit tree shape, which depends on `&self`. Brute-force verification via `&self` is correct; the prior associated-function form was buggy.

## Post-merge: publish to crates.io

This PR bumps versions but does NOT publish. The actual `cargo publish` needs `CARGO_REGISTRY_TOKEN` set in the local environment:

```sh
# After this PR merges:
export CARGO_REGISTRY_TOKEN=...    # crates.io token with publish permission
cargo publish -p confium-transparency
```

Once 0.4.0 is on crates.io, the Ruby gem's pending consistency-proof binding (TODO 061) unblocks.

## Test plan

- [x] `cargo publish -p confium-transparency --dry-run --allow-dirty` succeeds.
- [x] `cargo build -p confium-transparency -p confium-benchmarks` clean.
- [x] `cargo check -p confium-python` clean.
- [x] All 24 transparency unit tests pass on this version.
