### PR TITLE
feat(ci): vendored rnp-src for full Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,15 +174,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
     steps:
       - uses: actions/checkout@v7
 
+      # rnp-src compiles librnp + Botan from source via cmake. On
+      # Windows, it forces the GCC/MinGW toolchain (via MSYS2 UCRT64).
+      # This requires the GNU Rust target instead of the default MSVC.
+      - name: Set up MSYS2 (Windows)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          install: gcc cmake ninja
+
+      - name: Add MSYS2 to PATH (Windows)
+        if: runner.os == 'Windows'
+        run: echo "C:\msys64\ucrt64\bin" >> $GITHUB_PATH
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Switch to GNU toolchain (Windows)
+        if: runner.os == 'Windows'
+        run: rustup default stable-x86_64-pc-windows-gnu
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2

--- a/crates/confium-store-openpgp-card/Cargo.toml
+++ b/crates/confium-store-openpgp-card/Cargo.toml
@@ -21,10 +21,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 serde = { workspace = true }
 thiserror = { workspace = true }
-rnp = { workspace = true }
+rnp = { workspace = true, features = ["vendored"] }
 
 [dev-dependencies]
-rnp = { workspace = true }
+rnp = { workspace = true, features = ["vendored"] }
 
 [lib]
 crate-type = ["rlib"]


### PR DESCRIPTION
## Summary

Enables `vendored` feature for rnp in `confium-store-openpgp-card`, triggering rnp-src 0.1.2 to compile librnp + Botan + json-c from source. This eliminates the system librnp dependency and enables **full Windows support**.

### What changed

1. `crates/confium-store-openpgp-card/Cargo.toml`: `rnp = { workspace = true, features = ["vendored"] }`
2. `.github/workflows/ci.yml` test job: added MSYS2 + GNU Rust toolchain for Windows

### Why vendored

Without vendored, every platform needs `librnp` installed system-wide. With vendored:
- **Linux**: compiles from source via cmake (system GCC)
- **macOS**: compiles from source via cmake (Xcode clang)
- **Windows**: compiles from source via cmake with MSYS2 UCRT64 + MinGW GCC

The first build takes ~3 minutes (Botan compilation); subsequent builds use cargo's cache.

### Windows CI

rnp-src 0.1.2 forces the GCC/MinGW toolchain on Windows (via `BOTAN_CONFIGURE_CC=gcc`). This requires:
1. MSYS2 UCRT64 with gcc, cmake, ninja installed
2. The `x86_64-pc-windows-gnu` Rust target (not the default MSVC) because MinGW-produced static libraries (.a) are incompatible with MSVC's linker

## Test plan

- [x] `cargo build -p confium-store-openpgp-card` — compiles with vendored rnp (3 min first build)
- [x] `cargo test -p confium-store-openpgp-card --lib` — 2 passed (was failing locally due to missing librnp)
- [ ] CI Windows runner: verify MSYS2 + GNU target produces a green build
- [ ] CI Linux/macOS: verify vendored doesn't break existing green builds
