### PR TITLE
feat(wasm): XMLDSig canonicalize + parity matrix overhaul

### DIFF
--- a/crates/confium-wasm/src/lib.rs
+++ b/crates/confium-wasm/src/lib.rs
@@ -50,3 +50,17 @@ pub fn version() -> String {
 pub fn core_version() -> String {
     "0.2.0".to_string()
 }
+
+/// Canonicalize XML per RFC 3076 (Canonical XML 1.0).
+#[wasm_bindgen]
+pub fn canonicalize_xml(xml: &str) -> Result<String, JsValue> {
+    confium_pki::xmldsig::canonicalize(xml)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+/// Canonicalize XML per Exclusive C14N (RFC 3741).
+#[wasm_bindgen]
+pub fn canonicalize_exclusive_xml(xml: &str) -> Result<String, JsValue> {
+    confium_pki::xmldsig::canonicalize_exclusive(xml)
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}

--- a/docs/bindings/parity.mdx
+++ b/docs/bindings/parity.mdx
@@ -11,36 +11,37 @@ feature".
 |---|:---:|:---:|:---:|:---:|
 | **Composite verify** (Ed25519) | ✅ | ✅ | ✅ | ✅ |
 | **Composite verify** (ECDSA-P256) | ✅ | ✅ | ✅ | ✅ |
-| **Composite sign** (Ed25519) | ✅ | ✅ | ✅ | ❌ |
-| **Composite sign** (ECDSA-P256) | ✅ | ✅ | ✅ | ❌ |
-| **Composite custom verifier callback** | ✅ | ✅ | ✅ | ❌ |
+| **Composite sign** (Ed25519) | ✅ | ✅ | ✅ | ➖ |
+| **Composite sign** (ECDSA-P256) | ✅ | ✅ | ✅ | ➖ |
+| **Composite custom verifier callback** | ✅ | ✅ | ✅ | ➖ |
 | **Transparency append** | ✅ | ✅ | ✅ | ✅ |
 | **Transparency inclusion proof** | ✅ | ✅ | ✅ | ✅ |
-| **Transparency consistency proof** | ✅ | ✅ | ✅ | ❌ |
+| **Transparency consistency proof** | ✅ | ✅ | ✅ | ✅ |
 | **Transparency compute_leaf_hash** | ✅ | ✅ | ✅ | ✅ |
 | **Transparency verify_inclusion_with_leaf** | ✅ | ❌ | ✅ | ✅ |
 | **PKI Certificate** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
 | **PKI CSR** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
 | **PKI CMS SignedData** parse (JSON) | ✅ | ✅ | ✅ | ✅ |
 | **PKI CMS SignedData** verify | ✅ | ✅ | ✅ | ✅ |
-| **PKI CMS SignedData** build/sign | ✅ | ✅ | ✅ | ❌ |
-| **PKI CMS SignedData** DER encode | ✅ | ✅ | ✅ | ❌ |
-| **PKI XMLDSig** canonicalize | ✅ | ✅ | ✅ | ❌ |
+| **PKI CMS SignedData** build/sign | ✅ | ✅ | ✅ | ➖ |
+| **PKI CMS SignedData** DER encode | ✅ | ✅ | ✅ | ➖ |
+| **PKI XMLDSig** canonicalize | ✅ | ✅ | ✅ | ✅ |
 | **Attributes predicate** parse | ✅ | ✅ | ✅ | ✅ |
 | **Attributes evaluate** | ✅ | ✅ | ✅ | ✅ |
-| **Identity Actor** | ✅ | ✅ | ✅ | ❌ |
-| **Config Manifest** | ✅ | ✅ | ✅ | ❌ |
-| **TC FROST-P256** (Shamir + ECDSA) | ✅ | ✅ | ❌ | ❌ |
-| **TC ElGamal-P256** (threshold enc) | ✅ | ✅ | ❌ | ❌ |
-| **TC CMP20** | ✅ | ❌ | ❌ | ❌ |
-| **TC GG18** | ✅ | ❌ | ❌ | ❌ |
-| **OTS anchor** | ✅ | ✅ | ❌ | ❌ |
-| **ERS archival** | ✅ | ❌ | ❌ | ❌ |
+| **Identity Actor** | ✅ | ✅ | ✅ | ➖ |
+| **Config Manifest** | ✅ | ✅ | ✅ | ➖ |
+| **TC FROST-P256** (Shamir + ECDSA) | ✅ | ✅ | ❌ | ➖ |
+| **TC ElGamal-P256** (threshold enc) | ✅ | ✅ | ❌ | ➖ |
+| **TC CMP20** | ✅ | ❌ | ❌ | ➖ |
+| **TC GG18** | ✅ | ❌ | ❌ | ➖ |
+| **OTS anchor** | ✅ | ✅ | ❌ | ➖ |
+| **ERS archival** | ✅ | ❌ | ❌ | ➖ |
 
 ## Legend
 
 - ✅ — shipped, real implementation, spec'd
 - ❌ — not exposed in this binding (yet)
+- ➖ — **by design** not exposed (WASM is verifier-only: browsers verify, servers sign)
 
 ## How to read this table
 


### PR DESCRIPTION
## Summary

Two improvements bundled:

### WASM XMLDSig canonicalize

Adds `canonicalize_xml(xml)` and `canonicalize_exclusive_xml(xml)` to the WASM binding. Mirrors the Python and Ruby XMLDSig modules.

### Parity matrix overhaul

The parity matrix had stale ❌ entries for WASM features that were actually shipped (consistency_proof from PR #94) or are by-design exclusions (signing operations — WASM is verifier-only).

Changes:
- WASM consistency_proof: ❌ → ✅ (already shipped, matrix was stale)
- WASM XMLDSig: ❌ → ✅ (this commit)
- All WASM signing/build operations: ❌ → ➖ (by design)
- Legend: added ➖ = "by design (verifier-only)"
- Remaining genuine ❌ gaps clearly visible: Ruby (verify_inclusion_with_leaf, CMP20, GG18, ERS), Python (TC sessions, CMP20, GG18, OTS)

## Test plan

- [x] `cargo build -p confium-wasm` — compiles clean with new functions.
- [x] Parity matrix accurately reflects shipped vs. by-design vs. genuine gaps.
