### PR TITLE
fix(ci): drop release environment from wasm publish job

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -14,8 +14,6 @@
 #        - Under "Configured GitHub Actions" add:
 #            repository: confium/confium
 #            workflow:   .github/workflows/wasm.yml
-#            environment: release
-#        - Configure the GitHub environment `release` to require it.
 #
 #   3. **Subsequent publishes** run from this workflow on tag push. The
 #      `id-token: write` permission lets npm verify the workflow's OIDC
@@ -70,7 +68,6 @@ jobs:
   publish-npm:
     needs: build-wasm
     runs-on: ubuntu-latest
-    environment: release  # matches the npm trusted-publishing config
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       id-token: write  # required for npm trusted publishing (OIDC)


### PR DESCRIPTION
## Summary

- Removes `environment: release` from `publish-npm` job in `.github/workflows/wasm.yml`.
- The npm-side trusted-publishing config does not constrain to a GitHub environment, so the workflow presenting `environment: release` caused npm to reject the OIDC claim with **E404 on PUT** (`@confium/confium-wasm@0.3.1 is not in this registry`).
- Updates the inline trusted-publishing setup comment to drop the `environment:` line and the "Configure the GitHub environment `release`" note.

## Failure context

The `v0.3.1` tag push triggered run [31014623568](https://github.com/confium/confium/actions/runs/31014623568). Build succeeded; publish failed with `E404 Not Found - PUT https://registry.npmjs.org/@confium%2fconfium-wasm`. Same shape as an unscoped/anonymous publish attempt — i.e. the OIDC claim was being rejected.

## Test plan

- [ ] PR merges
- [ ] Force-tag `v0.3.1` to new main tip (or push `v0.3.2`) to re-trigger
- [ ] `publish-npm` job goes green
- [ ] `npm view @confium/confium-wasm dist-tags` shows `latest: 0.3.1`

## Out of scope

- Deciding whether to force-tag `v0.3.1` or bump to `v0.3.2`. Either works; this PR just unblocks the trusted-publishing claim.
