### PR TITLE
ci(quality): coverage + perf regression + welcome/stale bots + npm dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,3 +51,18 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+
+  # npm — WASM package + Cloudflare Worker edge verifier.
+  - package-ecosystem: "npm"
+    directory: "/crates/confium-log-edge"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      npm-edge:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,54 @@
+# Coverage reporting via cargo-llvm-cov.
+#
+# Runs on every PR (informational; doesn't gate merges for the first
+# 90 days while we establish a baseline). Uploads lcov.info to
+# Codecov. Add a coverage badge to README once we have a stable number.
+
+name: Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Generate coverage
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+        env:
+          # Skip the WASM crate (target_arch != wasm32 builds won't work here).
+          CARGO_LLVM_COV_TARGET_DIRECTORY: target/cov
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: lcov.info
+          fail_ci_if_error: false
+          # Use the CODECOV_TOKEN secret once we register at codecov.io;
+          # tokenless uploads work for PRs but not for push events.
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload lcov artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lcov.info
+          path: lcov.info
+          retention-days: 14

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,55 @@
+# Performance regression tracking.
+#
+# Runs the crates/confium-benchmarks suite on PRs that touch crypto
+# crates, posts a delta-vs-main comment on the PR, and fails on >10%
+# regression on the headline benchmarks.
+#
+# Tunable: edit the [thresholds] section below to adjust per-bench
+# sensitivity.
+
+name: Performance
+
+on:
+  pull_request:
+    paths:
+      # Only run when crypto-relevant code changes.
+      - "crates/confium-tc-*/**"
+      - "crates/confium-composite/**"
+      - "crates/confium-transparency/**"
+      - "crates/confium-crypto-*/**"
+      - "crates/confium-privacy/**"
+      - "crates/confium-benchmarks/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # We need main to diff against.
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            target
+          key: ${{ runner.os }}-perf-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run benchmarks on PR
+        uses: CodSpeedHQ/action@v3
+        with:
+          # confium-benchmarks uses criterion; CodSpeed wraps it.
+          run: cargo bench -p confium-benchmarks
+          token: ${{ secrets.CODSPEED_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+# Mark stale issues and PRs after a period of inactivity.
+#
+# Issue policy:
+#   - Mark stale after 60 days of inactivity
+#   - Close after another 14 days
+#   - Exempt: security issues, PRs, anything labeled 'pinned' or 'security'
+#
+# PR policy: same cadence so contributors get a clear signal.
+
+name: Stale bot
+
+on:
+  schedule:
+    - cron: "30 4 * * *"  # Daily at 04:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          # Issues
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue has been inactive for 60 days and is being marked
+            stale. It will be closed in 14 days unless there's new
+            activity or the `keep-open` label is applied.
+          close-issue-message: |
+            Closed as stale. Reopen or open a new issue with fresh context
+            if this is still relevant.
+          # PRs
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          stale-pr-message: |
+            This PR has been inactive for 60 days. It will be closed in
+            14 days unless the author rebases or comments.
+          # Exemptions
+          exempt-issue-labels: pinned,security,roadmap
+          exempt-pr-labels: pinned,security,do-not-merge
+          operations-per-run: 50

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,37 @@
+# Welcome first-time contributors + gently nudge on their PR.
+#
+# Triggers on a contributor's first-ever issue or PR in the repo and
+# posts a friendly welcome message. Pure UX; no enforcement.
+
+name: Welcome
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: |
+            👋 Thanks for opening your first PR on Confium!
+
+            A maintainer will review this soon. In the meantime:
+            - Check that CI is green
+            - Make sure `cargo fmt --all --check` and `cargo clippy --workspace -- -D warnings` pass locally
+            - If this is a non-trivial change, consider linking to a spec or design discussion
+
+            We're glad you're here.
+          issue-message: |
+            👋 Thanks for your first issue on Confium!
+
+            A maintainer will triage this within a few days. If it's urgent, ping us in [Discussions](https://github.com/confium/confium/discussions).


### PR DESCRIPTION
## Summary

Adds 4 new CI workflows + dependabot npm ecosystem.

### `coverage.yml`
Runs `cargo-llvm-cov` on every PR, uploads `lcov.info` to Codecov. Informational only (doesn't gate merges) for first 90 days while baseline is established. Needs `CODECOV_TOKEN` secret once we register at codecov.io.

### `perf.yml`
Runs `confium-benchmarks` via CodSpeed on PRs touching crypto crates. Path-filtered to:
- `crates/confium-tc-*/**`
- `crates/confium-composite/**`
- `crates/confium-transparency/**`
- `crates/confium-crypto-*/**`
- `crates/confium-privacy/**`
- `crates/confium-benchmarks/**`

Posts delta-vs-main to PR via CodSpeed. Needs `CODSPEED_TOKEN` secret.

### `welcome.yml`
`actions/first-interaction` on first PR/issue. Friendly welcome pointing at CONTRIBUTING + Discussions.

### `stale.yml`
Daily `actions/stale` sweep at 04:30 UTC.
- Issues + PRs marked stale after 60d, closed after 14d more
- Exempt: `pinned`, `security`, `roadmap`, `do-not-merge`

### `dependabot.yml`
Adds npm ecosystem for `crates/confium-log-edge` (Cloudflare Workers). Already had cargo + github-actions + docker.

## Secrets needed (when registering)

| Secret | Used by | Where to get |
|--------|---------|--------------|
| `CODECOV_TOKEN` | coverage.yml | codecov.io |
| `CODSPEED_TOKEN` | perf.yml | codspeed.io |

## Test plan

- [ ] All 4 workflows validate via actionlint
- [ ] First PR runs coverage and welcome workflows
- [ ] PR touching `crates/confium-tc-cmp20/` triggers perf workflow
- [ ] dependabot opens an npm PR within a week

## Closes

- TODO.complete/06 (coverage reporting)
- TODO.complete/07 (perf regression CI)
- TODO.complete/08 (dependabot expansion)
- TODO.complete/09 (stale + welcome bots)
