### PR TITLE
fix(ci): docker-release matrix — drop inputs-based expression

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: ${{ fromJSON(format('["{0}"]', join(split(github.event.inputs.services || 'signerd,log-server,verify-server', ','), '","'))) }}
+        service: [signerd, log-server, verify-server]
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

The matrix expression in `docker-release.yml` used `github.event.inputs.services`, which isn't populated on tag pushes (only on `workflow_dispatch`). Result: the workflow failed immediately when v0.4.0 was tagged.

Hardcoded the matrix to the 3 known services. Simpler, correct, no dynamic input needed for tag-triggered builds.

## Test plan

- [ ] PR merges
- [ ] Re-trigger via workflow_dispatch OR push a follow-up tag (e.g. v0.4.1) to validate
