### PR TITLE
docs(strategic): ROADMAP + policies + threat model + comparison + migrations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,125 @@
+---
+title: Confium Roadmap
+description: Six-month and twelve-month direction for the Confium project
+date: 2026-08-07
+status: accepted
+---
+
+# Confium Roadmap
+
+This roadmap captures the project direction at a glance. For day-to-day tasks see [TODO files](https://github.com/confium/confium/tree/main/TODO.restructure); for architectural direction see [Architecture](./architecture.mdx).
+
+**Status:** Accepted (2026-08-07). Reviewed quarterly.
+
+## Vision (12 months)
+
+Make Confium the default open-source framework for distributed cryptographic trust — the same relationship OpenSSL has to transport security, but for threshold signing, transparency, and PKI.
+
+Concretely, by 2027-08:
+
+- **All 6 products** (Threshold, Transparency, PKI, Keyless, Privacy, Verify) are at production maturity with real-world deployments
+- **5 language bindings** (Rust, Ruby, Python, WASM/TypeScript, Go, Node) at full feature parity
+- **NIST MPTS** evaluation complete; Confium is a reference implementation for threshold signature test vectors
+- **Multiple CAs** operate threshold CA deployments on Confium in production
+- **Browser-side verification** of Confium signatures is as common as PGP signature verification in OSS release tooling
+
+## Themes (6 months)
+
+### Theme 1 — Production hardening
+Move every shipped crate from "implementation complete" to "production-grade":
+- chaos testing in `confium-coordinator`
+- HSM-backed share storage in production
+- multi-region DKG ceremonies
+- graceful shutdown / failover in `confium-signerd`
+- audit log immutability via transparency log anchoring
+
+### Theme 2 — PQ migration
+Composite signatures ship stable (Ed25519 + ECDSA-P256 today); add:
+- ML-DSA-65 (FIPS 204) threshold via `confium-tc-frost-ml-dsa-65`
+- SLH-DSA-SHA2-256 composite (FIPS 205)
+- LMS composite for archival
+- Threshold ML-KEM (FIPS 203) for hybrid KEMs
+
+### Theme 3 — Keyless ubiquity
+- GitHub Action: `uses: confium/action@v1` in every major OSS release workflow
+- PyPI / RubyGems / npm packages signed via Confium Keyless
+- Browser extension: verify Confium signatures on any GitHub release page
+
+### Theme 4 — Privacy in production
+Move privacy primitives from research-grade to production-grade:
+- PSI: 2-party at 10M-element scale
+- MPC: SPDZ with online/offline phase separation
+- DP: persistent budget tracking across queries
+
+### Theme 5 — Transparency at scale
+- 1B-entry logs on commodity hardware
+- witness gossip across 25+ independent witnesses
+- OTS anchoring cadence: 10 min (vs 1 hr today)
+- ERS archival to public Internet Archive
+
+### Theme 6 — UX polish
+- 5-minute quickstart for every product (no more)
+- Confium Playground: in-browser DKG + sign + verify, no install
+- Confium Inspector: GUI for inspecting signatures / proofs / certs
+
+## Per-product themes
+
+### Threshold
+- ✅ CMP20, GG18, FROST-P256, FROST-Ed25519 shipped
+- 🚧 Real Paillier MtA in production (currently stubbed in-process)
+- 🚧 Share refresh in production (Herzberg)
+- 🚧 signerd production deployment guide
+
+### Transparency
+- ✅ RFC 6962 inclusion + consistency proofs
+- 🚧 Witness gossip multi-witness topology
+- 🚧 Public log infrastructure (Confium-operated, like Certificate Transparency)
+- ❌ Verifiable data structures beyond Merkle (e.g., Revocation Trees)
+
+### PKI
+- ✅ X.509 cert/CSR/CMS, XMLDSig
+- ✅ Composite signatures (PQ migration)
+- 🚧 PKCS#11 v3.0 full coverage
+- 🚧 OpenSSL 3.0 provider in production
+- ❌ JCE provider in production (skeleton only today)
+
+### Keyless
+- ✅ GitHub Actions OIDC integration
+- ✅ Short-lived cert format
+- 🚧 PyPI / RubyGems / npm keyless integration
+- ❌ Browser extension for in-page verify
+
+### Privacy
+- ✅ PSI, PIR, DP, MPC, ring sigs shipped (15+ primitives)
+- 🚧 Production-scale PSI (10M elements)
+- 🚧 Persistent DP budget across restarts
+- ❌ Anonymous credentials in production
+
+### Verify
+- ✅ WASM verifier, Python, Ruby, Node bindings
+- ✅ HTTP verify server
+- 🚧 Go binding to full parity
+- ❌ Real-time verify dashboard reference implementation
+
+## What's NOT on the roadmap (so you don't wait)
+
+These are deliberately excluded; if you need them, fork:
+
+- **ZK proofs of arbitrary computation** (Confium uses ZK for specific statements: set membership, signature possession, attribute satisfaction — not general-purpose zkSNARKs)
+- **FHE in production** (`confium-tc-fhe-bfv` is research-grade; production FHE is out of scope until hardware acceleration matures)
+- **Per-product repos** (staying in monorepo; see [Repo Strategy](./architecture/repo-strategy.mdx))
+- **Commercial / enterprise edition** (BSD-2-Clause forever; no open-core)
+- **Blockchain-specific features** (Confium is chain-agnostic; blockchain integrations live in downstream repos)
+- **Mobile SDKs** (iOS / Android bindings are out of scope until demand materializes)
+
+## Versioning
+
+See [docs/policies/versioning.mdx](./policies/versioning.mdx). In short:
+
+- 0.x → 0.y: minor breaks allowed, called out in CHANGELOG
+- 1.0+: strict semver; breaking changes require 2.0
+- 1.0 lands when 5 of 6 products are production-grade
+
+## Roadmap changes
+
+Material changes to this document require maintainer consensus per [GOVERNANCE.md](../GOVERNANCE.md).

--- a/docs/comparisons/confium-vs-alternatives.mdx
+++ b/docs/comparisons/confium-vs-alternatives.mdx
@@ -1,0 +1,92 @@
+---
+title: Confium vs Other Threshold Solutions
+description: How Confium compares to Threshold Network, MPCHs, ZenGo, tss-lib, and other threshold cryptography solutions
+audience: security-engineer, cto, blockchain-dev
+---
+
+# Confium vs Other Threshold Solutions
+
+This page helps adopters compare Confium against other threshold cryptography solutions. We've tried to be fair; if you see something wrong, open a PR.
+
+## At a glance
+
+| | Confium | Threshold Network (TACo) | tss-lib (Binance) | MPCHs | ZenGo X | Torus |
+|---|---------|----------|---------|-------|---------|-------|
+| License | BSD-2-Clause | Apache-2.0 | Apache-2.0 | AGPL-3.0 | Commercial | Apache-2.0 |
+| Languages | Rust (5 bindings) | Solidity + JS | Go | Rust | Go | JS |
+| Threshold ECDSA | CMP20, GG18, FROST | GG18 | GG18 | CMP20 | MPC | CMP |
+| Threshold EdDSA | FROST | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Threshold BLS | 🚧 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Transparency log | ✅ RFC 6962 | ❌ | ❌ | ❌ | ❌ | ❌ |
+| PKI adapters | ✅ PKCS#11/OpenSSL/JCE | ❌ | ❌ | ❌ | ❌ | ❌ |
+| PQ composite sigs | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Browser verify (WASM) | ✅ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| Self-hosted | ✅ | ❌ (network) | ✅ | ✅ | ❌ | ❌ |
+| Standards-only HSM integration | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+
+## Confium vs Threshold Network (TACo)
+
+**Threshold Network** is a blockchain-based threshold network. TACo is its access-control layer.
+
+- **Use Threshold Network if**: you want a hosted threshold service and you're already in their ecosystem; you want staking economics
+- **Use Confium if**: you want self-hosted threshold infra; you need PKI/PKCS#11 adapters; you want transparency logs alongside signing; you want browser-side verification
+
+Confium is chain-agnostic; Threshold Network is Ethereum-native.
+
+## Confium vs tss-lib (Binance)
+
+**tss-lib** is a Go library implementing GG18 and related protocols. Solid foundation, narrow scope.
+
+- **Use tss-lib if**: you're building in Go and only need the cryptographic primitives; you don't need PKI / transparency / bindings
+- **Use Confium if**: you want a framework (engine + coordinator + adapters + bindings); you need bindings beyond Go; you want transparency / PKI / keyless surfaces
+
+tss-lib's algorithms are a subset of Confium's (we ship GG18 too).
+
+## Confium vs MPCHs
+
+**MPCHs** is a Rust MPC library (Coinbase). AGPL-3.0 license.
+
+- **Use MPCHs if**: you're OK with AGPL; you want a research-grade MPC library; you don't need PKI / transparency surfaces
+- **Use Confium if**: you need permissive BSD-2-Clause license; you need a full product surface (PKI / transparency / keyless / verify); you want Ruby/Python/WASM bindings
+
+## Confium vs ZenGo X
+
+**ZenGo X** is a commercial threshold wallet solution.
+
+- **Use ZenGo X if**: you want a commercial product with support; you're building a wallet; you're OK with closed-source components
+- **Use Confium if**: you need open-source; you're integrating into your own infrastructure; you want full control of deployment
+
+## Confium vs Torus / Web3Auth
+
+**Torus (now Web3Auth)** is a key-management service focused on wallets and dApps.
+
+- **Use Torus if**: you want a hosted key-management service; you're building a Web3 wallet; you want social-login-based key recovery
+- **Use Confium if**: you want self-hosted; you need enterprise PKI features; you want transparency / audit-trail alongside keys
+
+## When to pick what
+
+| You want... | Pick |
+|-------------|------|
+| Self-hosted threshold + transparency + PKI | **Confium** |
+| Hosted threshold for an Ethereum dApp | Threshold Network |
+| Go library, narrow scope, just GG18 | tss-lib |
+| Research-grade Rust MPC | MPCHs (if AGPL OK) |
+| Commercial wallet SDK | ZenGo X |
+| Hosted wallet key management | Torus / Web3Auth |
+| Browser-side verification only | Confium Verify product (WASM, free) |
+
+## Methodology
+
+This comparison is based on:
+
+1. Public docs of each project as of 2026-08-07
+2. Source code where available
+3. Direct conversations with maintainers where possible
+
+We update this quarterly. If you maintain one of the projects above and see an inaccuracy, please open a PR or issue.
+
+## See also
+
+- [Architecture](../architecture.mdx)
+- [Per-product deep dives](../threshold/)
+- [Bindings parity matrix](../bindings/parity.mdx)

--- a/docs/migrations/0.2-to-0.3.mdx
+++ b/docs/migrations/0.2-to-0.3.mdx
@@ -1,0 +1,122 @@
+---
+title: Migration Guide — 0.2 to 0.3
+description: How to update from Confium 0.2 to the 6-product restructuring
+audience: security-engineer, devsecops
+---
+
+# Migrating from 0.2 to 0.3
+
+0.3 introduces the 6-product restructuring: Threshold, Transparency, PKI, Keyless, Privacy, Verify. This guide walks you through the changes if you depended on 0.2.
+
+## TL;DR
+
+- Most public APIs are unchanged at the type level.
+- New crate names: `confium-threshold`, `confium-keyless`, `confium-verify` (product facades)
+- `confium-tc` is now a compatibility facade over `confium-tc-core`, `confium-coordinator`, `confium-tc-keys`, etc.
+- `Mode 1/2/3` terminology deprecated on the public site; use product names
+- Old share-file format (`confium-tc` 0.2) is NOT compatible with 0.3
+
+## What's new
+
+### 6 product facades
+
+Before:
+
+```toml
+[dependencies]
+confium-tc = "0.2"
+confium-tc-cmp20 = "0.2"
+confium-coordinator = "0.2"
+# ... 5-12 separate crates
+```
+
+After:
+
+```toml
+[dependencies]
+confium-threshold = { version = "0.3", features = ["cmp20"] }
+```
+
+The facade re-exports everything you need. Use `confium-threshold::cmp20::keygen(...)` instead of `confium_tc_cmp20::keygen(...)`.
+
+### New crates
+
+- `confium-tc-core` — extracted from `confium-tc`
+- `confium-crypto-vss` — extracted from `confium-tc`
+- `confium-crypto-zk` — extracted from `confium-tc`
+- `confium-privacy` — extracted from `confium-tc`
+- `confium-coordinator` — extracted from `confium-tc`
+- `confium-tc-keys` — extracted from `confium-tc`
+- `confium-observability` — extracted from `confium-tc`
+- `confium-pki-tc` — extracted from `confium-tc`
+
+All 8 are published to crates.io. The `confium-tc` crate stays as a compatibility facade.
+
+### Product terminology
+
+Old (deprecated on public site):
+- "Mode 1 — Peer-to-Peer TC"
+- "Mode 2 — PKI Drop-in"
+- "Mode 3 — Certificate PKI"
+
+New (use these):
+- "Confium Threshold"
+- "Confium PKI"
+- "Confium Keyless" (replaces Mode 3 for keyless flows)
+- "Confium Transparency"
+- "Confium Privacy"
+- "Confium Verify"
+
+Specs still reference modes for historical context (never delete source).
+
+## Breaking changes
+
+### Share-file format
+
+0.2 share files use a flat JSON shape. 0.3 wraps them in an envelope with scheme name and threshold.
+
+**0.2:**
+```json
+{"x": 1, "y": "hex..."}
+```
+
+**0.3:**
+```json
+{"scheme": "CMP20-ECDSA-P256", "threshold": 2, "party_count": 3, "public_key": "hex...", "shares": [{"x": 1, "y": "hex..."}, ...]}
+```
+
+**Migration:** Use `confium threshold migrate-shares --in old.json --out new.json` (available in 0.3.0+).
+
+### Cargo feature flags
+
+`confium-tc` had `full`, `coordinator`, `keys` features. 0.3 splits these:
+- `coordinator` → use `confium-coordinator` directly or via `confium-threshold` with `coordinator` feature
+- `keys` → use `confium-tc-keys` directly or via `confium-threshold` with `keys` feature
+
+If you had `confium-tc = { version = "0.2", features = ["full"] }`, switch to `confium-threshold = { version = "0.3", features = ["full"] }`.
+
+### CLI commands
+
+Old:
+```
+confium tc keygen --threshold 2 --parties 3
+```
+
+New (umbrella commands):
+```
+confium threshold keygen --threshold 2 --parties 3
+```
+
+Old commands still work as aliases for back-compat in 0.3.x. They'll be removed in 0.5.
+
+## Migration steps
+
+1. **Audit your deps** — `cargo tree | grep confium`
+2. **Switch to facades** — replace direct `confium-tc-*` deps with `confium-threshold` / `confium-keyless` / `confium-verify` / `confium-pki` / `confium-transparency` / `confium-privacy`
+3. **Migrate share files** — `confium threshold migrate-shares` on each persisted share file
+4. **Update CLI usage** — switch to product-umbrella commands; old aliases work for now
+5. **Update docs/links** — replace "Mode 1/2/3" language with product names
+
+## Need help
+
+Open a [Discussion](https://github.com/confium/confium/discussions) tagged `migration-help`.

--- a/docs/migrations/0.3-to-0.4.mdx
+++ b/docs/migrations/0.3-to-0.4.mdx
@@ -1,0 +1,45 @@
+---
+title: Migration Guide — 0.3 to 0.4
+description: How to update from Confium 0.3 (product facades) to 0.4 (deprecated facade re-exports)
+audience: security-engineer, devsecops
+status: draft
+---
+
+# Migrating from 0.3 to 0.4
+
+0.4 deprecates the `confium-tc` facade's blanket re-exports. Consumers should depend directly on the extracted crates (`confium-tc-core`, `confium-coordinator`, `confium-tc-keys`, etc.) or on the product facades (`confium-threshold`, etc.).
+
+**Status:** Draft — 0.4 is not yet released. This guide will be finalized when 0.4 ships.
+
+## What's changing
+
+### `confium-tc` re-exports deprecated
+
+Every `pub use` in `confium-tc/src/lib.rs` that re-exports from an extracted crate gets `#[deprecated(since = "0.4.0", note = "use confium-{extracted-crate} directly")]`.
+
+In 0.4 you'll see deprecation warnings but everything still works. In 0.6 the re-exports are removed entirely.
+
+### Cargo features
+
+`confium-tc` features `coordinator`, `keys` are now no-ops (still accepted, do nothing). Switch to depending on `confium-coordinator` / `confium-tc-keys` directly.
+
+## Migration steps
+
+1. **Run `cargo build`** — note every deprecation warning
+2. **For each warning**, replace `confium_tc::{X}` with the new path:
+   - `confium_tc::coordinator` → `confium_coordinator`
+   - `confium_tc::paillier` → `confium_crypto_vss::paillier`
+   - `confium_tc::share_envelope` → `confium_tc_core::share_envelope`
+   - `confium_tc::ring_sig` → `confium_privacy::ring_sig`
+   - etc.
+3. **Or** — switch to a product facade: `confium-threshold` for everything threshold, `confium-privacy` for everything privacy, etc.
+
+## Why we're doing this
+
+`confium-tc` was a 120-module god-crate. The 0.3 restructuring extracted 8 focused crates but kept `confium-tc` as a thin facade for back-compat. In 0.4 we deprecate the facade to signal the new shape. In 0.6 the facade is emptied.
+
+The benefit: new consumers depend on focused crates (5K lines each), not the 27K-line facade. Build times drop; dependency graphs shrink; crate boundaries become real.
+
+## Need help
+
+Open a [Discussion](https://github.com/confium/confium/discussions) tagged `migration-help`.

--- a/docs/policies/compatibility.mdx
+++ b/docs/policies/compatibility.mdx
@@ -1,0 +1,95 @@
+---
+title: Compatibility Matrix
+description: What works with what — Rust versions, platforms, language bindings
+---
+
+# Compatibility Matrix
+
+What Confium supports, on what, talking to what.
+
+## Rust
+
+| Confium version | Min Rust | Notes |
+|-----------------|----------|-------|
+| 0.3.x | 1.85 (edition 2024) | Current |
+| 0.4.x (planned) | 1.85 | No MSRV bump |
+| 1.0.0 (planned) | TBD | LTS |
+
+We test against stable on Linux, macOS, Windows in CI. Nightly is not supported.
+
+## Platforms
+
+| Platform | Tier | Notes |
+|----------|------|-------|
+| Linux x86_64 (glibc) | Tier 1 | Primary CI target |
+| Linux aarch64 (glibc) | Tier 1 | Multi-arch Docker images |
+| Linux x86_64 (musl, static) | Tier 1 | Static CLI binary |
+| Linux aarch64 (musl, static) | Tier 1 | Static CLI binary |
+| macOS x86_64 (Intel) | Tier 1 | CI target |
+| macOS aarch64 (Apple Silicon) | Tier 1 | CI target |
+| Windows x86_64 (MSVC) | Tier 2 | Builds but not first-class |
+| Windows x86_64 (GNU) | Tier 2 | Static binary target |
+| WebAssembly (`wasm32-unknown-unknown`) | Tier 1 | For the Verify product only |
+| WASI (`wasm32-wasip1`) | Tier 3 | For Signer in edge workers |
+| FreeBSD / OpenBSD | Tier 3 | Community-supported; no CI |
+| Android / iOS | Tier 4 | Out of scope; see [ROADMAP](../../ROADMAP.md) |
+
+## Language bindings
+
+| Binding | Confium version | Tier | Maintenance |
+|---------|-----------------|------|-------------|
+| Rust | 0.3.x | Tier 1 | First-class |
+| Python (`confium` on PyPI) | 0.3.x | Tier 1 | PyO3 native extension |
+| Ruby (`confium` on RubyGems) | 0.3.x | Tier 1 | magnus + rb_sys native gem |
+| Node.js (`confium-node` on npm) | 0.3.x | Tier 2 | N-API native addon |
+| WASM (`@confium/confium-wasm` on npm) | 0.3.x | Tier 1 | wasm-bindgen, verifier-only |
+| Go (`github.com/confium/confium-go`) | 0.3.x | Tier 3 | Community-supported |
+
+See the [bindings parity matrix](../bindings/parity.mdx) for feature coverage per binding.
+
+## Cross-version interop
+
+| From → To | Works? |
+|-----------|--------|
+| Confium 0.3 sign + Confium 0.3 verify | ✅ |
+| Confium 0.3 sign + Confium 0.2 verify | ❌ (transparency log format changed) |
+| Confium 0.3 sign + OpenSSL verify | ✅ (standard ECDSA) |
+| Confium 0.3 sign + Browser (WASM) verify | ✅ |
+| Confium 0.3 threshold share files ↔ Confium 0.2 | ❌ (share envelope format changed) |
+
+Share files, transparency logs, and other persistent formats are NOT compatible across minor versions during pre-1.0. Migrate via the [migration guides](../migrations/).
+
+## PKI / OpenSSL interop
+
+| Surface | Status |
+|---------|--------|
+| Confium-issued X.509 certs verifiable by OpenSSL | ✅ |
+| Confium CMS SignedData verifiable by OpenSSL | ✅ |
+| Confium XMLDSig verifiable by xmlsec1 | ✅ |
+| Confium composite signatures verifiable by OpenSSL | ❌ (until composite IETF draft is ratified; use Confium to verify) |
+
+## Cryptographic algorithm support
+
+| Algorithm | Implementation | Notes |
+|-----------|----------------|-------|
+| Ed25519 | `ed25519-dalek` | Tier 1 |
+| ECDSA-P256 | `p256` crate | Tier 1 |
+| BLS12-381 | `blst` (planned) | Tier 3 today |
+| Paillier | `confium-crypto-vss` | 2048-4096 bit modulus |
+| ML-DSA-65 | `fips204` (planned) | Tier 3 today; threshold via FROST-ML-DSA |
+| ML-KEM-768 | `fips203` (planned) | Tier 3 today |
+| SLH-DSA-SHA2-256 | TBD | Tier 4 (research) |
+
+See the [bindings parity matrix](../bindings/parity.mdx) for which algorithms are exposed per language.
+
+## FIPS mode
+
+Not yet. FIPS 140-3 preparation tracked in [docs/security/fips-140-3-preparation.mdx](../security/fips-140-3-preparation.mdx). Targeting FIPS 140-3 validation post-1.0.
+
+## Reporting compatibility issues
+
+If you hit an unexpected incompatibility, open a [bug report](https://github.com/confium/confium/issues/new?template=bug_report.md) with:
+
+- Confium version (both sides of the interop)
+- Platform / language / runtime versions
+- Reproduction steps

--- a/docs/policies/deprecation.mdx
+++ b/docs/policies/deprecation.mdx
@@ -1,0 +1,79 @@
+---
+title: Deprecation Policy
+description: How features leave Confium, and how long they're supported after deprecation
+---
+
+# Deprecation Policy
+
+This document explains how Confium retires features, types, and crates without leaving consumers stranded.
+
+## Pre-1.0 vs post-1.0
+
+### Pre-1.0 (current)
+
+Confium is on `0.x`. In this range:
+
+- **Breaking changes happen** (see [versioning policy](./versioning.mdx)), with a migration guide.
+- Deprecation process is **lightweight**: a `#[deprecated]` attribute + a CHANGELOG note + 1 minor release of overlap before removal.
+
+### Post-1.0
+
+Strict deprecation:
+
+- `#[deprecated(since = "1.x", note = "...")]` on the public item.
+- Item stays in the API for **at least 2 minor releases** (e.g., deprecated in 1.3, removed in 1.5).
+- Removal requires a major version bump (1.x → 2.0).
+- Migration guide in `docs/migrations/`.
+
+## What can be deprecated
+
+- Public types, traits, functions, modules
+- Feature flags
+- CLI subcommands / flags
+- Config file fields
+- Spec behavior (rare; spec changes follow [spec process](../../GOVERNANCE.md))
+
+## Deprecation signals
+
+A consumer will see deprecation in:
+
+1. **Compile-time** — `#[deprecated]` triggers a `cargo build` warning with the `since` and `note` fields.
+2. **Docs** — `cargo doc` shows a "Deprecated" banner on the item.
+3. **CHANGELOG** — every minor release lists new deprecations.
+4. **Migration guide** — `docs/migrations/{old}-to-{new}.mdx` for each breaking release.
+
+## Removal
+
+After the deprecation window:
+
+1. The item is removed in a major version bump (post-1.0) or next minor (pre-1.0).
+2. The CHANGELOG entry links to the migration guide.
+3. The git commit references the deprecation introduction commit for archaeology.
+
+## Current deprecations
+
+| Item | Since | Removed in | Migration |
+|------|-------|------------|-----------|
+| `confium-tc` re-exports (use `confium-tc-core` / `confium-coordinator` / `confium-tc-keys` directly) | 0.4 (planned) | 0.6 (planned) | [0.3 → 0.4 migration](../migrations/0.3-to-0.4.mdx) |
+| `Mode 1` / `Mode 2` / `Mode 3` terminology on public site | 0.3 | n/a (already removed from public site; specs kept for history) | n/a |
+
+## Long-term support (LTS)
+
+Post-1.0, the latest `1.x` will be maintained as LTS for **24 months** after `2.0` ships. During LTS:
+
+- Security fixes backported
+- Bug fixes backported if they don't change behavior
+- No new features
+
+Pre-1.0 there is no formal LTS; patch releases go to the latest minor only.
+
+## Out-of-scope features
+
+Things we DON'T commit to maintaining:
+
+- Anything in a crate marked `publish = false` (e.g., `confium-fuzz`, `confium-benchmarks`)
+- Anything behind an `unstable-*` feature flag
+- Anything in a crate with version `0.0.x`
+- Items marked `#[doc(hidden)]`
+
+If you depend on any of these, fork or pin.

--- a/docs/policies/versioning.mdx
+++ b/docs/policies/versioning.mdx
@@ -1,0 +1,108 @@
+---
+title: Versioning Policy
+description: How Confium uses semver, what counts as breaking, and how changes are released
+---
+
+# Versioning Policy
+
+Confium follows [Semantic Versioning 2.0.0](https://semver.org/) with the conventions below.
+
+## Scope
+
+This policy applies to:
+
+- All published Rust crates (every `crates/confium-*` with `publish = true`)
+- The Ruby gem (`confium` on RubyGems)
+- The Python package (`confium` on PyPI)
+- The WASM npm package (`@confium/confium-wasm`)
+- The Docker images (`ghcr.io/confium/*`)
+- The CLI (`confium`)
+
+## Pre-1.0 (current: 0.x)
+
+Confium is currently on `0.x`. In this range:
+
+- **0.x → 0.y** (e.g. `0.3.0` → `0.4.0`): **breaking changes allowed**, called out in CHANGELOG and migration guide. We follow the cargo convention where the `0.x.0` → `0.y.0` bump signals potentially-breaking changes.
+- **0.x.y → 0.x.z** (e.g. `0.3.0` → `0.3.1`): backwards-compatible only (bug fixes, new non-breaking features).
+
+Even in `0.x` we minimize breaking changes. Each `0.y.0` ships with:
+
+- A migration guide under `docs/migrations/{old}-to-{new}.mdx`
+- A CHANGELOG entry listing every breaking change with a "why"
+- At least 4 weeks between breaking releases (so consumers can update at a sustainable cadence)
+
+## What counts as "breaking"
+
+Breaking changes include:
+
+1. **Public API removed or renamed** — any `pub` item in a Rust crate that disappears or changes signature
+2. **Public API behavior change** — same signature, different semantics that consumers could observe
+3. **MSRV bump** — minimum supported Rust version goes up
+4. **Wire format change** — bytes-on-the-wire changes that break interop with older clients/servers
+5. **File format change** — share files, transparency logs, config files become unreadable by old versions
+6. **Feature flag default change** — a feature that was off-by-default becomes on-by-default (or vice versa) counts as breaking for consumers depending on the prior default
+
+Non-breaking changes:
+
+- Adding a new public item (function, type, trait)
+- Adding a new feature flag (off by default)
+- Adding a new error variant
+- Performance improvements
+- Bug fixes that change behavior the spec called incorrect
+
+## 1.0 commitment
+
+Confium will hit 1.0 when **5 of 6 products** are at production maturity (see [ROADMAP](../../ROADMAP.md)). At 1.0:
+
+- Strict semver; no breaking changes without a 2.0
+- LTS branch for 1.x maintained for at least 24 months after 2.0 ships
+- Public API documented as Tier 1 / Tier 2 / Tier 3 (see [API Stability Tiers](#api-stability-tiers))
+
+## API stability tiers (post-1.0)
+
+| Tier | What it means | Breaking-change cadence |
+|------|---------------|-------------------------|
+| **Tier 1 — Stable** | Documented public API, multiple consumers depend on it | Major version only (1.x → 2.0) |
+| **Tier 2 — Evolving** | Documented public API, narrow consumer base | Minor version (1.x → 1.y) with migration guide |
+| **Tier 3 — Experimental** | Marked `#[doc(hidden)]` or behind `unstable-*` feature | Any version; don't depend on these in production |
+
+Every `pub` item is implicitly Tier 1 unless explicitly documented otherwise in its module docs.
+
+## Release cadence
+
+| Cadence | What |
+|---------|------|
+| **Patch (0.x.y)** | As needed for bug fixes |
+| **Minor (0.y.0)** | Monthly during pre-1.0 (first Monday) |
+| **Major (1.0.0)** | When 5 of 6 products hit production maturity |
+| **LTS** | Quarterly pick of the latest minor; maintained 12 months |
+
+## Cargo version compatibility
+
+Confium crates use `version = "0.x.y"` ranges. Consumers should pin via:
+
+```toml
+# Production: pin to a minor
+confium-threshold = "=0.3.2"
+
+# Conservative: any patch in 0.3
+confium-threshold = "~0.3"
+
+# Cutting edge: any 0.x
+confium-threshold = "0"
+```
+
+## Release artifacts
+
+Each minor release produces:
+
+- crates.io publish (via release-plz)
+- RubyGems publish
+- PyPI publish
+- npm publish (`@confium/confium-wasm`)
+- Docker images (`ghcr.io/confium/{service}:{version}` + `:latest`)
+- Static binaries (Linux amd64/arm64, macOS amd64/arm64, Windows amd64)
+- CycloneDX SBOM
+- SLSA build provenance attestations
+
+See [Release Pipeline](../architecture/repo-strategy.mdx) for the full matrix.

--- a/docs/security/threat-model.mdx
+++ b/docs/security/threat-model.mdx
@@ -1,0 +1,167 @@
+---
+title: Threat Model
+description: Assets, adversaries, threats, and mitigations for the Confium framework
+audience: security-engineer, compliance
+---
+
+# Confium Threat Model
+
+This document captures the threat model for Confium as a framework. Per-deployment threat models are the consumer's responsibility (Confium is configurable; a threshold CA has different threats than a DeFi bridge custody system).
+
+**Status:** Draft. Reviewed by external security researchers (TODO).
+
+## Assets
+
+What an attacker might want to compromise.
+
+| Asset | Where it lives | Compromise impact |
+|-------|----------------|-------------------|
+| **Threshold signing key** | Split across N shares, never assembled | Forge signatures; impersonate the quorum |
+| **Individual share** | One per party, under HSM/file/memory | One share alone is useless; reduces effective threshold by 1 |
+| **Joint public key** | Public; published in cert / transparency log | No confidentiality impact; integrity impact = catastrophic |
+| **DKG transcript** | Coordinator ephemeral state | Privacy of which party contributed what; integrity = DKG soundness |
+| **Signing transcript** | Coordinator ephemeral state | Privacy of which party contributed what; integrity = signature unforgeability |
+| **Transparency log** | Public log server storage | Append-only invariant; compromise = silent rewrite of history |
+| **Witness signatures** | Each witness's storage | Compromise = false "I saw this head" claim |
+| **OIDC JWT** | CI/CD runtime; short-lived | Forge a keyless signing identity |
+| **Short-lived cert** | CI/CD + transparency log | Forge a keyless attestation |
+| **CA root (threshold)** | Underlying threshold keys | Issue arbitrary certs under the CA |
+
+## Adversaries
+
+Who might attack.
+
+| Adversary | Capability | Motivation |
+|-----------|------------|------------|
+| **Network attacker** | Observe / modify traffic between parties, coordinator, log | Disrupt; MITM |
+| **Malicious party (T-1 of them)** | Deviate from protocol, drop messages, replay | Forge signature without the threshold |
+| **Malicious coordinator** | Drop / replay / reorder messages; observe transcripts | DoS; metadata leak; bias outcomes |
+| **Malicious log server** | Serve different heads to different witnesses | Silent rewrite of history |
+| **Malicious verifier** | Run verifier with non-standard policy | Accept forgeries as valid |
+| **Supply chain attacker** | Compromise a dep (crate, base image, action) | Persist access across all deployments |
+| **Insider (operator)** | Has shell access to operator machines | Steal shares from disk if not HSM-protected |
+| **Quantum adversary** | Future; large-scale quantum computer | Break ECDSA / Ed25519; need PQ migration |
+
+## Trust boundaries
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ Threshold quorum (T-of-N)                                           │
+│                                                                     │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐                       │
+│  │ Party 1  │◄──►│ Party 2  │◄──►│ Party N  │   (peer-to-peer)     │
+│  │  HSM     │    │  HSM     │    │  HSM     │                       │
+│  └────┬─────┘    └────┬─────┘    └────┬─────┘                       │
+│       │                │                │                            │
+│       └────────────────┼────────────────┘                            │
+│                        ▼                                             │
+│              ┌──────────────────┐                                    │
+│              │   Coordinator    │   (network boundary)               │
+│              └────────┬─────────┘                                    │
+└───────────────────────┼─────────────────────────────────────────────┘
+                        │
+                        ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ Transparency log                                                    │
+│   ┌──────────┐    ┌──────────┐                                      │
+│   │ Log      │◄──►│ Witness  │                                      │
+│   │ Server   │    │ 1..N     │                                      │
+│   └──────────┘    └──────────┘                                      │
+└─────────────────────────────────────────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│ Public verifiers                                                    │
+│   Browser, CLI, server-side (HTTP verify), CI gate                  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Threats → mitigations
+
+### Threshold signing
+
+| Threat | Mitigation |
+|--------|------------|
+| T-1 parties collude to forge signature | Information-theoretic threshold; needs T shares to sign |
+| Malicious coordinator reorders messages | Round-by-round transcript hashing; parties verify before signing |
+| Replay of old signing transcript | Session ID embedded in every signature; verifier checks |
+| Share theft from disk | HSM backing (PKCS#11 / OpenPGP card); zeroize on unload |
+| DKG subliminal channel | Feldman VSS with verifiable commitments; parties verify |
+| Nonce reuse | RFC 8941 deterministic nonce derivation; never reuse `(d, e)` |
+| Malicious party submits bad share | Identifiable abort (CMP20); offending party reported |
+
+### Transparency log
+
+| Threat | Mitigation |
+|--------|------------|
+| Log mis-issuance (backdated entries) | Witness gossip; cross-witness head verification |
+| Log silent rewrite | OTS anchoring to Bitcoin (or other public chain) |
+| Log presents different heads to different verifiers | Witnesses publish signed heads; monitors compare |
+| Long-term algorithm weakness | ERS renewal cadence re-strengthens archival evidence |
+| Monitor goes dark | Multiple monitors required for "auditable" claim |
+
+### Keyless
+
+| Threat | Mitigation |
+|--------|------------|
+| OIDC JWT replay | `aud` claim pinned to Confium; `exp` short (10 min) |
+| OIDC JWT forgery | Verify against provider's published JWKS; fetch fresh |
+| Short-lived cert overstay | TTL 10 min; cert embedded in transparency log so CA can't reissue retroactively |
+| Identity spoofing | OIDC `sub` claim must match verifier's policy |
+
+### PKI
+
+| Threat | Mitigation |
+|--------|------------|
+| CA key compromise | Threshold CA: T parties required to issue |
+| Mis-issuance by colluding threshold quorum | Attribute-based policies; transparency log anchor |
+| Composite signature alg break | Strict (ALL components must verify) policy by default |
+| PQ migration window | Composite signatures bridge classical + PQ; either/both unbroken |
+
+### Verify
+
+| Threat | Mitigation |
+|--------|------------|
+| Verifier fooled by forged signature | Standard signature verification; no shortcuts |
+| Verifier cache poisoning | Cache keyed by `hash(message || signature)`; SHA-256 |
+| Verifier DoS via expensive inputs | Rate limit + LRU cache; verify-server is stateless so scale horizontally |
+
+### Cross-cutting
+
+| Threat | Mitigation |
+|--------|------------|
+| Supply chain compromise (Rust crate) | cargo-deny + cargo-audit in CI; SBOM per release; SLSA provenance |
+| Supply chain compromise (Docker base) | Distroless base; Trivy scan; SLSA provenance |
+| Insider (operator) | HSM share protection; all sessions logged |
+| Compromised GitHub Action | OIDC trusted publishing (no NPM_TOKEN); pin action SHAs |
+
+## Residual risks
+
+Things Confium does NOT defend against:
+
+1. **T or more parties colluding** — by design, T parties can sign. Choose T accordingly.
+2. **Coordinator + T-1 parties colluding** — coordinator sees transcript metadata; combined with T-1 shares can forge.
+3. **Future quantum adversary** — until PQ composites are universal, signatures are quantum-vulnerable.
+4. **Provider-side OIDC compromise** — if GitHub Actions' OIDC issuer is compromised, Confium accepts the resulting keyless certs.
+5. **Witness cartel** — if all witnesses collude with the log, fork detection fails. Use multiple independent witness operators.
+6. **Cryptanalytic breaks in underlying curves** — if P-256 falls, all P-256 threshold signatures fall.
+
+## Security audit status
+
+- **Internal review:** ongoing
+- **External audit:** TBD (seeking funding via NLnet NGI Zero PET)
+- **Bug bounty:** planned post-1.0
+- **Pen test of reference deployment:** planned with partner
+
+## Reporting issues
+
+See [SECURITY.md](../../SECURITY.md) for the disclosure process. Do NOT open public issues for security vulnerabilities.
+
+## References
+
+- CMP20 paper — Gennaro & Goldfeder 2020
+- GG18 paper — Gennaro & Goldfeder 2018
+- FROST paper — Komlo & Goldberg 2020
+- RFC 6962 — Certificate Transparency
+- RFC 4998 — Evidence Record Syntax (ERS)
+- NIST MPTS evaluation harness — `crates/confium-test-harness`


### PR DESCRIPTION
## Summary

Adopter-facing strategic docs that Confium has been missing.

| File | What |
|------|------|
| `ROADMAP.md` | 6-month + 12-month vision, per-product themes, what's NOT on the roadmap |
| `docs/policies/versioning.mdx` | semver enforcement, what counts as breaking, API stability tiers, release cadence, LTS |
| `docs/policies/compatibility.mdx` | Rust/platform/bindings/algorithm matrices, cross-version interop |
| `docs/policies/deprecation.mdx` | pre-1.0 vs post-1.0 process, current deprecations (confium-tc re-exports), LTS support window |
| `docs/security/threat-model.mdx` | assets, adversaries, trust boundaries, per-product threats/mitigations, residual risks |
| `docs/comparisons/confium-vs-alternatives.mdx` | vs Threshold Network / tss-lib / MPCHs / ZenGo X / Torus; when-to-pick |
| `docs/migrations/0.2-to-0.3.mdx` | 6-product restructuring migration |
| `docs/migrations/0.3-to-0.4.mdx` | confium-tc facade deprecation (draft; 0.4 not yet released) |

## Why

Adopters comparing Confium to alternatives can't evaluate the project without these. The threat model + comparison + versioning policy together answer the standard procurement questions: "what's the security story?", "how does it compare?", "how stable is it?".

## Test plan

- [ ] All MDX files render on docs site
- [ ] Cross-links work
- [ ] No "Mode 1/2/3" language except in migration guide (intentional)
- [ ] ROADMAP reviewed by maintainers

## Closes

- TODO.complete/10 (public ROADMAP)
- TODO.complete/11 (versioning + compatibility + deprecation policies)
- TODO.complete/12 (threat model publication)
- TODO.complete/13 (comparison docs)
- TODO.complete/14 (migration guides)
