### PR TITLE
chore(deps): bump rnp-rs from 0.1.6 to 0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ cryptoki = "0.12"
 curve25519-dalek = { version = "4", features = ["rand_core"] }
 # rnp-rs: idiomatic Rust binding to librnp (OpenPGP C FFI). Published on
 # crates.io. We alias to `rnp` because the crate's lib name is `rnp`.
-rnp = { package = "rnp-rs", version = "0.1.6" }
+rnp = { package = "rnp-rs", version = "0.1.10" }
 ed25519-dalek = "2"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 aes-gcm = "0.10"


### PR DESCRIPTION
## Summary

Bumps `rnp-rs` from 0.1.6 to 0.1.10 in the workspace dependencies. This is the latest published version of the Rust binding to librnp (OpenPGP C FFI).

## What's new in 0.1.10

- **vendored feature** — delegates to `rnp-src` crate for from-source build (eliminates system librnp dependency). Note: has an upstream bug in `rnp-src 0.1.1` where the `is_packaging()` check fires incorrectly for dependent builds. Not enabled in this PR.
- **pqc feature** — post-quantum crypto support in OpenPGP
- **crypto-refresh feature** — RFC 9580 (crypto-refresh) support
- **logging feature** — optional structured logging
- Various bug fixes

## Also noted

`@rnpgp/rnp@0.1.0` (WASM build) was published on npm. Confium's WASM binding (`@confium/confium-wasm`) is separate and does not use rnp — it's a verifier-only package for browser-side transparency log + composite signature verification.

## Test plan

- [x] `cargo build -p confium-store-openpgp-card` — compiles clean against 0.1.10.
- [x] No API changes that affect confium-store-openpgp-card's usage.
- [ ] Runtime tests still require system `librnp` installed (same as before — the vendored feature isn't enabled due to the upstream bug).
