### PR TITLE
deploy: reference deployments — full-stack docker-compose + production K8s + dashboards

### DIFF
--- a/deploy/docker-compose/full-stack.yml
+++ b/deploy/docker-compose/full-stack.yml
@@ -1,0 +1,113 @@
+# Reference deployment — full-stack local via Docker Compose
+#
+# Brings up:
+#   - 3 signerd replicas (one share each of a 2-of-3 CMP20 key)
+#   - 1 coordinator (orchestrates signing sessions)
+#   - 1 log-server (RFC 6962 transparency log)
+#   - 1 verify-server (HTTP verification endpoint)
+#   - 1 prometheus (scrape all services)
+#   - 1 grafana (dashboards)
+#
+# Usage:
+#   docker compose -f deploy/docker-compose/full-stack.yml up -d
+#   open http://localhost:3000  (grafana, admin/admin)
+#
+# Tear down:
+#   docker compose -f deploy/docker-compose/full-stack.yml down -v
+
+name: confium-full-stack
+
+services:
+  # --- Threshold signing cluster -----------------------------------------
+  coordinator:
+    image: ghcr.io/confium/coordinator:latest
+    ports:
+      - "7000:7000"
+    environment:
+      RUST_LOG: info
+    volumes:
+      - coordinator-data:/var/lib/confium
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "7000"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  signerd-1:
+    image: ghcr.io/confium/signerd:latest
+    depends_on: [coordinator]
+    environment:
+      COORDINATOR_URL: http://coordinator:7000
+      RUST_LOG: info
+    volumes:
+      - signerd-1-data:/etc/confium/shares
+
+  signerd-2:
+    image: ghcr.io/confium/signerd:latest
+    depends_on: [coordinator]
+    environment:
+      COORDINATOR_URL: http://coordinator:7000
+      RUST_LOG: info
+    volumes:
+      - signerd-2-data:/etc/confium/shares
+
+  signerd-3:
+    image: ghcr.io/confium/signerd:latest
+    depends_on: [coordinator]
+    environment:
+      COORDINATOR_URL: http://coordinator:7000
+      RUST_LOG: info
+    volumes:
+      - signerd-3-data:/etc/confium/shares
+
+  # --- Transparency log --------------------------------------------------
+  log-server:
+    image: ghcr.io/confium/log-server:latest
+    ports:
+      - "7878:7878"
+    environment:
+      RUST_LOG: info
+    volumes:
+      - log-data:/var/lib/confium
+    healthcheck:
+      test: ["CMD", "nc", "-z", "localhost", "7878"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # --- HTTP verification service -----------------------------------------
+  verify-server:
+    image: ghcr.io/confium/verify-server:latest
+    ports:
+      - "8080:8080"
+    environment:
+      RUST_LOG: info
+
+  # --- Observability -----------------------------------------------------
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ../grafana:/var/lib/grafana/dashboards:ro
+      - ./grafana-datasources.yml:/etc/grafana/provisioning/datasources/datasources.yml:ro
+      - ./grafana-dashboards.yml:/etc/grafana/provisioning/dashboards/dashboards.yml:ro
+    depends_on: [prometheus]
+
+volumes:
+  coordinator-data:
+  signerd-1-data:
+  signerd-2-data:
+  signerd-3-data:
+  log-data:
+  prometheus-data:

--- a/deploy/docker-compose/grafana-dashboards.yml
+++ b/deploy/docker-compose/grafana-dashboards.yml
@@ -1,0 +1,13 @@
+# Grafana dashboard provisioning for Confium stack.
+
+apiVersion: 1
+
+providers:
+  - name: 'Confium'
+    orgId: 1
+    folder: 'Confium'
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/deploy/docker-compose/grafana-datasources.yml
+++ b/deploy/docker-compose/grafana-datasources.yml
@@ -1,0 +1,10 @@
+# Grafana datasource provisioning for Confium stack.
+
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/deploy/docker-compose/prometheus.yml
+++ b/deploy/docker-compose/prometheus.yml
@@ -1,0 +1,34 @@
+# Prometheus scrape config for Confium services.
+# Used by deploy/docker-compose/full-stack.yml
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'coordinator'
+    static_configs:
+      - targets: ['coordinator:7000']
+    metrics_path: /metrics
+
+  - job_name: 'signerd'
+    static_configs:
+      - targets:
+          - 'signerd-1:7000'
+          - 'signerd-2:7000'
+          - 'signerd-3:7000'
+    metrics_path: /metrics
+
+  - job_name: 'log-server'
+    static_configs:
+      - targets: ['log-server:7878']
+    metrics_path: /metrics
+
+  - job_name: 'verify-server'
+    static_configs:
+      - targets: ['verify-server:8080']
+    metrics_path: /metrics
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']

--- a/deploy/grafana/confium-log-server.json
+++ b/deploy/grafana/confium-log-server.json
@@ -1,0 +1,62 @@
+{
+  "annotations": { "list": [] },
+  "description": "Confium log server — transparency log metrics",
+  "editable": true,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "title": "Appends per minute",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(confium_log_appends_total[1m])",
+          "legendFormat": "appends",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Tree size",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "confium_log_tree_size", "legendFormat": "entries", "refId": "A" }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "title": "Proof requests per minute",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(confium_log_proof_requests_total[1m])",
+          "legendFormat": "proofs",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 }
+    },
+    {
+      "title": "OTS anchoring success rate",
+      "type": "gauge",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(rate(confium_log_anchor_success_total[5m])) / sum(rate(confium_log_anchor_total[5m]))",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 16 }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": ["confium", "transparency"],
+  "time": { "from": "now-1h", "to": "now" },
+  "title": "Confium Log Server",
+  "uid": "confium-log-server",
+  "version": 1
+}

--- a/deploy/grafana/confium-signerd.json
+++ b/deploy/grafana/confium-signerd.json
@@ -1,0 +1,97 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Confium signerd — signing session metrics",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "title": "Signing sessions per minute",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "rate(confium_signerd_sessions_total[1m])",
+          "legendFormat": "{{scheme}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 }
+    },
+    {
+      "title": "Signing latency (p50, p95, p99)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum(rate(confium_signerd_session_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(confium_signerd_session_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum(rate(confium_signerd_session_duration_seconds_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 }
+    },
+    {
+      "title": "Sessions by status",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "sum(confium_signerd_sessions_total) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 8 }
+    },
+    {
+      "title": "Active sessions",
+      "type": "stat",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        { "expr": "confium_signerd_active_sessions", "refId": "A" }
+      ],
+      "gridPos": { "h": 6, "w": 6, "x": 6, "y": 8 }
+    },
+    {
+      "title": "Memory usage",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "targets": [
+        {
+          "expr": "container_memory_working_set_bytes{pod=~\"confium-signerd-.*\"}",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["confium", "signerd"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Confium Signerd",
+  "uid": "confium-signerd",
+  "version": 1,
+  "weekStart": ""
+}

--- a/deploy/k8s/production/00-confium.yaml
+++ b/deploy/k8s/production/00-confium.yaml
@@ -1,0 +1,356 @@
+# Confium production deployment on Kubernetes.
+#
+# This is a fuller deployment than deploy/k8s/bundle.yaml — includes
+# monitoring, NetworkPolicies, PodDisruptionBudgets, HPAs, and TLS.
+# Use this as a starting point for production; tune for your cluster.
+#
+# Apply:
+#   kubectl apply -f deploy/k8s/production/
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: confium-system
+  labels:
+    name: confium-system
+    pod-security.kubernetes.io/enforce: restricted
+---
+# ----- ServiceAccounts + RBAC -------------------------------------------
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: confium-coordinator
+  namespace: confium-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: confium-log-server
+  namespace: confium-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+subjects:
+  - kind: ServiceAccount
+    name: confium-signerd
+    namespace: confium-system
+roleRef:
+  kind: Role
+  name: confium-signerd
+  apiGroup: rbac.authorization.k8s.io
+---
+# ----- ConfigMaps -------------------------------------------------------
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: confium-coordinator-config
+  namespace: confium-system
+data:
+  coordinator.toml: |
+    [server]
+    listen = "0.0.0.0:7000"
+    tls_cert = "/etc/confium/tls/tls.crt"
+    tls_key = "/etc/confium/tls/tls.key"
+
+    [policy]
+    max_concurrent_sessions = 100
+    session_timeout_seconds = 300
+
+    [metrics]
+    path = "/metrics"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: confium-log-server-config
+  namespace: confium-system
+data:
+  log-server.toml: |
+    [log]
+    identity = "confium-prod"
+    data_path = "/var/lib/confium/log.db"
+
+    [gossip]
+    witnesses = []
+
+    [anchor]
+    cadence_minutes = 60
+    calendar_url = "https://a.pool.opentimestamps.org"
+---
+# ----- Coordinator Deployment -------------------------------------------
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: confium-coordinator
+  namespace: confium-system
+spec:
+  replicas: 1  # Single instance; coordinator holds session state
+  strategy:
+    type: Recreate  # Don't roll more than one at a time
+  selector:
+    matchLabels: { app: confium-coordinator }
+  template:
+    metadata:
+      labels: { app: confium-coordinator }
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7000"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: confium-coordinator
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: coordinator
+          image: ghcr.io/confium/coordinator:latest
+          imagePullPolicy: IfNotPresent
+          args: ["--config", "/etc/confium/coordinator.toml"]
+          env:
+            - name: RUST_LOG
+              value: info
+          ports:
+            - name: grpc
+              containerPort: 7000
+            - name: metrics
+              containerPort: 9000
+          volumeMounts:
+            - name: config
+              mountPath: /etc/confium
+              readOnly: true
+            - name: data
+              mountPath: /var/lib/confium
+            - name: tls
+              mountPath: /etc/confium/tls
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /health/ready
+              port: 9000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health/live
+              port: 9000
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            requests: { cpu: 250m, memory: 256Mi }
+            limits:   { cpu: 1,    memory: 1Gi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+      volumes:
+        - name: config
+          configMap: { name: confium-coordinator-config }
+        - name: data
+          persistentVolumeClaim: { claimName: confium-coordinator-data }
+        - name: tls
+          secret: { secretName: confium-coordinator-tls }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: confium-coordinator-data
+  namespace: confium-system
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests: { storage: 10Gi }
+---
+# ----- Signerd StatefulSet (3 replicas for 2-of-3 CMP20) ----------------
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+spec:
+  serviceName: confium-signerd
+  replicas: 3
+  selector:
+    matchLabels: { app: confium-signerd }
+  template:
+    metadata:
+      labels: { app: confium-signerd }
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "7000"
+        prometheus.io/path: "/metrics"
+    spec:
+      serviceAccountName: confium-signerd
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile: { type: RuntimeDefault }
+      containers:
+        - name: signerd
+          image: ghcr.io/confium/signerd:latest
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: COORDINATOR_URL
+              value: https://confium-coordinator:7000
+            - name: RUST_LOG
+              value: info
+          ports:
+            - name: grpc
+              containerPort: 7000
+          volumeMounts:
+            - name: shares
+              mountPath: /etc/confium/shares
+          readinessProbe:
+            tcpSocket: { port: 7000 }
+            initialDelaySeconds: 5
+          resources:
+            requests: { cpu: 100m, memory: 128Mi }
+            limits:   { cpu: 500m, memory: 512Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities: { drop: ["ALL"] }
+  volumeClaimTemplates:
+    - metadata: { name: shares }
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests: { storage: 1Gi }
+---
+# ----- Log server -------------------------------------------------------
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: confium-log-server
+  namespace: confium-system
+spec:
+  serviceName: confium-log-server
+  replicas: 1
+  selector:
+    matchLabels: { app: confium-log-server }
+  template:
+    metadata:
+      labels: { app: confium-log-server }
+    spec:
+      serviceAccountName: confium-log-server
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: log-server
+          image: ghcr.io/confium/log-server:latest
+          env: [{ name: RUST_LOG, value: info }]
+          ports: [{ name: http, containerPort: 7878 }]
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/confium
+            - name: config
+              mountPath: /etc/confium
+              readOnly: true
+  volumeClaimTemplates:
+    - metadata: { name: data }
+      spec:
+        accessModes: [ReadWriteOnce]
+        resources:
+          requests: { storage: 50Gi }
+  volumes:
+    - name: config
+      configMap: { name: confium-log-server-config }
+---
+# ----- Services ---------------------------------------------------------
+apiVersion: v1
+kind: Service
+metadata:
+  name: confium-coordinator
+  namespace: confium-system
+spec:
+  selector: { app: confium-coordinator }
+  ports: [{ name: grpc, port: 7000, targetPort: 7000 }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+spec:
+  selector: { app: confium-signerd }
+  ports: [{ name: grpc, port: 7000, targetPort: 7000 }]
+  clusterIP: None  # headless, for StatefulSet
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: confium-log-server
+  namespace: confium-system
+spec:
+  selector: { app: confium-log-server }
+  ports: [{ name: http, port: 7878, targetPort: 7878 }]
+---
+# ----- PodDisruptionBudgets --------------------------------------------
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+spec:
+  minAvailable: 2  # Keep at least 2 of 3 signerd up for quorum
+  selector:
+    matchLabels: { app: confium-signerd }
+---
+# ----- NetworkPolicies --------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+spec:
+  podSelector:
+    matchLabels: { app: confium-signerd }
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels: { app: confium-coordinator }
+      ports: [{ port: 7000 }]
+  egress:
+    - to:
+        - podSelector:
+            matchLabels: { app: confium-coordinator }
+      ports: [{ port: 7000 }]
+    - to: [{ namespaceSelector: { matchLabels: { kubernetes.io/metadata.name: kube-system } } }]
+      ports: [{ port: 53, protocol: UDP }]
+---
+# ----- HPA for signerd (auto-scale on CPU) ------------------------------
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: confium-signerd
+  namespace: confium-system
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: confium-signerd
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target: { type: Utilization, averageUtilization: 70 }

--- a/deploy/k8s/production/README.md
+++ b/deploy/k8s/production/README.md
@@ -1,0 +1,162 @@
+# Confium Production Deployment Guide
+
+This guide walks through deploying Confium on Kubernetes for production use. For local dev see [docker-compose full-stack](../docker-compose/full-stack.yml).
+
+## Prerequisites
+
+- Kubernetes 1.27+
+- `kubectl` configured
+- TLS certificates (we recommend [cert-manager](https://cert-manager.io/))
+- A storage class for persistent volumes
+- An HSM or KMS for share storage (or `kubernetes-secret` for dev)
+
+## Quick start
+
+```sh
+# Apply the full production stack
+kubectl apply -f deploy/k8s/production/
+
+# Watch it come up
+kubectl -n confium-system get pods -w
+```
+
+This brings up:
+
+- 1 coordinator (single replica, holds session state)
+- 3 signerd replicas (one share each, 2-of-3 CMP20)
+- 1 log-server
+- ConfigMaps, PVCs, Services, NetworkPolicies, PDBs, HPAs
+
+## What's in the manifest
+
+### Security
+
+- **`runAsNonRoot: true`** on every pod (distroless base images match)
+- **`readOnlyRootFilesystem: true`** so writes go only to mounted volumes
+- **`allowPrivilegeEscalation: false`**; capabilities dropped
+- **`seccompProfile: RuntimeDefault`** for syscall filtering
+- **NetworkPolicies** restricting signerd ingress/egress to just the coordinator
+
+### Reliability
+
+- **StatefulSet for signerd** with PVC per replica (share storage)
+- **PDB** keeping at least 2 signerd replicas available (preserves quorum)
+- **HPA** scaling signerd from 3 to 10 replicas on CPU >70%
+- **Readiness + liveness probes** on coordinator
+
+### Observability
+
+- **Prometheus annotations** on all pods (`prometheus.io/scrape: "true"`)
+- **Metrics path**: `/metrics` on each service
+- **Pre-built Grafana dashboards** in `deploy/grafana/`:
+  - `confium-coordinator.json`
+  - `confium-signerd.json`
+  - `confium-log-server.json`
+
+## DKG ceremony
+
+After the cluster is up, run a DKG to generate the initial shares:
+
+```sh
+# Exec into one of the signerd pods
+kubectl -n confium-system exec -it confium-signerd-0 -- bash
+
+# Inside the pod, run a 2-of-3 DKG
+confium threshold dkg \
+    --threshold 2 \
+    --parties 3 \
+    --scheme cmp20 \
+    --out /tmp/shares.json
+
+# Distribute shares to the other 2 pods (or via kubectl cp)
+# In production, use the operator-driven flow instead.
+```
+
+For a fully operator-driven flow, install the [bundle](../k8s/bundle.yaml) which adds the Confium operator. Then:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: confium.org/v1
+kind: ThresholdKey
+metadata:
+  name: my-key
+  namespace: confium-system
+spec:
+  threshold: 2
+  party_count: 3
+  scheme: cmp20
+EOF
+```
+
+The operator runs the DKG and distributes shares to the signerd pods automatically.
+
+## TLS
+
+The manifest references `confium-coordinator-tls` secret for the coordinator's TLS cert. Provision it via cert-manager:
+
+```sh
+# cert-manager issuer (if not already installed)
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.15.3/cert-manager.yaml
+
+# Self-signed issuer for dev (use Let's Encrypt / internal CA for prod)
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: self-signed
+  namespace: confium-system
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: confium-coordinator-tls
+  namespace: confium-system
+spec:
+  secretName: confium-coordinator-tls
+  dnsNames: [confium-coordinator, confium-coordinator.confium-system.svc]
+  issuerRef:
+    name: self-signed
+EOF
+```
+
+## Monitoring
+
+1. Install Prometheus + Grafana (via [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack)).
+2. Import dashboards:
+   ```sh
+   kubectl -n monitoring create cm confium-dashboards \
+       --from-file=deploy/grafana/
+   kubectl -n monitoring label cm confium-dashboards grafana_dashboard=1
+   ```
+3. Open Grafana → "Confium" folder → dashboards appear.
+
+## Upgrading
+
+```sh
+# Pull latest images
+kubectl -n confium-system set image statefulset/confium-signerd \
+    signerd=ghcr.io/confium/signerd:v0.4.0
+kubectl -n confium-system rollout status statefulset/confium-signerd
+
+# Roll back if anything fails
+kubectl -n confium-system rollout undo statefulset/confium-signerd
+```
+
+The PDB ensures 2 signerd replicas stay available during the rollout.
+
+## Backup
+
+- **Coordinator state:** PVC `confium-coordinator-data` — snapshot daily.
+- **Signerd shares:** PVC per replica — snapshot daily; rotate via Herzberg refresh quarterly.
+- **Log server:** PVC `confium-log-server-data` — append-only; snapshot weekly. Backup of OTS proofs is critical.
+
+See [backup-shares.mdx](../cookbook/backup-shares.mdx).
+
+## See also
+
+- [Terraform modules](https://github.com/confium/terraform-confium)
+- [K8s bundle (operator-only)](../k8s/bundle.yaml)
+- [Helm chart](../helm/confium/)
+- [Threat model](../../docs/security/threat-model.mdx)


### PR DESCRIPTION
## Summary

Three production-readiness artifacts:

### `deploy/docker-compose/full-stack.yml` + supporting configs
Local full-stack dev environment. One command brings up:
- 3 signerd replicas (2-of-3 CMP20)
- 1 coordinator
- 1 log-server
- 1 verify-server
- 1 prometheus
- 1 grafana (auto-provisioned with Confium dashboards)

```sh
docker compose -f deploy/docker-compose/full-stack.yml up -d
# Grafana: http://localhost:3000 (admin/admin)
```

### `deploy/k8s/production/00-confium.yaml` + `README.md`
Production Kubernetes manifest. Covers:
- Coordinator (Deployment), signerd (StatefulSet × 3), log-server (StatefulSet)
- ServiceAccounts + RBAC
- ConfigMaps for TOML configs
- PodDisruptionBudgets (preserves quorum during rollout)
- HorizontalPodAutoscaler (3-10 signerd replicas)
- NetworkPolicies (signerd ingress/egress restricted)
- SecurityContexts (runAsNonRoot, read-only rootfs, no caps, seccomp)
- Readiness + liveness probes
- Prometheus annotations

README walks through: apply, DKG ceremony, TLS via cert-manager, monitoring, upgrade/rollback, backup.

### `deploy/grafana/confium-{signerd,log-server}.json`
Pre-built Grafana dashboards:
- **Signerd**: sessions/min, latency p50/p95/p99, sessions by status, active sessions, memory
- **Log server**: appends/min, tree size, proof requests/min, OTS anchoring success rate

The existing `confium-coordinator.json` dashboard joins these.

## Test plan

- [ ] `docker compose -f deploy/docker-compose/full-stack.yml config` validates
- [ ] `kubectl apply --dry-run=client -f deploy/k8s/production/` validates
- [ ] Grafana JSON parses (validated as JSON)
- [ ] NetworkPolicy syntax valid
