### PR TITLE
fix(ci): bump wasm publish to Node 22 for trusted-publishing auth

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -13,11 +13,13 @@
 #        - Visit https://www.npmjs.com/package/@confium/confium-wasm/access
 #        - Under "Configured GitHub Actions" add:
 #            repository: confium/confium
-#            workflow:   .github/workflows/wasm.yml
+#            workflow:   wasm.yml
 #
 #   3. **Subsequent publishes** run from this workflow on tag push. The
 #      `id-token: write` permission lets npm verify the workflow's OIDC
-#      identity and accept the publish without a token.
+#      identity and accept the publish without a token. Requires
+#      Node.js 22+ (npm 10.9+) — earlier npm versions sign provenance
+#      but cannot authenticate the PUT via OIDC alone.
 #
 # Triggered on release tags (v*.*.*) and via workflow_dispatch.
 
@@ -84,11 +86,13 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: "20"
-        # No `registry-url` here: setting it causes setup-node to write
-        # an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, which (without
-        # a NODE_AUTH_TOKEN env var) sends an empty bearer token and npm
-        # prefers that over the OIDC claim, producing a 404 on PUT.
+          # Node 22 LTS ships with npm 10.9+, the first npm release
+          # supporting trusted publishing end-to-end. npm 10.8 (bundled
+          # with Node 20) signs provenance via OIDC but still requires
+          # a token for the PUT itself.
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          # No NODE_AUTH_TOKEN — trusted publishing authenticates via OIDC.
 
       - name: Publish via trusted publishing (OIDC, no NPM_TOKEN)
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

- Bump `setup-node` from Node 20 (npm 10.8.2) → Node 22 (npm 10.9+) for the `publish-npm` job.
- Restore `registry-url: 'https://registry.npmjs.org'` (the standard trusted-publishing pattern).

## Root cause of prior failures

Three prior runs on tag `v0.3.1` all failed publish despite provenance signing successfully:

| Run | Config | npm | Error |
|---|---|---|---|
| [31014623568](https://github.com/confium/confium/actions/runs/31014623568) | `environment: release` + `registry-url` | 10.8.2 | E404 |
| [31149563153](https://github.com/confium/confium/actions/runs/31149563153) | no env + `registry-url` | 10.8.2 | E404 |
| [31151758338](https://github.com/confium/confium/actions/runs/31151758338) | no env + no `registry-url` | 10.8.2 | ENEEDAUTH |

npm 10.8.2 (bundled with Node 20) **signs provenance via OIDC but cannot authenticate the PUT itself without a token**. Trusted-publishing PUT auth lands in **npm 10.9+** ([npm/cli changelog](https://github.com/npm/cli/releases)). Node 22 LTS ships with npm 10.9.

With this fix, `npm publish --provenance` should authenticate end-to-end via the OIDC claim and no NPM_TOKEN.

## Test plan

- [ ] PR merges
- [ ] Force-tag `v0.3.1` to new main tip to re-trigger
- [ ] `publish-npm` job goes green
- [ ] `npm view @confium/confium-wasm dist-tags` shows `latest: 0.3.1`

## Out of scope

If this still fails, the fallback is to set up `NPM_TOKEN` as a repo secret and use traditional auth. Not doing that yet — trusted publishing should work with the right npm version.
