### PR TITLE
fix(ci): drop registry-url from wasm publish setup-node

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -85,7 +85,10 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+        # No `registry-url` here: setting it causes setup-node to write
+        # an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, which (without
+        # a NODE_AUTH_TOKEN env var) sends an empty bearer token and npm
+        # prefers that over the OIDC claim, producing a 404 on PUT.
 
       - name: Publish via trusted publishing (OIDC, no NPM_TOKEN)
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Removes `registry-url: 'https://registry.npmjs.org'` from the `setup-node` step in `publish-npm`.
- With `registry-url` set, `actions/setup-node` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}`. Since we don't set `NODE_AUTH_TOKEN`, the PUT ships with an empty bearer, and npm prefers that over the OIDC claim — so it returns E404 on PUT (provenance still signs successfully, which is why we see the discrepancy).
- Drop `registry-url` so the publish job has no `.npmrc` auth entry and npm falls back to the OIDC claim end-to-end.

## Failure context

Two prior runs on tag `v0.3.1` both failed publish with E404 ([31014623568](https://github.com/confium/confium/actions/runs/31014623568), [31149563153](https://github.com/confium/confium/actions/runs/31149563153)). Both signed provenance successfully but rejected the PUT. npm-side trusted publisher is correctly configured as `confium/confium` + `wasm.yml` + no environment.

## Test plan

- [ ] PR merges
- [ ] Force-tag `v0.3.1` to new main tip to re-trigger
- [ ] `publish-npm` job goes green
- [ ] `npm view @confium/confium-wasm dist-tags` shows `latest: 0.3.1`
