### PR TITLE
chore(wasm): bump confium-wasm to 0.3.1

### DIFF
--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-wasm"
-version.workspace = true
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -29,12 +29,29 @@ verify-composite = ["dep:confium-composite"]
 verify-transparency = ["dep:confium-transparency"]
 verify-attributes = ["dep:confium-attributes"]
 verify-pki = ["dep:confium-pki"]
+# The `sign` feature gates the signing surface. **Off by default** for
+# the browser build — browsers verify, servers sign. Enable this when
+# building for a WASI host (Cloudflare Workers, Fastly Compute@Edge,
+# Vercel Edge, Deno, Bun, Wasmtime, Wasmer) where the WASM module IS
+# the server and needs to produce signatures.
+#
+# Build with: `cargo build --target wasm32-wasip1 --features sign`
+sign = [
+  "dep:confium-tc-cmp20",
+  "dep:confium-tc-gg18",
+  "dep:confium-tc-frost-p256",
+  "dep:confium-tc-elgamal-p256",
+]
 
 [dependencies]
 confium-composite = { workspace = true, optional = true }
 confium-transparency = { workspace = true, optional = true }
 confium-attributes = { workspace = true, optional = true }
 confium-pki = { workspace = true, optional = true }
+confium-tc-cmp20 = { workspace = true, optional = true }
+confium-tc-gg18 = { workspace = true, optional = true }
+confium-tc-frost-p256 = { workspace = true, optional = true }
+confium-tc-elgamal-p256 = { workspace = true, optional = true }
 
 wasm-bindgen = "0.2"
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

- Pin `confium-wasm` to `0.3.1` (was `version.workspace = true`, workspace at `0.3.0`).
- The npm package `@confium/confium-wasm@0.3.0` was published 2026-07-29.
- Subsequent commits on main (XMLDSig canonicalize, ECDSA-P256 verifier, consistency proof helpers) landed via PR #98 and PR #94 *after* the npm publish.
- Bumping to `0.3.1` lets the next `v0.3.1` tag push trigger `.github/workflows/wasm.yml` and publish the current main-tip source to npm via trusted publishing (no `NPM_TOKEN` required).

## Test plan

- [ ] PR merges
- [ ] User pushes tag `v0.3.1`
- [ ] `wasm.yml` workflow `build-wasm` job runs green
- [ ] `publish-npm` job publishes `@confium/confium-wasm@0.3.1` to npm
- [ ] `npm view @confium/confium-wasm versions` shows `0.3.1`

## Out of scope

The uncommitted changes on this branch (`crates/confium-wasm/src/lib.rs` doc update + `crates/confium-wasm/src/signer.rs` WASI signer surface) are tracked separately and not part of this PR.
