### PR TITLE
docs: per-product doc roots for threshold, transparency, pki, keyless, privacy, verify

### DIFF
--- a/TODO.restructure/README.phase2.md
+++ b/TODO.restructure/README.phase2.md
@@ -1,0 +1,58 @@
+# TODO.restructure/ Phase 2 — Product Depth (TODOs 19-32)
+
+Phase 1 (TODOs 00-18) shipped the 6-product restructuring: extracted crates, published facades, shipped one minisite index page per product. All complete.
+
+Phase 2 (TODOs 19-32) fills the **depth** gaps:
+- Three product facades still missing (threshold, keyless, verify)
+- Minisite nav links 404 (subpages don't exist)
+- Audience ↔ use-case matrix is implicit
+- Specs are mode-tagged not product-tagged
+- No per-product docs in the Rust workspace
+- CLI has no product-umbrella commands
+- Repo strategy undocumented
+
+## Audit
+
+Start with [19-deep-architecture-audit.md](19-deep-architecture-audit.md) — it explains the gap analysis and links to all TODOs below.
+
+## TODOs
+
+| # | Title | Priority | Status |
+|---|-------|----------|--------|
+| 19 | Deep architecture audit | — | ✅ Done (this doc is it) |
+| 20 | [Product facade crates](20-product-facade-crates.md) | CRITICAL | ☐ Blocked: requires committing 19 prior-session crate directories (tc-core, coordinator, crypto-vss, etc.) before facades can reference them |
+| 21 | [Audience/use-case matrix](21-audience-use-case-matrix.md) | HIGH | ✅ Done (PR confium.github.io#76) |
+| 22 | [Minisite shared subpage templates](22-minisite-shared-templates.md) | HIGH | ✅ Done (PR confium.github.io#77) |
+| 23 | [Threshold minisite depth](23-minisite-threshold.md) | HIGH | ✅ Done (PR confium.github.io#78) |
+| 24 | [Transparency minisite depth](24-minisite-transparency.md) | HIGH | ✅ Done (PR confium.github.io#79) |
+| 25 | [PKI minisite depth](25-minisite-pki.md) | HIGH | ✅ Done (PR confium.github.io#79) |
+| 26 | [Keyless minisite depth](26-minisite-keyless.md) | HIGH | ✅ Done (PR confium.github.io#79) |
+| 27 | [Privacy minisite depth](27-minisite-privacy.md) | HIGH | ✅ Done (PR confium.github.io#79) |
+| 28 | [Verify minisite depth](28-minisite-verify.md) | HIGH | ✅ Done (PR confium.github.io#79) |
+| 29 | [Specs product-tagging](29-specs-product-tagging.md) | MEDIUM | ✅ Done (PR specs#5) |
+| 30 | [Per-product docs in Rust workspace](30-per-product-docs.md) | MEDIUM | ☐ |
+| 31 | [CLI product subcommands](31-cli-product-subcommands.md) | MEDIUM | ☐ |
+| 32 | [Repo strategy decision record](32-repo-strategy-decision.md) | LOW | ✅ Done (PR confium#107) |
+
+## Execution order
+
+1. **Foundation** (TODOs 20, 21, 22) — must land first; everything else consumes them.
+2. **Per-product depth** (TODOs 23-28) — can land in parallel once foundation is in.
+3. **Cross-cutting** (TODOs 29-32) — independent of foundation and depth.
+
+## How to run a TODO
+
+Each TODO has:
+- **Problem**: why this exists
+- **Solution**: what to build
+- **Acceptance criteria**: definition of done
+- **Files to touch**: exact paths
+
+For code TODOs: open a PR per TODO, rebase-merge (per existing memory). For docs TODOs: same. For website TODOs: build site locally before PR.
+
+## Out of scope for Phase 2
+
+- New cryptographic primitives
+- Per-product repos (decision: stay in monorepo — see TODO 32)
+- Marketing site redesign
+- Rebranding

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -29,6 +29,19 @@ For the public website, see [www.confium.org](https://www.confium.org/).
 - [Language bindings](./bindings/) — Python, Ruby, WASM, and the
   bindings parity matrix.
 
+## Browse by product
+
+Confium is organized into 6 products. Each has its own doc root:
+
+| Product | Description | Docs |
+|--------|-------------|------|
+| **Threshold** | T-of-N distributed signing (CMP20, GG18, FROST) | [docs/threshold/](./threshold/) |
+| **Transparency** | RFC 6962 audit trails + OTS + ERS | [docs/transparency/](./transparency/) |
+| **PKI** | Threshold CA + PKCS#11 + OpenSSL + JCE | [docs/pki/](./pki/) |
+| **Keyless** | OIDC-based keyless signing | [docs/keyless/](./keyless/) |
+| **Privacy** | PSI, PIR, DP, MPC, ring sigs, VRF, VDF | [docs/privacy/](./privacy/) |
+| **Verify** | Multi-language verification (WASM/Python/Ruby/Node/Go) | [docs/verify/](./verify/) |
+
 ## The three deployment modes
 
 Confium is layered across three deployment modes. The same engine and

--- a/docs/keyless/index.mdx
+++ b/docs/keyless/index.mdx
@@ -1,0 +1,44 @@
+---
+title: Confium Keyless
+description: OIDC-based keyless threshold signing for short-lived certificates
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Confium Keyless
+
+Confium Keyless is the **keyless-signing** product: sign releases
+without managing keys. OIDC providers (GitHub Actions, Google, GitLab,
+Azure AD, Okta) prove identity; Confium issues short-lived signing
+certificates from threshold keys.
+
+## Components
+
+- `confium-oidc` — OIDC JWT verification + claim validation
+- `confium-keyless` (TODO 20) — facade crate for the keyless flow
+- The Confium Action (GitHub) — drop-in for release workflows
+
+## Concepts
+
+- [OIDC for code signing](./concepts/oidc.mdx)
+- [Short-lived certificates from threshold keys](./concepts/short-lived-certs.mdx)
+- [Transparency log anchoring](./concepts/anchoring.mdx)
+- [Root of trust model](./concepts/root-of-trust.mdx)
+
+## How-to
+
+- [Configure the GitHub Action](./how-to/github-action.mdx)
+- [Add a new OIDC provider](./how-to/new-oidc-provider.mdx)
+- [Verify keyless signatures in CI](./how-to/verify-in-ci.mdx)
+
+## Reference
+
+- [Rust API](https://docs.rs/confium-oidc)
+- [OIDC binding spec](https://www.confium.org/specs/90-oidc-binding)
+- [Keyless flow spec](https://www.confium.org/specs/91-keyless-flow)
+- [Short-lived cert spec](https://www.confium.org/specs/92-short-lived-cert)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx)
+- [Confium Keyless on the website](https://www.confium.org/keyless/)

--- a/docs/pki/index.mdx
+++ b/docs/pki/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Confium PKI
+description: Threshold-backed certificate authority, OCSP/CRL, ACME, composite signatures
+product: pki
+audience: ca-operator, security-engineer
+---
+
+# Confium PKI
+
+Confium PKI is the **public-key-infrastructure** product: run a CA
+without a single trusted key. Issue, revoke, and prove via threshold
+signing.
+
+## Components
+
+- `confium-pki` — X.509 cert, CSR, CMS SignedData, XMLDSig
+- `confium-composite` — Composite signatures for PQ migration
+- `confium-attributes` — Attribute-based signing predicates
+- `confium-pkcs11-server` — Drop-in HSM replacement via PKCS#11
+- `confium-openssl-provider` — OpenSSL 3.0 provider
+- `confium-jce-provider` — Java Cryptography Extension provider
+- `confium-tls-signer` — TLS 1.3 signature callback
+
+## Concepts
+
+- [Threshold CA lifecycle](./concepts/threshold-ca.mdx)
+- [OCSP / CRL from threshold keys](./concepts/ocsp-crl.mdx)
+- [ACME integration](./concepts/acme.mdx)
+- [Composite signatures (PQ migration)](./concepts/composite.mdx)
+- [Attribute-based signing policies](./concepts/attributes.mdx)
+
+## How-to
+
+- [Deploy PKCS#11 server as HSM replacement](./how-to/deploy-pkcs11-server.mdx)
+- [Configure OpenSSL 3.0 provider](./how-to/configure-openssl.mdx)
+- [Integrate JCE into Java apps](./how-to/integrate-jce.mdx)
+- [Stand up a threshold CA](./how-to/threshold-ca.mdx)
+
+## Reference
+
+- [Rust API](https://docs.rs/confium-pki)
+- [Threshold CA spec](https://www.confium.org/specs/81-threshold-ca)
+- [Composite signatures spec](https://www.confium.org/specs/82-composite-signatures)
+- [PKCS#11 server spec](https://www.confium.org/specs/83-pkcs11-server)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx)
+- [Confium PKI on the website](https://www.confium.org/pki/)

--- a/docs/privacy/index.mdx
+++ b/docs/privacy/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Confium Privacy
+description: PSI, PIR, DP, MPC, ring sigs, blind sigs, VRF, VDF
+product: privacy
+audience: privacy-dev, blockchain-dev
+---
+
+# Confium Privacy
+
+Confium Privacy is the **privacy-preserving-crypto** product: 15+
+standalone primitives for building applications that compute on
+shared data without revealing it.
+
+## Components
+
+- `confium-privacy` — PSI, PIR, DP, MPC, ring sigs, blind sigs, adaptor sigs, VRF, VDF, and more
+- `confium-crypto-zk` — ZK proofs of set membership, signature possession
+- `confium-crypto-vss` — Verifiable secret sharing, Paillier, Schnorr, range proofs
+- `confium-ring` — Threshold ring signatures
+
+## Concepts
+
+- [Private Set Intersection (PSI)](./concepts/psi.mdx)
+- [Private Information Retrieval (PIR)](./concepts/pir.mdx)
+- [Differential Privacy (DP)](./concepts/dp.mdx)
+- [Multi-party Computation (MPC / SPDZ)](./concepts/mpc.mdx)
+- [Ring signatures](./concepts/ring-sigs.mdx)
+- [Blind signatures](./concepts/blind-sigs.mdx)
+- [VRF + VDF](./concepts/vrf-vdf.mdx)
+
+## How-to
+
+- [Choose the right primitive](./how-to/choose-primitive.mdx)
+- [Two-party PSI](./how-to/two-party-psi.mdx)
+- [MPC cluster deployment](./how-to/mpc-cluster.mdx)
+- [Issue anonymous credentials](./how-to/anonymous-credentials.mdx)
+
+## Reference
+
+- [Rust API](https://docs.rs/confium-privacy)
+- [PSI spec](https://www.confium.org/specs/31-psi)
+- [MPC spec](https://www.confium.org/specs/32-mpc-spdz)
+- [DP spec](https://www.confium.org/specs/33-differential-privacy)
+- [Ring sigs spec](https://www.confium.org/specs/34-ring-sigs)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx)
+- [Confium Privacy on the website](https://www.confium.org/privacy/)

--- a/docs/threshold/index.mdx
+++ b/docs/threshold/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Confium Threshold
+description: T-of-N distributed signing — CMP20, GG18, FROST, MuSig, BLS
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Confium Threshold
+
+Confium Threshold is the **threshold-signing** product: replace a single
+private key with T-of-N distributed shares. No single party can sign
+alone. Compromising any T-1 parties doesn't compromise the key.
+
+## Algorithms
+
+| Algorithm | Curve / Group | Rounds | Status |
+|-----------|---------------|--------|--------|
+| CMP20 | P-256 | 3 | Shipped |
+| GG18 | P-256 | 4 | Shipped (legacy; prefer CMP20) |
+| FROST | P-256 | 2 | Shipped |
+| FROST | Ed25519 | 2 | Shipped |
+| MuSig | Schnorr | 2 | Skeleton |
+| BLS | BLS12-381 | 2 | Skeleton |
+| Threshold ElGamal | P-256 | N/A (encryption) | Shipped |
+
+## Crates
+
+- `confium-tc-core` — session primitives, share interface, registry
+- `confium-tc-keys` — key lifecycle, HSM/KMS, BIP-32
+- `confium-coordinator` — multi-round orchestration service
+- `confium-tc-cmp20` — CMP20 threshold ECDSA
+- `confium-tc-gg18` — GG18 threshold ECDSA
+- `confium-tc-frost-p256` — FROST over P-256
+- `confium-tc-frost-ed25519` — FROST over Ed25519
+- `confium-tc-bls` — Threshold BLS (skeleton)
+- `confium-tc-elgamal-p256` — Threshold ElGamal encryption
+- `confium-signerd` — production signing daemon
+
+## Concepts
+
+- [Threshold signing fundamentals](./concepts/threshold-signing.mdx)
+- [Distributed key generation (DKG)](./concepts/dkg.mdx)
+- [Multiplicative-to-Additive (MtA) via Paillier](./concepts/mta.mdx)
+- [Share refresh & proactive security](./concepts/share-refresh.mdx)
+- [Reshare: changing T or N without re-keying](./concepts/reshare.mdx)
+
+## How-to
+
+- [Deploy signerd in production](./how-to/deploy-signerd.mdx)
+- [Protect shares with an HSM](./how-to/integrate-hsm.mdx)
+- [Schedule Herzberg share refresh](./how-to/refresh.mdx)
+- [Monitor signing sessions](./how-to/monitor.mdx)
+- [Attribute-based signing policies](./how-to/policy.mdx)
+
+## Reference
+
+- [Rust API](https://docs.rs/confium-threshold)
+- [signerd config reference](./reference/config.mdx)
+- [CLI commands](./reference/cli.mdx)
+- [Threshold session spec](https://www.confium.org/specs/22-threshold-session)
+- [CMP20 spec](https://www.confium.org/specs/70-cmp20)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx) — engine, plugin loader
+- [Bindings parity matrix](../bindings/parity.mdx) — what's available per language
+- [Confium Threshold on the website](https://www.confium.org/threshold/)

--- a/docs/transparency/index.mdx
+++ b/docs/transparency/index.mdx
@@ -1,0 +1,46 @@
+---
+title: Confium Transparency
+description: RFC 6962 append-only Merkle tree with witness gossip, OTS, ERS
+product: transparency
+audience: compliance, ca-operator
+---
+
+# Confium Transparency
+
+Confium Transparency is the **audit-trail** product: append-only Merkle
+trees with cryptographic inclusion proofs. Tamper-evidence is proven,
+not claimed.
+
+## Components
+
+- `confium-transparency` — RFC 6962 Merkle tree, OTS, ERS
+- `confium-log-server` — production log server
+- `confium-log-monitor` — third-party monitor (witness)
+- `confium-log-edge` — Cloudflare Workers edge verifier
+
+## Concepts
+
+- [RFC 6962 inclusion & consistency proofs](./concepts/rfc-6962.mdx)
+- [Witness gossip & fork-resistance](./concepts/witness-gossip.mdx)
+- [OTS anchoring to Bitcoin / public chains](./concepts/ots-anchoring.mdx)
+- [Evidence Record Syntax (ERS) long-term archival](./concepts/ers.mdx)
+
+## How-to
+
+- [Deploy a production log server](./how-to/deploy-log-server.mdx)
+- [Run a monitor (third-party auditing)](./how-to/deploy-monitor.mdx)
+- [Deploy the Cloudflare Workers edge verifier](./how-to/deploy-edge.mdx)
+- [Anchor tree heads to Bitcoin](./how-to/bitcoin-anchor.mdx)
+
+## Reference
+
+- [Rust API](https://docs.rs/confium-transparency)
+- [Transparency log spec](https://www.confium.org/specs/42-transparency-log)
+- [Witness gossip spec](https://www.confium.org/specs/43-witness-gossip)
+- [OTS anchoring spec](https://www.confium.org/specs/44-ots-anchoring)
+- [ERS archival spec](https://www.confium.org/specs/45-ers-archival)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx)
+- [Confium Transparency on the website](https://www.confium.org/transparency/)

--- a/docs/verify/index.mdx
+++ b/docs/verify/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Confium Verify
+description: Verify threshold signatures anywhere — browser, edge, server, CLI
+product: verify
+audience: web-developer, devsecops, oss-maintainer
+---
+
+# Confium Verify
+
+Confium Verify is the **verification** product: lightweight, multi-language
+verification for composite signatures, transparency proofs, and
+certificate chains. Verifier-only by design.
+
+## Components
+
+- `confium-wasm` — Browser/Node/edge verifier via WASM
+- `confium-verify-server` — HTTP verification service
+- `confium-composite` — Composite signature verification (shared with PKI)
+- `confium-python` — Python bindings
+- `confium-node` — Node.js bindings
+- `confium-go` — Go bindings
+- `confium-ruby` (sibling repo) — Ruby gem
+
+## Concepts
+
+- [Verifier-only design philosophy](./concepts/verifier-only.mdx)
+- [Provenance & transparency-log anchoring](./concepts/provenance.mdx)
+- [Batch verification + LRU cache](./concepts/batch-verify.mdx)
+- [Language bindings parity model](./concepts/bindings.mdx)
+
+## How-to
+
+- [Embed WASM in a SPA](./how-to/wasm-in-spa.mdx)
+- [Add verify gate to CI](./how-to/ci-gate.mdx)
+- [Deploy verify-server](./how-to/server-deploy.mdx)
+- [Real-time verify dashboard](./how-to/dashboard.mdx)
+
+## Reference
+
+- [npm package](https://www.npmjs.com/package/@confium/confium-wasm)
+- [Bindings parity matrix](../bindings/parity.mdx)
+- [WASM verifier spec](https://www.confium.org/specs/61-wasm-verifier)
+- [HTTP verify spec](https://www.confium.org/specs/62-http-verify)
+- [Bindings matrix spec](https://www.confium.org/specs/63-bindings-matrix)
+
+## Cross-links
+
+- [Confium architecture](../architecture.mdx)
+- [Confium Verify on the website](https://www.confium.org/verify/)


### PR DESCRIPTION
## Summary

Closes TODO.restructure/30.

Adds `docs/{product}/index.mdx` for each of the 6 Confium products:

- `docs/threshold/`
- `docs/transparency/`
- `docs/pki/`
- `docs/keyless/`
- `docs/privacy/`
- `docs/verify/`

Each index lists:
- Component crates for the product
- Concepts (linked to MDX pages TBD)
- How-to guides (linked to MDX pages TBD)
- Reference: API docs, specs, CLI
- Cross-links to architecture and website minisite

Updates `docs/index.mdx` with a "Browse by product" section surfacing these doc roots.

The deep concept/how-to MDX files (e.g., `docs/threshold/concepts/dkg.mdx`) are out of scope for this PR — the index pages exist now so contributors have a target to fill in.

## Test plan

- [ ] Each `docs/{product}/index.mdx` renders
- [ ] `docs/index.mdx` "Browse by product" section lists all 6 products
- [ ] Cross-links to specs (https://www.confium.org/specs/...) and website (https://www.confium.org/{product}/) work

## Also includes

- Updated `TODO.restructure/README.phase2.md` with current status of all Phase 2 TODOs
