### PR TITLE
docs(parity): Ruby verify_inclusion_with_leaf → ✅ (last genuine Ruby gap closed)

### DIFF
--- a/docs/bindings/parity.mdx
+++ b/docs/bindings/parity.mdx
@@ -18,7 +18,7 @@ feature".
 | **Transparency inclusion proof** | ✅ | ✅ | ✅ | ✅ |
 | **Transparency consistency proof** | ✅ | ✅ | ✅ | ✅ |
 | **Transparency compute_leaf_hash** | ✅ | ✅ | ✅ | ✅ |
-| **Transparency verify_inclusion_with_leaf** | ✅ | ❌ | ✅ | ✅ |
+| **Transparency verify_inclusion_with_leaf** | ✅ | ✅ | ✅ | ✅ |
 | **PKI Certificate** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
 | **PKI CSR** parse (DER/PEM) | ✅ | ✅ | ✅ | ✅ |
 | **PKI CMS SignedData** parse (JSON) | ✅ | ✅ | ✅ | ✅ |


### PR DESCRIPTION
With PR #48 in confium-ruby shipping `InclusionProof#verify_with_leaf`, Ruby now has full coverage on all non-TC features.