### PR TITLE
feat: product facade crates (confium-threshold, confium-keyless, confium-verify) + expand confium-pki

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ members = [
     "crates/confium-oidc",
     "crates/confium-node",
     "crates/confium-fuzz",
+    # Product facade crates (Layer 3 entry points).
+    "crates/confium-threshold",
+    "crates/confium-keyless",
+    "crates/confium-verify",
 ]
 
 [workspace.package]
@@ -138,6 +142,10 @@ confium-operator = { path = "crates/confium-operator", version = "0.3.0" }
 confium-oidc = { path = "crates/confium-oidc", version = "0.3.0" }
 confium-node = { path = "crates/confium-node", version = "0.3.0" }
 confium-fuzz = { path = "crates/confium-fuzz", version = "0.3.0" }
+# Product facade crates (Layer 3 entry points).
+confium-threshold = { path = "crates/confium-threshold", version = "0.3.0" }
+confium-keyless = { path = "crates/confium-keyless", version = "0.3.0" }
+confium-verify = { path = "crates/confium-verify", version = "0.3.0" }
 
 libloading = "0.8"
 snafu = "0.8"

--- a/crates/confium-keyless/Cargo.toml
+++ b/crates/confium-keyless/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "confium-keyless"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+readme = "README.md"
+description = "Confium Keyless product facade — OIDC-based keyless threshold signing"
+documentation = "https://docs.rs/confium-keyless"
+keywords = ["crypto", "keyless", "oidc", "signing", "confium"]
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+default = ["oidc", "threshold"]
+oidc = ["dep:confium-oidc"]
+threshold = ["dep:confium-threshold"]
+verify = ["dep:confium-composite"]
+full = ["oidc", "threshold", "verify"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+confium-oidc = { workspace = true, optional = true }
+confium-threshold = { workspace = true, optional = true }
+confium-composite = { workspace = true, optional = true }

--- a/crates/confium-keyless/README.md
+++ b/crates/confium-keyless/README.md
@@ -1,0 +1,9 @@
+# confium-keyless
+
+Product facade for **Confium Keyless** — OIDC-based keyless signing.
+
+```toml
+confium-keyless = { version = "0.3" }
+```
+
+See <https://www.confium.org/keyless/>.

--- a/crates/confium-keyless/src/lib.rs
+++ b/crates/confium-keyless/src/lib.rs
@@ -1,0 +1,24 @@
+//! Single-entry-point crate for the Confium **Keyless** product.
+//!
+//! OIDC-based keyless threshold signing for short-lived certificates.
+//!
+//! # Example
+//!
+//! ```toml
+//! confium-keyless = { version = "0.3" }
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+#[cfg(feature = "oidc")]
+/// OIDC JWT verification + claim validation.
+pub use confium_oidc as oidc;
+
+#[cfg(feature = "threshold")]
+/// Threshold signing surface used to issue short-lived certs.
+pub use confium_threshold as threshold;
+
+#[cfg(feature = "verify")]
+/// Composite signature verification for keyless artifacts.
+pub use confium_composite as composite;

--- a/crates/confium-pki/Cargo.toml
+++ b/crates/confium-pki/Cargo.toml
@@ -19,6 +19,14 @@ parsing = []
 delegation = []
 cms = []
 xmldsig = []
+# Product-surface expansions (optional adapters).
+pkcs11-server = ["dep:confium-pkcs11-server"]
+openssl-provider = ["dep:confium-openssl-provider"]
+jce-provider = ["dep:confium-jce-provider"]
+tls-signer = ["dep:confium-tls-signer"]
+composite = ["dep:confium-composite"]
+attributes = ["dep:confium-attributes"]
+full = ["pkcs11-server", "openssl-provider", "jce-provider", "tls-signer", "composite", "attributes"]
 
 
 [package.metadata.docs.rs]
@@ -36,6 +44,14 @@ spki = { workspace = true }
 chrono = { workspace = true }
 data-encoding = { workspace = true }
 sha2 = { workspace = true }
+
+confium-pkcs11-server = { workspace = true, optional = true }
+confium-openssl-provider = { workspace = true, optional = true }
+confium-jce-provider = { workspace = true, optional = true }
+confium-tls-signer = { workspace = true, optional = true }
+confium-composite = { workspace = true, optional = true }
+confium-attributes = { workspace = true, optional = true }
+
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/confium-pki/src/lib.rs
+++ b/crates/confium-pki/src/lib.rs
@@ -50,3 +50,28 @@ pub use cms::*;
 
 #[cfg(feature = "xmldsig")]
 pub use xmldsig::*;
+
+// Product-surface expansions (optional adapters, off by default).
+#[cfg(feature = "pkcs11-server")]
+/// PKCS#11 server (drop-in HSM replacement).
+pub use confium_pkcs11_server as pkcs11_server;
+
+#[cfg(feature = "openssl-provider")]
+/// OpenSSL 3.0 provider.
+pub use confium_openssl_provider as openssl_provider;
+
+#[cfg(feature = "jce-provider")]
+/// Java Cryptography Extension provider.
+pub use confium_jce_provider as jce_provider;
+
+#[cfg(feature = "tls-signer")]
+/// TLS 1.3 signature callback.
+pub use confium_tls_signer as tls_signer;
+
+#[cfg(feature = "composite")]
+/// Composite signatures (PQ migration).
+pub use confium_composite as composite;
+
+#[cfg(feature = "attributes")]
+/// Attribute-based signing predicates.
+pub use confium_attributes as attributes;

--- a/crates/confium-threshold/Cargo.toml
+++ b/crates/confium-threshold/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "confium-threshold"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+readme = "README.md"
+description = "Confium Threshold product facade — T-of-N distributed signing (CMP20, GG18, FROST)"
+documentation = "https://docs.rs/confium-threshold"
+keywords = ["crypto", "threshold", "cmp20", "frost", "confium"]
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+default = ["cmp20", "frost-p256", "frost-ed25519", "coordinator", "keys"]
+cmp20 = ["dep:confium-tc-cmp20"]
+gg18 = ["dep:confium-tc-gg18"]
+frost-p256 = ["dep:confium-tc-frost-p256"]
+frost-ed25519 = ["dep:confium-tc-frost-ed25519"]
+bls = ["dep:confium-tc-bls"]
+elgamal-p256 = ["dep:confium-tc-elgamal-p256"]
+coordinator = ["dep:confium-coordinator"]
+keys = ["dep:confium-tc-keys"]
+full = ["cmp20", "gg18", "frost-p256", "frost-ed25519", "bls", "elgamal-p256", "coordinator", "keys"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+confium-tc-core = { workspace = true }
+confium-tc-cmp20 = { workspace = true, optional = true }
+confium-tc-gg18 = { workspace = true, optional = true }
+confium-tc-frost-p256 = { workspace = true, optional = true }
+confium-tc-frost-ed25519 = { workspace = true, optional = true }
+confium-tc-bls = { workspace = true, optional = true }
+confium-tc-elgamal-p256 = { workspace = true, optional = true }
+confium-coordinator = { workspace = true, optional = true }
+confium-tc-keys = { workspace = true, optional = true }

--- a/crates/confium-threshold/README.md
+++ b/crates/confium-threshold/README.md
@@ -1,0 +1,9 @@
+# confium-threshold
+
+Product facade for **Confium Threshold** — T-of-N distributed signing.
+
+```toml
+confium-threshold = { version = "0.3", features = ["cmp20", "frost-p256"] }
+```
+
+See <https://www.confium.org/threshold/>.

--- a/crates/confium-threshold/src/lib.rs
+++ b/crates/confium-threshold/src/lib.rs
@@ -1,0 +1,49 @@
+//! Single-entry-point crate for the Confium **Threshold** product.
+//!
+//! Re-exports the threshold-cryptography crates that comprise the product
+//! behind feature flags. Consumers depend on `confium-threshold` instead
+//! of pulling 5–12 separate crates.
+//!
+//! # Example
+//!
+//! ```toml
+//! confium-threshold = { version = "0.3", features = ["cmp20", "frost-p256"] }
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Core session interface for scheme plugins.
+pub use confium_tc_core as core;
+
+#[cfg(feature = "cmp20")]
+/// CMP20 threshold ECDSA over P-256.
+pub use confium_tc_cmp20 as cmp20;
+
+#[cfg(feature = "gg18")]
+/// GG18 threshold ECDSA over P-256 (legacy; prefer CMP20).
+pub use confium_tc_gg18 as gg18;
+
+#[cfg(feature = "frost-p256")]
+/// FROST over P-256.
+pub use confium_tc_frost_p256 as frost_p256;
+
+#[cfg(feature = "frost-ed25519")]
+/// FROST over Ed25519.
+pub use confium_tc_frost_ed25519 as frost_ed25519;
+
+#[cfg(feature = "bls")]
+/// Threshold BLS.
+pub use confium_tc_bls as bls;
+
+#[cfg(feature = "elgamal-p256")]
+/// Threshold ElGamal encryption over P-256.
+pub use confium_tc_elgamal_p256 as elgamal_p256;
+
+#[cfg(feature = "coordinator")]
+/// Multi-round orchestration coordinator.
+pub use confium_coordinator as coordinator;
+
+#[cfg(feature = "keys")]
+/// Threshold key lifecycle, HSM protection, BIP-32.
+pub use confium_tc_keys as keys;

--- a/crates/confium-verify/Cargo.toml
+++ b/crates/confium-verify/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "confium-verify"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories.workspace = true
+readme = "README.md"
+description = "Confium Verify product facade — multi-language verification of signatures, proofs, certs"
+documentation = "https://docs.rs/confium-verify"
+keywords = ["crypto", "verify", "wasm", "signature", "confium"]
+
+[lib]
+crate-type = ["rlib"]
+
+[features]
+default = ["composite", "transparency", "pki"]
+composite = ["dep:confium-composite"]
+transparency = ["dep:confium-transparency"]
+pki = ["dep:confium-pki"]
+attributes = ["dep:confium-attributes"]
+server = ["dep:confium-verify-server"]
+full = ["composite", "transparency", "pki", "attributes", "server"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+confium-composite = { workspace = true, optional = true }
+confium-transparency = { workspace = true, optional = true }
+confium-pki = { workspace = true, optional = true }
+confium-attributes = { workspace = true, optional = true }
+confium-verify-server = { workspace = true, optional = true }

--- a/crates/confium-verify/README.md
+++ b/crates/confium-verify/README.md
@@ -1,0 +1,9 @@
+# confium-verify
+
+Product facade for **Confium Verify** — multi-language verification.
+
+```toml
+confium-verify = { version = "0.3" }
+```
+
+See <https://www.confium.org/verify/>.

--- a/crates/confium-verify/src/lib.rs
+++ b/crates/confium-verify/src/lib.rs
@@ -1,0 +1,33 @@
+//! Single-entry-point crate for the Confium **Verify** product.
+//!
+//! Lightweight multi-language verification of composite signatures,
+//! transparency proofs, and certificate chains. Verifier-only by design.
+//!
+//! # Example
+//!
+//! ```toml
+//! confium-verify = { version = "0.3" }
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+#[cfg(feature = "composite")]
+/// Composite multi-algorithm signature verification.
+pub use confium_composite as composite;
+
+#[cfg(feature = "transparency")]
+/// RFC 6962 transparency proof verification.
+pub use confium_transparency as transparency;
+
+#[cfg(feature = "pki")]
+/// X.509 certificate + CMS verification.
+pub use confium_pki as pki;
+
+#[cfg(feature = "attributes")]
+/// Attribute-based predicate evaluation.
+pub use confium_attributes as attributes;
+
+#[cfg(feature = "server")]
+/// HTTP verification service.
+pub use confium_verify_server as server;


### PR DESCRIPTION
## Summary

Closes TODO.restructure/20 — the last blocked TODO from Phase 2.

Adds three product facade crates (single-entry-point per product) and expands `confium-pki`'s feature set to cover the full PKI product surface.

### `confium-threshold`

Re-exports `tc-core` + scheme crates (`cmp20`/`gg18`/`frost-p256`/`frost-ed25519`/`bls`/`elgamal-p256`) + `coordinator` + `keys` behind feature flags.

- Default: `cmp20`, `frost-p256`, `frost-ed25519`, `coordinator`, `keys`
- Full: + `gg18`, `bls`, `elgamal-p256`

### `confium-keyless`

Re-exports `oidc` + `confium-threshold` + `composite` behind feature flags.

- Default: `oidc`, `threshold`
- Full: + `verify` (composite)

### `confium-verify`

Re-exports `composite` + `transparency` + `pki` + `attributes` + `verify-server`.

- Default: `composite`, `transparency`, `pki`
- Full: + `attributes`, `server`

### `confium-pki` expansion (back-compat)

Adds optional features that re-export adapter crates:
- `pkcs11-server`, `openssl-provider`, `jce-provider`, `tls-signer`, `composite`, `attributes`
- All default-off; existing `parsing`/`delegation`/`cms`/`xmldsig` defaults unchanged
- `--features full` pulls in the entire PKI product surface

## Verification

- `cargo build -p confium-threshold -p confium-keyless -p confium-verify` green
- `cargo check -p confium-pki --no-default-features --features full` green
- 64 workspace members (was 61)

## Consumer shape

```toml
# Threshold — pick schemes
confium-threshold = { version = "0.3", features = ["cmp20", "frost-p256"] }

# Keyless — end-to-end keyless signing
confium-keyless = "0.3"

# Verify — verifier-only surface
confium-verify = "0.3"

# PKI — full product surface (parsing + adapters + composite)
confium-pki = { version = "0.3", features = ["full"] }
```

## Test plan

- [x] All three facades build with default + full features
- [x] confium-pki back-compat preserved (no breaking changes to existing API)
- [x] Workspace `cargo check --workspace` green
- [ ] CI full suite
