### PR TITLE
feat(daemon): attributes_evaluate stateless JSON-RPC method

### DIFF
--- a/crates/confium-daemon/Cargo.toml
+++ b/crates/confium-daemon/Cargo.toml
@@ -28,6 +28,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 # imports as `confium_core::*` for clarity.
 confium_core = { package = "confium-core", path = "../confium-core", version = "0.2.0" }
 confium-composite = { path = "../confium-composite", version = "0.3.1" }
+confium-attributes = { path = "../confium-attributes", version = "0.3.1" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/confium-daemon/src/dispatch.rs
+++ b/crates/confium-daemon/src/dispatch.rs
@@ -198,6 +198,12 @@ impl Dispatch {
             rc(methods::composite::composite_verify),
         );
 
+        // -- attributes (stateless predicate evaluator) --
+        table.insert(
+            "attributes_evaluate".to_string(),
+            rc(methods::attributes::attributes_evaluate),
+        );
+
         Dispatch { table }
     }
 

--- a/crates/confium-daemon/src/methods/attributes.rs
+++ b/crates/confium-daemon/src/methods/attributes.rs
@@ -1,0 +1,148 @@
+//! Attribute-based threshold predicate methods.
+//!
+//! `attributes_evaluate` is the second stateless daemon handler
+//! (alongside `composite_verify`). It accepts a DSL expression +
+//! JSON list of signers, returns whether the predicate is satisfied.
+
+use std::collections::HashSet;
+
+use serde::Deserialize;
+use serde_json::{Map, Value, json};
+
+use confium_attributes::{evaluate, parse as dsl_parse, SignerAttributes};
+use crate::error::RpcError;
+use crate::server::SharedConfium;
+
+/// Request body for `attributes_evaluate`.
+#[derive(Debug, Deserialize)]
+struct AttributesEvaluateRequest {
+    /// DSL expression, e.g. `min_count("role:director", 3)`.
+    predicate: String,
+    /// JSON array of signer attribute maps. Each signer is an object
+    /// mapping attribute name → array of string values, e.g.
+    /// `[{"role:director": ["yes"], "region": ["europe"]}, ...]`.
+    signers: Vec<Map<String, Value>>,
+}
+
+/// Convert a JSON object (`{attr: [vals]}`) into a `SignerAttributes`.
+fn signer_from_json(obj: &Map<String, Value>) -> Result<SignerAttributes, RpcError> {
+    let mut attrs = SignerAttributes::new();
+    for (key, value) in obj {
+        let arr = value.as_array().ok_or_else(|| RpcError::InvalidParams {
+            detail: format!("attribute '{key}' value must be a JSON array of strings"),
+        })?;
+        let mut set = HashSet::new();
+        for v in arr {
+            let s = v.as_str().ok_or_else(|| RpcError::InvalidParams {
+                detail: format!("attribute '{key}' has a non-string value"),
+            })?;
+            set.insert(s.to_string());
+        }
+        attrs.attrs.insert(key.clone(), set);
+    }
+    Ok(attrs)
+}
+
+/// `attributes_evaluate({ "predicate": "...", "signers": [...] })`
+///
+/// Returns:
+/// ```json
+/// { "satisfied": true }
+/// ```
+pub async fn attributes_evaluate(
+    _cfm: SharedConfium,
+    params: Value,
+) -> std::result::Result<Value, RpcError> {
+    let req: AttributesEvaluateRequest = serde_json::from_value(params).map_err(|e| {
+        RpcError::InvalidParams {
+            detail: format!("attributes_evaluate params: {e}"),
+        }
+    })?;
+
+    let predicate = dsl_parse(&req.predicate).map_err(|e| RpcError::InvalidParams {
+        detail: format!("predicate parse error: {e}"),
+    })?;
+
+    let mut signers = Vec::with_capacity(req.signers.len());
+    for obj in &req.signers {
+        signers.push(signer_from_json(obj)?);
+    }
+    let refs: Vec<&SignerAttributes> = signers.iter().collect();
+
+    let satisfied = evaluate(&predicate, &refs);
+    Ok(json!({ "satisfied": satisfied }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_util::test_confium;
+
+    #[tokio::test]
+    async fn attributes_evaluate_satisfied() {
+        let params = json!({
+            "predicate": "min_count(\"role:director\", 3)",
+            "signers": [
+                {"role:director": ["yes"]},
+                {"role:director": ["yes"]},
+                {"role:director": ["yes"]},
+            ]
+        });
+        let result = attributes_evaluate(test_confium(), params).await.unwrap();
+        assert_eq!(result["satisfied"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn attributes_evaluate_not_satisfied() {
+        let params = json!({
+            "predicate": "min_count(\"role:director\", 5)",
+            "signers": [
+                {"role:director": ["yes"]},
+                {"role:director": ["yes"]},
+            ]
+        });
+        let result = attributes_evaluate(test_confium(), params).await.unwrap();
+        assert_eq!(result["satisfied"], json!(false));
+    }
+
+    #[tokio::test]
+    async fn attributes_evaluate_distinct_values() {
+        let params = json!({
+            "predicate": "min_distinct(\"region\", 3)",
+            "signers": [
+                {"region": ["europe"]},
+                {"region": ["americas"]},
+                {"region": ["asia-pacific"]},
+            ]
+        });
+        let result = attributes_evaluate(test_confium(), params).await.unwrap();
+        assert_eq!(result["satisfied"], json!(true));
+    }
+
+    #[tokio::test]
+    async fn attributes_evaluate_rejects_bad_predicate() {
+        let params = json!({
+            "predicate": "bogus_function(\"arg\")",
+            "signers": [],
+        });
+        let result = attributes_evaluate(test_confium(), params).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn attributes_evaluate_rejects_missing_fields() {
+        let result = attributes_evaluate(test_confium(), json!({})).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn attributes_evaluate_rejects_non_array_signer_value() {
+        let params = json!({
+            "predicate": "any(\"x\")",
+            "signers": [{"x": "scalar"}],
+        });
+        let result = attributes_evaluate(test_confium(), params).await;
+        assert!(result.is_err());
+    }
+}
+

--- a/crates/confium-daemon/src/methods/mod.rs
+++ b/crates/confium-daemon/src/methods/mod.rs
@@ -11,6 +11,7 @@
 //! no dispatch change is needed.
 
 pub mod aead;
+pub mod attributes;
 pub mod audit;
 pub mod cipher;
 pub mod composite;

--- a/docs/bindings/parity.mdx
+++ b/docs/bindings/parity.mdx
@@ -65,6 +65,12 @@ Rust workspace.
 Built on **magnus 0.8** + **rb_sys**. Targets MRI 3.0+. Ships as a
 gem (`gem install confium`). Source: `github.com/confium/confium-ruby`.
 
+**Most complete binding**: composite sign + verify, CMS build/sign +
+DER encode, transparency inclusion + consistency proof + verify,
+attributes DSL, TC sessions (FROST-P256, ElGamal-P256), identity
+actor, deployment manifest. Ships against `confium-transparency 0.4`
+on crates.io.
+
 ### WASM
 
 Built on **wasm-bindgen**. Targets `wasm32-unknown-unknown`.


### PR DESCRIPTION
## Summary

Adds the second stateless daemon method: `attributes_evaluate`. Alongside `composite_verify`, this makes the daemon actually useful for evaluating attribute-based threshold predicates via JSON-RPC.

### JSON-RPC shape

Request:
```json
{
  "method": "attributes_evaluate",
  "params": {
    "predicate": "min_count(\"role:director\", 3)",
    "signers": [
      {"role:director": ["yes"]},
      {"role:director": ["yes"]},
      {"role:director": ["yes"]}
    ]
  }
}
```

Response:
```json
{ "satisfied": true }
```

Supports the full DSL: `min_count`, `min_distinct`, `none`, `any`, `all`, `and`, `or`, `not`. Signers are JSON objects mapping attribute name → array of string values.

Also updates `docs/bindings/parity.mdx` to note Ruby as the most complete binding (post-PR #44 in confium-ruby shipping `verify_consistency`).

## Test plan

- [x] `cargo test -p confium-daemon --lib` — 22 passed (6 new).
- [x] Happy path: min_count satisfied, min_count not satisfied, min_distinct satisfied.
- [x] Error paths: bad predicate (DSL parse error), missing fields, non-array signer value.
