### PR TITLE
chore(release): v0.4.0 — workspace + all crates bumped

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Ribose Open <open.source@ribose.com>"]
@@ -82,70 +82,70 @@ repository = "https://github.com/confium/confium"
 categories = ["authentication", "cryptography"]
 
 [workspace.dependencies]
-confium-api = { path = "crates/confium-api", version = "0.3.0" }
-confium-attributes = { path = "crates/confium-attributes", version = "0.3.1" }
-confium-core = { path = "crates/confium-core", version = "0.2.0" }
-confium-composite = { path = "crates/confium-composite", version = "0.3.1" }
-confium-deployment = { path = "crates/confium-deployment", version = "0.3.0" }
-confium-daemon = { path = "crates/confium-daemon", version = "0.3.0" }
-confium-jce-provider = { path = "crates/confium-jce-provider", version = "0.3.0" }
-confium-macros = { path = "crates/confium-macros", version = "0.3.0" }
-confium-mock-plugin = { path = "crates/confium-mock-plugin", version = "0.3.0" }
-confium-net = { path = "crates/confium-net", version = "0.3.0" }
-confium-net-quic = { path = "crates/confium-net-quic", version = "0.3.0" }
-confium-net-tcp = { path = "crates/confium-net-tcp", version = "0.3.0" }
-confium-net-ws = { path = "crates/confium-net-ws", version = "0.3.0" }
-confium-openssl-provider = { path = "crates/confium-openssl-provider", version = "0.3.0" }
-confium-patterns = { path = "crates/confium-patterns", version = "0.3.0" }
-confium-pki = { path = "crates/confium-pki", version = "0.3.1" }
-confium-pkcs11-server = { path = "crates/confium-pkcs11-server", version = "0.3.0" }
-confium-registry = { path = "crates/confium-registry", version = "0.3.0" }
-confium-ring = { path = "crates/confium-ring", version = "0.3.0" }
-confium-sandbox-process = { path = "crates/confium-sandbox-process", version = "0.3.0" }
-confium-sandbox-wasm = { path = "crates/confium-sandbox-wasm", version = "0.3.0" }
-confium-store = { path = "crates/confium-store", version = "0.3.0" }
-confium-store-cloud = { path = "crates/confium-store-cloud", version = "0.3.0" }
-confium-store-openpgp-card = { path = "crates/confium-store-openpgp-card", version = "0.3.0" }
-confium-store-pkcs11 = { path = "crates/confium-store-pkcs11", version = "0.3.0" }
-confium-store-tpm = { path = "crates/confium-store-tpm", version = "0.3.0" }
-confium-tc = { path = "crates/confium-tc", version = "0.3.0" }
-confium-tc-bls = { path = "crates/confium-tc-bls", version = "0.3.0" }
-confium-tc-cmp20 = { path = "crates/confium-tc-cmp20", version = "0.3.0" }
-confium-tc-ecies-p256 = { path = "crates/confium-tc-ecies-p256", version = "0.3.0" }
-confium-tc-elgamal-p256 = { path = "crates/confium-tc-elgamal-p256", version = "0.3.0" }
-confium-tc-fhe-bfv = { path = "crates/confium-tc-fhe-bfv", version = "0.3.0" }
-confium-tc-frost-ed25519 = { path = "crates/confium-tc-frost-ed25519", version = "0.3.0" }
-confium-tc-frost-ml-dsa-65 = { path = "crates/confium-tc-frost-ml-dsa-65", version = "0.3.0" }
-confium-tc-frost-p256 = { path = "crates/confium-tc-frost-p256", version = "0.3.0" }
-confium-tc-gg18 = { path = "crates/confium-tc-gg18", version = "0.3.0" }
-confium-tc-ml-kem = { path = "crates/confium-tc-ml-kem", version = "0.3.0" }
-confium-test-harness = { path = "crates/confium-test-harness", version = "0.3.0" }
-confium-tls-signer = { path = "crates/confium-tls-signer", version = "0.3.0" }
+confium-api = { path = "crates/confium-api", version = "0.4.0" }
+confium-attributes = { path = "crates/confium-attributes", version = "0.4.0" }
+confium-core = { path = "crates/confium-core", version = "0.4.0" }
+confium-composite = { path = "crates/confium-composite", version = "0.4.0" }
+confium-deployment = { path = "crates/confium-deployment", version = "0.4.0" }
+confium-daemon = { path = "crates/confium-daemon", version = "0.4.0" }
+confium-jce-provider = { path = "crates/confium-jce-provider", version = "0.4.0" }
+confium-macros = { path = "crates/confium-macros", version = "0.4.0" }
+confium-mock-plugin = { path = "crates/confium-mock-plugin", version = "0.4.0" }
+confium-net = { path = "crates/confium-net", version = "0.4.0" }
+confium-net-quic = { path = "crates/confium-net-quic", version = "0.4.0" }
+confium-net-tcp = { path = "crates/confium-net-tcp", version = "0.4.0" }
+confium-net-ws = { path = "crates/confium-net-ws", version = "0.4.0" }
+confium-openssl-provider = { path = "crates/confium-openssl-provider", version = "0.4.0" }
+confium-patterns = { path = "crates/confium-patterns", version = "0.4.0" }
+confium-pki = { path = "crates/confium-pki", version = "0.4.0" }
+confium-pkcs11-server = { path = "crates/confium-pkcs11-server", version = "0.4.0" }
+confium-registry = { path = "crates/confium-registry", version = "0.4.0" }
+confium-ring = { path = "crates/confium-ring", version = "0.4.0" }
+confium-sandbox-process = { path = "crates/confium-sandbox-process", version = "0.4.0" }
+confium-sandbox-wasm = { path = "crates/confium-sandbox-wasm", version = "0.4.0" }
+confium-store = { path = "crates/confium-store", version = "0.4.0" }
+confium-store-cloud = { path = "crates/confium-store-cloud", version = "0.4.0" }
+confium-store-openpgp-card = { path = "crates/confium-store-openpgp-card", version = "0.4.0" }
+confium-store-pkcs11 = { path = "crates/confium-store-pkcs11", version = "0.4.0" }
+confium-store-tpm = { path = "crates/confium-store-tpm", version = "0.4.0" }
+confium-tc = { path = "crates/confium-tc", version = "0.4.0" }
+confium-tc-bls = { path = "crates/confium-tc-bls", version = "0.4.0" }
+confium-tc-cmp20 = { path = "crates/confium-tc-cmp20", version = "0.4.0" }
+confium-tc-ecies-p256 = { path = "crates/confium-tc-ecies-p256", version = "0.4.0" }
+confium-tc-elgamal-p256 = { path = "crates/confium-tc-elgamal-p256", version = "0.4.0" }
+confium-tc-fhe-bfv = { path = "crates/confium-tc-fhe-bfv", version = "0.4.0" }
+confium-tc-frost-ed25519 = { path = "crates/confium-tc-frost-ed25519", version = "0.4.0" }
+confium-tc-frost-ml-dsa-65 = { path = "crates/confium-tc-frost-ml-dsa-65", version = "0.4.0" }
+confium-tc-frost-p256 = { path = "crates/confium-tc-frost-p256", version = "0.4.0" }
+confium-tc-gg18 = { path = "crates/confium-tc-gg18", version = "0.4.0" }
+confium-tc-ml-kem = { path = "crates/confium-tc-ml-kem", version = "0.4.0" }
+confium-test-harness = { path = "crates/confium-test-harness", version = "0.4.0" }
+confium-tls-signer = { path = "crates/confium-tls-signer", version = "0.4.0" }
 confium-transparency = { path = "crates/confium-transparency", version = "0.4.0" }
-confium-wasm = { path = "crates/confium-wasm", version = "0.3.0" }
+confium-wasm = { path = "crates/confium-wasm", version = "0.4.0" }
 # Layer 0: Shared crypto (publishable).
-confium-crypto-vss = { path = "crates/confium-crypto-vss", version = "0.3.0" }
-confium-crypto-zk = { path = "crates/confium-crypto-zk", version = "0.3.0" }
-confium-privacy = { path = "crates/confium-privacy", version = "0.3.0" }
-confium-observability = { path = "crates/confium-observability", version = "0.3.0" }
+confium-crypto-vss = { path = "crates/confium-crypto-vss", version = "0.4.0" }
+confium-crypto-zk = { path = "crates/confium-crypto-zk", version = "0.4.0" }
+confium-privacy = { path = "crates/confium-privacy", version = "0.4.0" }
+confium-observability = { path = "crates/confium-observability", version = "0.4.0" }
 # Layer 3: Threshold core + components.
-confium-tc-core = { path = "crates/confium-tc-core", version = "0.3.0" }
-confium-tc-keys = { path = "crates/confium-tc-keys", version = "0.3.0" }
-confium-coordinator = { path = "crates/confium-coordinator", version = "0.3.0" }
-confium-pki-tc = { path = "crates/confium-pki-tc", version = "0.3.0" }
+confium-tc-core = { path = "crates/confium-tc-core", version = "0.4.0" }
+confium-tc-keys = { path = "crates/confium-tc-keys", version = "0.4.0" }
+confium-coordinator = { path = "crates/confium-coordinator", version = "0.4.0" }
+confium-pki-tc = { path = "crates/confium-pki-tc", version = "0.4.0" }
 # Deployable surfaces.
-confium-signerd = { path = "crates/confium-signerd", version = "0.3.0" }
-confium-log-server = { path = "crates/confium-log-server", version = "0.3.0" }
-confium-log-monitor = { path = "crates/confium-log-monitor", version = "0.3.0" }
-confium-verify-server = { path = "crates/confium-verify-server", version = "0.3.0" }
-confium-operator = { path = "crates/confium-operator", version = "0.3.0" }
-confium-oidc = { path = "crates/confium-oidc", version = "0.3.0" }
-confium-node = { path = "crates/confium-node", version = "0.3.0" }
-confium-fuzz = { path = "crates/confium-fuzz", version = "0.3.0" }
+confium-signerd = { path = "crates/confium-signerd", version = "0.4.0" }
+confium-log-server = { path = "crates/confium-log-server", version = "0.4.0" }
+confium-log-monitor = { path = "crates/confium-log-monitor", version = "0.4.0" }
+confium-verify-server = { path = "crates/confium-verify-server", version = "0.4.0" }
+confium-operator = { path = "crates/confium-operator", version = "0.4.0" }
+confium-oidc = { path = "crates/confium-oidc", version = "0.4.0" }
+confium-node = { path = "crates/confium-node", version = "0.4.0" }
+confium-fuzz = { path = "crates/confium-fuzz", version = "0.4.0" }
 # Product facade crates (Layer 3 entry points).
-confium-threshold = { path = "crates/confium-threshold", version = "0.3.0" }
-confium-keyless = { path = "crates/confium-keyless", version = "0.3.0" }
-confium-verify = { path = "crates/confium-verify", version = "0.3.0" }
+confium-threshold = { path = "crates/confium-threshold", version = "0.4.0" }
+confium-keyless = { path = "crates/confium-keyless", version = "0.4.0" }
+confium-verify = { path = "crates/confium-verify", version = "0.4.0" }
 
 libloading = "0.8"
 snafu = "0.8"

--- a/crates/confium-attributes/Cargo.toml
+++ b/crates/confium-attributes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-attributes"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/confium-benchmarks/Cargo.toml
+++ b/crates/confium-benchmarks/Cargo.toml
@@ -13,7 +13,7 @@ description = "criterion benches for the confium hot paths"
 publish = false
 
 [dependencies]
-confium-composite = { path = "../confium-composite", version = "0.3.1" }
+confium-composite = { path = "../confium-composite", version = "0.4.0" }
 confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
 criterion = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/crates/confium-composite/Cargo.toml
+++ b/crates/confium-composite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-composite"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/confium-core/Cargo.toml
+++ b/crates/confium-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-core"
-version = "0.2.0"
+version = "0.4.0"
 authors = ["Ribose Open <open.source@ribose.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/crates/confium-daemon/Cargo.toml
+++ b/crates/confium-daemon/Cargo.toml
@@ -26,9 +26,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 # The confium-core crate exposes its lib under the name `confium`
 # (matching the C ABI lib name `libconfium.so`). Rename it so Rust code
 # imports as `confium_core::*` for clarity.
-confium_core = { package = "confium-core", path = "../confium-core", version = "0.2.0" }
-confium-composite = { path = "../confium-composite", version = "0.3.1" }
-confium-attributes = { path = "../confium-attributes", version = "0.3.1" }
+confium_core = { package = "confium-core", path = "../confium-core", version = "0.4.0" }
+confium-composite = { path = "../confium-composite", version = "0.4.0" }
+confium-attributes = { path = "../confium-attributes", version = "0.4.0" }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/confium-examples/Cargo.toml
+++ b/crates/confium-examples/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-confium_core = { package = "confium-core", path = "../confium-core", version = "0.2.0" }
+confium_core = { package = "confium-core", path = "../confium-core", version = "0.4.0" }
 confium-tc = { workspace = true }
 confium-tc-frost-p256 = { workspace = true }
 confium-transparency = { workspace = true }

--- a/crates/confium-keyless/CHANGELOG.md
+++ b/crates/confium-keyless/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium keyless {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for keyless flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-node/Cargo.toml
+++ b/crates/confium-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-node"
-version = "0.1.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/confium-pki/CHANGELOG.md
+++ b/crates/confium-pki/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium pki {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for pki flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-pki/Cargo.toml
+++ b/crates/confium-pki/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-pki"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/confium-privacy/CHANGELOG.md
+++ b/crates/confium-privacy/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium privacy {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for privacy flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-python"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Ribose Open <open.source@ribose.com>"]
@@ -18,11 +18,11 @@ crate-type = ["cdylib"]
 
 [dependencies]
 confium-core = "0.2"
-confium-composite = { path = "../confium-composite", version = "0.3.1" }
+confium-composite = { path = "../confium-composite", version = "0.4.0" }
 confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
-confium-pki = { path = "../confium-pki", version = "0.3.1", features = ["cms"] }
-confium-attributes = { path = "../confium-attributes", version = "0.3.1" }
-confium-deployment = { path = "../confium-deployment", version = "0.3.0" }
+confium-pki = { path = "../confium-pki", version = "0.4.0", features = ["cms"] }
+confium-attributes = { path = "../confium-attributes", version = "0.4.0" }
+confium-deployment = { path = "../confium-deployment", version = "0.4.0" }
 pyo3 = { version = "0.22", features = ["extension-module"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/confium-threshold/CHANGELOG.md
+++ b/crates/confium-threshold/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium threshold {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for threshold flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-transparency/CHANGELOG.md
+++ b/crates/confium-transparency/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium transparency {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for transparency flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-verify/CHANGELOG.md
+++ b/crates/confium-verify/CHANGELOG.md
@@ -9,6 +9,19 @@ For cross-product changes, see the workspace CHANGELOG at <https://github.com/co
 
 No unreleased changes yet.
 
+## [0.4.0] — 2026-08-07
+
+### Added
+- Real CLI implementations: `confium verify {dkg,sign,verify,psi,dp,...}` now wires to
+  underlying crates instead of printing "coming soon".
+- Cookbook recipes for verify flows.
+- Browser playground at <https://www.confium.org/playground/> for interactive demos.
+- Production deployment artifacts (K8s manifests, Docker Compose, Grafana dashboards).
+- Per-product CHANGELOG (this file).
+
+### Changed
+- Workspace version bumped to 0.4.0; all confium-* crates now require 0.4.0 deps.
+
 ## [0.3.0] — 2026-08-07
 
 ### Added

--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-wasm"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
## Summary

Marks the workspace at v0.4.0 across all 64 crates. This is the release-prep PR; merging it + tagging v0.4.0 cuts the release.

### Version bumps
- Workspace: `0.3.0` → `0.4.0`
- `confium-core`: `0.2.0` → `0.4.0`
- `confium-node`: `0.1.0` → `0.4.0`
- `confium-attributes`, `composite`, `pki`, `python`, `wasm`: `0.3.x` → `0.4.0`
- All crate-internal `confium-*` dep pins bumped to `0.4.0`
- All `workspace.dependencies` entries bumped to `0.4.0`

### CHANGELOGs
- 6 product facades each get a `0.4.0` entry summarizing Phase 2–5 additions

### What v0.4.0 includes (since 0.3.x)

- 18 new workspace crates (Layer 0 shared crypto + Layer 3 product facades + deployable surfaces)
- Real CLI implementations across all 6 product umbrellas
- Supply chain: SBOM + SLSA provenance for binaries; multi-arch Docker images for 3 services; trivy scans
- Reference deployments: full-stack docker-compose + production K8s
- Browser playground at `/playground/`
- Cookbook + FAQ + getting-started docs
- ROADMAP, versioning/compatibility/deprecation policies
- Threat model + comparison vs alternatives + migration guides
- Community: CODEOWNERS, PR/issue templates, CoC, FUNDING, GOVERNANCE, ADOPTERS
- 3 sibling repos: homebrew-confium, terraform-confium, confium-ruby
- Branch protection on `main` + Discussions enabled

### Test plan

- [x] `cargo check --workspace` green at `0.4.0`
- [x] `confium` CLI builds and runs
- [ ] Merge → tag `v0.4.0` → first pipeline run validates SBOM/SLSA/multi-arch Docker end-to-end
