### PR TITLE
fix(ci): drop empty .npmrc auth before wasm publish

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -92,7 +92,15 @@ jobs:
           # a token for the PUT itself.
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-          # No NODE_AUTH_TOKEN — trusted publishing authenticates via OIDC.
+
+      - name: Drop empty auth from .npmrc (force OIDC for the PUT)
+        run: |
+          NPMRC="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+          echo "Before:"
+          [ -f "$NPMRC" ] && cat "$NPMRC" || echo "(no npmrc at $NPMRC)"
+          [ -f "$NPMRC" ] && sed -i -E '/_authToken=/d; /^[[:space:]]*$/d' "$NPMRC" || true
+          echo "After:"
+          [ -f "$NPMRC" ] && cat "$NPMRC" || echo "(no npmrc at $NPMRC)"
 
       - name: Publish via trusted publishing (OIDC, no NPM_TOKEN)
         run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

Add a step that strips the empty `_authToken=${NODE_AUTH_TOKEN}` entry from the `.npmrc` that `setup-node` writes when given a `registry-url`. With the entry removed, npm has no `.npmrc` auth and falls back to the OIDC claim for the PUT.

## Why this is needed

`actions/setup-node@v7` writes `~/.npmrc` (or `${NPM_CONFIG_USERCONFIG}`) with `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` whenever `registry-url` is set. With no `NODE_AUTH_TOKEN` env var, npm substitutes an empty string and sends an empty bearer on the PUT. npm prefers that empty token over the OIDC claim, so the publish fails with E404 even on npm 10.9+ (which supports trusted publishing).

The 4 prior runs all failed with this shape:
- 31014623568: E404 with `environment: release` + `registry-url` + Node 20
- 31149563153: E404 with no env + `registry-url` + Node 20
- 31151758338: ENEEDAUTH with no env + no `registry-url` + Node 20 (npm 10.8)
- 31152096069: E404 with no env + `registry-url` + Node 22 (npm 10.9.8)

The diagnostic step also prints the `.npmrc` before/after so we can verify on the next run.

## Test plan

- [ ] PR merges
- [ ] Force-tag `v0.3.1` to re-trigger
- [ ] "Drop empty auth" step prints the `.npmrc` before/after (verify `_authToken` line is gone)
- [ ] `npm publish --provenance` succeeds
- [ ] `npm view @confium/confium-wasm dist-tags` shows `latest: 0.3.1`
