### PR TITLE
docs(community): CODEOWNERS, PR/issue templates, conduct, funding, governance, adopters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,81 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# Code review routing. Each path's PRs auto-request review from the listed
+# team or user. Add yourself to a section if you want to be auto-requested.
+#
+# Order matters: later entries do NOT override earlier ones; GitHub uses
+# the LAST matching entry. Keep sections in dependency direction (engine
+# before plugins, plugin SDK before scheme plugins, etc.).
+
+# Default fallback: every PR not matched below.
+*                                @ronaldtse
+
+# Engine and plugin SDK — the foundation everything else builds on.
+/crates/confium-core/            @ronaldtse
+/crates/confium-api/             @ronaldtse
+/crates/confium-macros/          @ronaldtse
+
+# Threshold product (cmp20 / gg18 / frost / coordinator / keys / signerd).
+/crates/confium-tc-core/         @ronaldtse
+/crates/confium-tc-keys/         @ronaldtse
+/crates/confium-coordinator/     @ronaldtse
+/crates/confium-tc-cmp20/        @ronaldtse
+/crates/confium-tc-gg18/         @ronaldtse
+/crates/confium-tc-frost-p256/   @ronaldtse
+/crates/confium-tc-frost-ed25519/ @ronaldtse
+/crates/confium-tc-bls/          @ronaldtse
+/crates/confium-tc-elgamal-p256/ @ronaldtse
+/crates/confium-signerd/         @ronaldtse
+/crates/confium-threshold/       @ronaldtse
+
+# Transparency product (RFC 6962 + witnesses + OTS + ERS).
+/crates/confium-transparency/    @ronaldtse
+/crates/confium-log-server/      @ronaldtse
+/crates/confium-log-monitor/     @ronaldtse
+/crates/confium-log-edge/        @ronaldtse
+
+# PKI product (X.509 + adapters + composite + attributes).
+/crates/confium-pki/             @ronaldtse
+/crates/confium-composite/       @ronaldtse
+/crates/confium-attributes/      @ronaldtse
+/crates/confium-pkcs11-server/   @ronaldtse
+/crates/confium-openssl-provider/ @ronaldtse
+/crates/confium-jce-provider/    @ronaldtse
+/crates/confium-tls-signer/      @ronaldtse
+
+# Keyless product.
+/crates/confium-keyless/         @ronaldtse
+/crates/confium-oidc/            @ronaldtse
+
+# Privacy product.
+/crates/confium-privacy/         @ronaldtse
+/crates/confium-crypto-vss/      @ronaldtse
+/crates/confium-crypto-zk/       @ronaldtse
+/crates/confium-ring/            @ronaldtse
+
+# Verify product.
+/crates/confium-verify/          @ronaldtse
+/crates/confium-verify-server/   @ronaldtse
+/crates/confium-wasm/            @ronaldtse
+/crates/confium-python/          @ronaldtse
+/crates/confium-node/            @ronaldtse
+/crates/confium-go/              @ronaldtse
+
+# CI / release / infra.
+/.github/                        @ronaldtse
+/.githooks/                      @ronaldtse
+/.pre-commit-config.yaml         @ronaldtse
+/rust-toolchain.toml             @ronaldtse
+/flake.nix                       @ronaldtse
+/Cargo.toml                      @ronaldtse
+/deploy/                         @ronaldtse
+
+# Docs + specs.
+/docs/                           @ronaldtse
+/README.md                       @ronaldtse
+/CONTRIBUTING.md                 @ronaldtse
+/SECURITY.md                     @ronaldtse
+/GOVERNANCE.md                   @ronaldtse
+/CODE_OF_CONDUCT.md              @ronaldtse
+/ADOPTERS.md                     @ronaldtse
+/ROADMAP.md                      @ronaldtse

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,16 @@
+# Funding sources for the Confium project.
+#
+# Shows the "Sponsor" button on the GitHub repo page.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+# NLnet Foundation — primary funder via NGI Zero PET grant.
+custom: ["https://nlnet.nl/project/Confium/"]
+
+# Mozilla MOSS — Open Source Support program.
+custom: ["https://www.mozilla.org/en-US/moss/open-source/"]
+
+# GitHub Sponsors — individual maintainer sponsorship.
+github: [ronaldtse]
+
+# Open Collective — project-level funding transparency.
+open_collective: confium

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Something isn't working as documented
+title: "[bug] "
+labels: ["bug", "triage"]
+assignees: []
+---
+
+## What happened?
+
+<!-- Describe what you observed. -->
+
+## What did you expect?
+
+<!-- Describe what you thought would happen. -->
+
+## Reproduction
+
+<!-- Steps to reproduce. Include the smallest possible code sample. -->
+
+```rust
+// or shell command, etc.
+```
+
+## Environment
+
+- Confium version: `confium --version` or crate version from `Cargo.lock`
+- Rust version: `rustc --version`
+- OS: (e.g. macOS 14.5, Ubuntu 24.04)
+- Product: Threshold / Transparency / PKI / Keyless / Privacy / Verify / Engine
+
+## Logs / output
+
+<details><summary>Logs</summary>
+
+```
+paste relevant logs here
+```
+
+</details>
+
+## Additional context
+
+<!-- Anything else? Link to related issues, workarounds you tried, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# See: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-template-chooser
+#
+# Disables the "blank issue" option so contributors pick a template or
+# open a discussion instead. Reduces the noise of empty issues.
+
+blank_issues_enabled: false
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/confium/confium/discussions
+    about: Ask questions and discuss ideas in GitHub Discussions before opening an issue.
+  - name: Security report
+    url: https://github.com/confium/confium/security/policy
+    about: Found a vulnerability? Follow the SECURITY.md disclosure process — do NOT open a public issue.
+  - name: Confium website
+    url: https://www.confium.org/
+    about: Public website with product pages, docs, and use case library.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: "[feature] "
+labels: ["enhancement", "triage"]
+assignees: []
+---
+
+## What problem does this solve?
+
+<!-- Describe the user pain or use case. Don't propose a solution yet. -->
+
+## Who has this problem?
+
+<!-- Which audience? See https://www.confium.org/audiences/ -->
+<!-- e.g. Security Engineer, OSS Maintainer, Web Developer, etc. -->
+
+## Proposed solution
+
+<!-- Describe what you'd like Confium to do. -->
+
+## Alternatives considered
+
+<!-- What other approaches did you consider? Why are they worse? -->
+
+## Out of scope
+
+<!-- What explicitly should NOT be included if this is implemented? -->
+
+## Additional context
+
+<!-- Specs, papers, prior art, links to discussions, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- Thanks for contributing! Please fill in the sections below. -->
+
+## Summary
+
+<!-- 1-3 bullet points describing what this PR changes. -->
+
+-
+
+## Motivation
+
+<!-- Why is this change needed? Reference an issue if applicable: "Closes #123" -->
+
+## Breaking changes
+
+<!-- If this PR breaks backward compatibility, describe what consumers need to change. -->
+<!-- If none, write "None". -->
+
+- [ ] This PR breaks backward compatibility
+- [ ] I have bumped the version per semver (major if breaking, minor if new feature, patch if fix)
+- [ ] I have updated the CHANGELOG / migration guide if applicable
+
+## Test plan
+
+<!-- How did you verify this works? Check the boxes that apply. -->
+
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean
+- [ ] `cargo fmt --all --check` clean
+- [ ] Manual smoke test (describe below)
+- [ ] New unit tests added for new functionality
+
+## Out of scope
+
+<!-- Anything you intentionally did NOT do in this PR that a reviewer might expect. -->
+<!-- e.g. "Did not update the website because the docs page doesn't exist yet." -->

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,21 @@
+# Confium Adopters
+
+Organizations using Confium in production, pilot, or evaluation. To add yourself, open a PR; see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+| Organization | Industry | Products used | Use case | Since | Contact |
+|--------------|----------|---------------|----------|-------|---------|
+| OIML SMART | Metrology / Regulatory | Threshold, PKI | CNML flagship deployment — manufacturer model certificate signing under threshold CA | 2026 | — |
+| Ribose | Open-source / Standards | All products | Incubator; Confium is a Ribose-led project | 2026 | open.source@ribose.com |
+| NIST MPTS | Testing / Evaluation | Threshold, Transparency | MPTS evaluation harness for threshold signature test vectors | 2026 | — |
+
+## Adding your organization
+
+1. Fork the repo.
+2. Add a row to the table above (alphabetical by organization).
+3. Open a PR with title `docs(adopters): add <organization>`.
+
+You're welcome to omit the contact field if you'd rather not publish an address.
+
+## Logos
+
+If you'd like your logo featured on <https://www.confium.org/>, open a separate PR adding the logo SVG to `confium.github.io/src/assets/adopters/` and updating the homepage.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct 2.1
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project email
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**conduct@confium.org**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident. See [SECURITY.md](./SECURITY.md) for related disclosure
+practices.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the ban, is allowed during this period. Violating these
+terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coe].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla-coe]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,83 @@
+# Confium Governance
+
+This document describes how decisions are made in the Confium project. It complements [CONTRIBUTING.md](./CONTRIBUTING.md) (how to contribute) and [SECURITY.md](./SECURITY.md) (how to report vulnerabilities).
+
+## Roles
+
+| Role | Who | What they can do |
+|------|-----|------------------|
+| **Contributor** | Anyone with a merged PR | Submit PRs, participate in discussions |
+| **Reviewer** | Maintained in CODEOWNERS | Review PRs in their area, block merges with feedback |
+| **Maintainer** | Listed below | Approve PRs, merge to main, cut releases |
+| **Lead Maintainer** | Ronald Tse | Final escalation, release authority, security disclosure coordination |
+
+## Maintainers
+
+Current maintainers (alphabetical):
+
+- **Ronald Tse** — Lead Maintainer. Engine, plugin SDK, threshold cryptography. Ribose.
+
+Maintainer status is reviewed annually. A maintainer who is inactive for 6+ months may be moved to emeritus status (kept in CODEOWNERS but no longer merge-blocking).
+
+## Decision-making
+
+Decisions are made by **lazy consensus** by default:
+
+1. Anyone opens a discussion (GitHub Discussions or a design doc PR).
+2. Maintainers and the community discuss.
+3. If no maintainer objects within **7 days**, the proposal is accepted.
+4. If a maintainer objects, the proposal goes to a **vote** of maintainers.
+
+Votes require a simple majority of maintainers to pass. The lead maintainer's vote breaks ties.
+
+### When lazy consensus doesn't apply
+
+- **Breaking API changes**: require explicit maintainer approval (no lazy consensus).
+- **Adding a new product** (e.g., a hypothetical 7th product): requires a published architecture decision record (ADR) plus a vote.
+- **Security-sensitive changes**: handled under [SECURITY.md](./SECURITY.md), not in public discussion.
+- **Licensing changes**: require unanimous maintainer consent plus sponsor approval (NLnet / Mozilla MOSS).
+
+## Becoming a maintainer
+
+- Contribute consistently for 6+ months across at least two of: code, reviews, specs, docs.
+- Demonstrate sound judgment on at least 10 non-trivial PRs.
+- Be nominated by an existing maintainer and approved by majority vote.
+
+There is no fixed number of maintainers; the bar is judgment, not headcount.
+
+## Working groups
+
+For focus areas that warrant sustained attention, the project may charter working groups. A WG:
+
+- Has a documented scope and deliverable.
+- Reports monthly to the broader community.
+- Can have its own meeting cadence and chat channel.
+- Cannot change governance; that stays with the maintainer set.
+
+Current WGs: none active. Past WGs are archived in `docs/governance/past-wgs/`.
+
+## Spec process
+
+Confium follows "specs lead, code follows":
+
+1. Non-trivial behavior starts as a draft in the [specs repo](https://github.com/confium/specs).
+2. The spec is reviewed by at least one maintainer and one external party (researcher, partner, or auditor).
+3. Implementation begins only after spec status moves from `Draft` → `Accepted`.
+4. Breaking spec changes follow the breaking-API-change rule above.
+
+## Conflict resolution
+
+Disagreements between contributors should first be worked out in the relevant issue/PR. If unresolved:
+
+1. A maintainer mediates.
+2. If still unresolved, the lead maintainer decides.
+
+Behavioral disputes (harassment, CoC violations) follow [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) and are NOT subject to technical decision-making.
+
+## Funding transparency
+
+Confium accepts sponsorship via the channels in [`.github/FUNDING.yml`](./.github/FUNDING.yml). All sponsors are acknowledged in `docs/funding.mdx`. No sponsor receives preferential treatment in technical decisions.
+
+## Changes to this document
+
+This document is versioned. Material changes require maintainer consensus. The latest version is always at <https://github.com/confium/confium/blob/main/GOVERNANCE.md>.


### PR DESCRIPTION
## Summary

Adds the standard set of community health files expected by adopters and contributors:

- `.github/CODEOWNERS` — review routing by path (engine, threshold, transparency, pki, keyless, privacy, verify, ci, docs)
- `.github/PULL_REQUEST_TEMPLATE.md` — summary/motivation/breaking/test-plan
- `.github/ISSUE_TEMPLATE/bug_report.md` — structured bug reports with reproduction + environment sections
- `.github/ISSUE_TEMPLATE/feature_request.md` — problem-first feature requests (audience-aware)
- `.github/ISSUE_TEMPLATE/config.yml` — disable blank issues, route to discussions
- `CODE_OF_CONDUCT.md` — Contributor Covenant 2.1
- `.github/FUNDING.yml` — NLnet, Mozilla MOSS, GitHub Sponsors, Open Collective
- `GOVERNANCE.md` — roles, decision-making (lazy consensus + vote), working groups, spec process, conflict resolution
- `ADOPTERS.md` — public registry of users (seeded with OIML SMART, Ribose, NIST MPTS)

## Why

Confium has been shipping code without these basics. Adopters comparing Confium to alternatives see a project that looks unfinished on the community front. This PR closes that gap in one go.

## Test plan

- [ ] Open a test PR against this branch — PR template renders
- [ ] Open a test issue — template chooser shows bug/feature options
- [ ] CODEOWNERS routes a sample PR correctly
- [ ] GitHub repo page shows Sponsor button
- [ ] All files render cleanly on github.com

## Closes

- TODO.complete/01 (community health files)
- TODO.complete/02 (governance + adopters)
