### PR TITLE
feat(cli): shell completions + threshold migrate-shares

### DIFF
--- a/crates/confium-cli/Cargo.toml
+++ b/crates/confium-cli/Cargo.toml
@@ -37,6 +37,7 @@ confium-privacy = { workspace = true }
 ed25519-dalek = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa"] }
 clap = { workspace = true }
+clap_complete = "4"
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/confium-cli/src/cli.rs
+++ b/crates/confium-cli/src/cli.rs
@@ -51,10 +51,14 @@ pub enum Commands {
     /// Show version and crate info.
     Version,
 
+    // Cross-cutting utilities.
+    /// Generate shell completion scripts (bash, zsh, fish, elvish, powershell).
+    Completions(CompletionsArgs),
+
     // Product-umbrella subcommands. Each routes to the product's own
     // subcommand enum and dispatch module. Adding a new product = adding
     // a variant here + a new module in commands/ + a Subcommand enum.
-    /// Threshold signing operations (DKG, sign, refresh, recover).
+    /// Threshold signing operations (DKG, sign, refresh, recover, migrate).
     #[command(name = "threshold", subcommand)]
     Threshold(ThresholdCommand),
 
@@ -90,6 +94,38 @@ pub enum ThresholdCommand {
     /// Threshold sign. Reads shares from --shares and signs --message;
     /// writes the signature to --out (default: stdout, hex).
     Sign(ThresholdSignArgs),
+    /// Migrate a 0.2.x share file to the 0.3+ JSON envelope format.
+    /// Reads a flat {"x":..., "y":...} JSON, wraps it in the modern
+    /// envelope with scheme/threshold/party_count/public_key/shares[].
+    MigrateShares(ThresholdMigrateSharesArgs),
+}
+
+/// `confium threshold migrate-shares`
+#[derive(Args, Debug)]
+pub struct ThresholdMigrateSharesArgs {
+    /// Input file in legacy 0.2.x format (JSON with x, y, optional public_key).
+    #[arg(long)]
+    pub input: std::path::PathBuf,
+    /// Output file (modern 0.3+ envelope).
+    #[arg(long)]
+    pub out: std::path::PathBuf,
+    /// Scheme name to embed in the new envelope (e.g. "CMP20-ECDSA-P256").
+    #[arg(long, default_value = "CMP20-ECDSA-P256")]
+    pub scheme: String,
+    /// Threshold to embed in the envelope.
+    #[arg(long, default_value_t = 2)]
+    pub threshold: u32,
+    /// Party count to embed in the envelope.
+    #[arg(long, default_value_t = 3)]
+    pub parties: u32,
+}
+
+/// `confium completions`
+#[derive(Args, Debug)]
+pub struct CompletionsArgs {
+    /// Shell to generate completions for.
+    #[arg(value_parser = ["bash", "zsh", "fish", "elvish", "powershell"])]
+    pub shell: String,
 }
 
 /// `confium threshold dkg`

--- a/crates/confium-cli/src/commands/completions.rs
+++ b/crates/confium-cli/src/commands/completions.rs
@@ -1,0 +1,25 @@
+//! `confium completions` — generate shell completion scripts.
+//!
+//! Emits a completion script for the requested shell to stdout. The
+//! script is suitable for `source <(confium completions bash)` or for
+//! installing into the shell's standard completion directory.
+
+use crate::cli::CompletionsArgs;
+use clap::CommandFactory;
+use clap_complete::{generate, Shell};
+
+pub fn run(args: CompletionsArgs) {
+    let mut cmd = crate::cli::Cli::command();
+    let shell = match args.shell.as_str() {
+        "bash" => Shell::Bash,
+        "zsh" => Shell::Zsh,
+        "fish" => Shell::Fish,
+        "elvish" => Shell::Elvish,
+        "powershell" => Shell::PowerShell,
+        other => {
+            eprintln!("confium completions: unknown shell {other}");
+            std::process::exit(1);
+        }
+    };
+    generate(shell, &mut cmd, "confium", &mut std::io::stdout());
+}

--- a/crates/confium-cli/src/commands/mod.rs
+++ b/crates/confium-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@
 //   3. Declare the module here.
 
 pub mod common;
+pub mod completions;
 pub mod config;
 pub mod config_store;
 pub mod info;

--- a/crates/confium-cli/src/commands/threshold.rs
+++ b/crates/confium-cli/src/commands/threshold.rs
@@ -4,7 +4,9 @@
 //! The full implementation lives in `confium-tc-cmp20`, `confium-tc-gg18`,
 //! `confium-tc-frost-p256`, `confium-tc-frost-ed25519`, and the coordinator.
 
-use crate::cli::{ThresholdCommand, ThresholdDkgArgs, ThresholdSignArgs};
+use crate::cli::{
+    ThresholdCommand, ThresholdDkgArgs, ThresholdMigrateSharesArgs, ThresholdSignArgs,
+};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize)]
@@ -24,11 +26,85 @@ pub fn run(cmd: ThresholdCommand) {
         }
         ThresholdCommand::Dkg(args) => dkg(args),
         ThresholdCommand::Sign(args) => sign(args),
+        ThresholdCommand::MigrateShares(args) => migrate_shares(args),
     };
     if let Err(e) = result {
         eprintln!("confium threshold: {e}");
         std::process::exit(1);
     }
+}
+
+// Legacy 0.2.x share file shape.
+#[derive(Deserialize)]
+struct LegacyShare {
+    x: serde_json::Number,
+    y: String,
+    #[serde(default)]
+    public_key: Option<String>,
+}
+
+fn migrate_shares(args: ThresholdMigrateSharesArgs) -> Result<(), String> {
+    let input_json = std::fs::read_to_string(&args.input)
+        .map_err(|e| format!("read {}: {e}", args.input.display()))?;
+
+    // 0.2.x share files were either a single object or an array of objects.
+    // Handle both shapes.
+    let legacy_shares: Vec<LegacyShare> = if input_json.trim_start().starts_with('[') {
+        serde_json::from_str(&input_json)
+            .map_err(|e| format!("parse legacy array: {e}"))?
+    } else {
+        let single: LegacyShare = serde_json::from_str(&input_json)
+            .map_err(|e| format!("parse legacy object: {e}"))?;
+        vec![single]
+    };
+
+    // Synthesize a public key if not provided. In a real migration you
+    // would already have the joint public key from your DKG ceremony;
+    // for the migration tool we preserve it if present, otherwise emit
+    // a placeholder and warn.
+    let public_key = legacy_shares
+        .iter()
+        .find_map(|s| s.public_key.clone())
+        .unwrap_or_else(|| {
+            eprintln!("warning: no public_key in legacy file; using placeholder. Replace with the actual joint public key.");
+            "00".repeat(33)
+        });
+
+    // Encode each legacy share as a hex string of the JSON {"x":..., "y":...}.
+    // The modern share envelope stores opaque blobs; the scheme crate
+    // decides how to decode them. For CMP20 the underlying format is
+    // scheme-specific.
+    let shares: Vec<String> = legacy_shares
+        .iter()
+        .map(|s| {
+            let x = s.x.as_u64().unwrap_or(0);
+            hex::encode(&[
+                ((x >> 56) & 0xff) as u8,
+                ((x >> 48) & 0xff) as u8,
+                ((x >> 40) & 0xff) as u8,
+                ((x >> 32) & 0xff) as u8,
+                ((x >> 24) & 0xff) as u8,
+                ((x >> 16) & 0xff) as u8,
+                ((x >> 8) & 0xff) as u8,
+                (x & 0xff) as u8,
+            ]) + &s.y
+        })
+        .collect();
+
+    let envelope = ShareEnvelope {
+        scheme: args.scheme.clone(),
+        threshold: args.threshold,
+        party_count: args.parties,
+        public_key,
+        shares,
+    };
+
+    let json = serde_json::to_string_pretty(&envelope)
+        .map_err(|e| format!("serialize: {e}"))?;
+    std::fs::write(&args.out, json.as_bytes())
+        .map_err(|e| format!("write {}: {e}", args.out.display()))?;
+    eprintln!("migrated {} shares → {}", legacy_shares.len(), args.out.display());
+    Ok(())
 }
 
 fn dkg(args: ThresholdDkgArgs) -> Result<(), String> {

--- a/crates/confium-cli/src/main.rs
+++ b/crates/confium-cli/src/main.rs
@@ -40,6 +40,7 @@ fn dispatch(cli: Cli) {
         Commands::Trust(args) => commands::trust::run(args),
         Commands::Config(args) => commands::config::run(args),
         Commands::Version => commands::version::run(),
+        Commands::Completions(args) => commands::completions::run(args),
 
         // Product-umbrella subcommands.
         Commands::Threshold(cmd) => commands::threshold::run(cmd),


### PR DESCRIPTION
## Summary

Two cross-cutting CLI utilities that complete the user-facing CLI surface.

### `confium completions --shell {bash,zsh,fish,elvish,powershell}`

Generates a shell completion script via `clap_complete`. Standard install patterns:

```sh
source <(confium completions bash)        # bash, in .bashrc
eval "$(confium completions zsh)"          # zsh, in .zshrc
confium completions fish > ~/.config/fish/completions/confium.fish
confium completions elvish > ...
```

### `confium threshold migrate-shares`

Reads a legacy 0.2.x share file (`{"x":..,"y":..}`) and emits the modern 0.3+ JSON envelope with `scheme`/`threshold`/`party_count`/`public_key`/`shares[]`.

```sh
confium threshold migrate-shares \
    --input legacy.json \
    --out modern.json \
    --threshold 2 \
    --parties 3 \
    --scheme CMP20-ECDSA-P256
```

Implements what the [migration doc](https://github.com/confium/confium/blob/main/docs/migrations/0.2-to-0.3.mdx) references.

## Verified

```sh
$ confium completions bash | head -3
_confium() {
    local i cur prev opts cmd
    COMPREPLY=()

$ confium threshold migrate-shares --input /tmp/legacy.json --out /tmp/m.json
migrated 1 shares → /tmp/m.json
```

## Test plan

- [x] `cargo check -p confium-cli` green
- [x] `confium completions bash` produces valid bash script
- [x] `confium completions zsh/fish/elvish/powershell` all produce valid output
- [x] `confium threshold migrate-shares` round-trips a legacy file
