### PR TITLE
docs(cookbook): 9 more recipes — refresh, verify-server, monitoring, backup, k8s, witness, OTS, PKCS#11, composite

### DIFF
--- a/docs/cookbook/backup-shares.mdx
+++ b/docs/cookbook/backup-shares.mdx
@@ -1,0 +1,131 @@
+---
+title: Backup and restore shares
+description: Don't lose your shares — backup strategy and recovery procedures
+audience: security-engineer, devsecops
+---
+
+# Backup and restore shares
+
+**Problem:** A signerd replica's host crashes. The share on its PVC is gone. Now what?
+
+## TL;DR
+
+- **Back up** the share file to an encrypted, offsite location after the DKG ceremony and after every refresh.
+- **Restore** by mounting the backup as a new PVC and pointing signerd at it.
+- **Never** store plaintext shares on shared infrastructure.
+
+## Backup strategies
+
+### Option A: KMS-encrypted object storage (recommended)
+
+```sh
+# On the signerd pod, dump the share to stdout in encrypted form
+kubectl -n confium-system exec confium-signerd-0 -- \
+    confium threshold share-export \
+        --share /etc/confium/shares/party1.json \
+        --kms aws-kms://alias/confium-share-encryption \
+    > backups/party1.json.enc
+
+# Upload to S3 (versioned bucket)
+aws s3 cp backups/party1.json.enc \
+    s3://confium-share-backups/confium-signerd-0/$(date +%Y%m%d)/party1.json.enc
+```
+
+The `--kms` flag tells Confium to encrypt the share with the KMS key before writing to stdout. The bucket sees ciphertext only.
+
+### Option B: Volume snapshots
+
+If your storage class supports snapshots (e.g., EBS, GCE PD, Azure Disk):
+
+```sh
+# Take a snapshot
+kubectl -n confium-system create volume snapshot signerd-0-snap \
+    --source=pvc/confium-signerd-0-shares
+
+# Verify
+kubectl -n confium-system get volumesnapshot signerd-0-snap
+```
+
+Snapshots are point-in-time. Use these for short-term recovery; long-term backups should be KMS-encrypted to object storage.
+
+### Option C: HSM-stored shares (best)
+
+If shares live in an HSM (recommended for production), there's no "share file" to back up. The HSM provides its own redundancy. Backup becomes:
+
+- HSM configuration (partitions, roles, policies)
+- HSM vendor-specific backup (e.g., Luna `vsp backup`, YubiHSM `yhsm-yubihsm-shell`)
+
+See your HSM vendor's docs for their backup procedure.
+
+## Restore procedure
+
+### From KMS-encrypted backup
+
+```sh
+# Download the backup
+aws s3 cp s3://confium-share-backups/confium-signerd-0/20260807/party1.json.enc .
+
+# Decrypt to a new PVC
+kubectl -n confium-system exec confium-signerd-0 -- \
+    confium threshold share-import \
+        --encrypted-share /dev/stdin \
+        --kms aws-kms://alias/confium-share-encryption \
+        --out /etc/confium/shares/party1.json \
+    < party1.json.enc
+```
+
+### From volume snapshot
+
+```sh
+# Restore PVC from snapshot
+kubectl -n confium-system apply -f - <<EOF
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: confium-signerd-0-shares-restored
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests: { storage: 1Gi }
+  dataSource:
+    name: signerd-0-snap
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+EOF
+
+# Swap the PVC in the StatefulSet
+kubectl -n confium-system patch statefulset confium-signerd \
+    --type=json \
+    -p='[{"op":"replace","path":"/spec/volumeClaimTemplates/0/metadata/name","value":"confium-signerd-0-shares-restored"}]'
+```
+
+## Verification
+
+After restore:
+
+```sh
+# Verify the share parses
+kubectl -n confium-system exec confium-signerd-0 -- \
+    confium threshold share-verify \
+        --share /etc/confium/shares/party1.json
+
+# Verify the public key still matches
+kubectl -n confium-system exec confium-signerd-0 -- \
+    cat /etc/confium/shares/party1.json | jq -r '.public_key'
+# Should match what's in your cert / transparency log
+```
+
+## Post-restore refresh
+
+After a restore, run a refresh ceremony to "rotate" the recovered share. This protects against the scenario where the backup was also compromised.
+
+```sh
+# All parties refresh
+confium threshold refresh --shares ... --out-dir ...
+```
+
+## See also
+
+- [Refresh shares without re-keying](./refresh-shares.mdx)
+- [Production K8s deployment](https://github.com/confium/confium/blob/main/deploy/k8s/production/README.md)
+- [Threat model](../security/threat-model.mdx)

--- a/docs/cookbook/composite-sign-pq-migration.mdx
+++ b/docs/cookbook/composite-sign-pq-migration.mdx
@@ -1,0 +1,141 @@
+---
+title: Composite sign for PQ migration
+description: Hybrid classical + PQ signatures to bridge the post-quantum transition
+audience: security-engineer, ca-operator
+---
+
+# Composite sign for PQ migration
+
+**Problem:** You're issuing signatures today that need to remain valid for 10+ years. ECDSA might be broken by quantum computers in that window. You want to start signing with BOTH classical and post-quantum algorithms so the signature stays valid if EITHER algorithm holds.
+
+## Solution
+
+Composite signatures (IETF draft) bundle multiple per-algorithm signatures into one envelope. Verifiers check all components; the signature is valid if all pass.
+
+## Current state
+
+Confium's composite signatures support:
+
+- **Ed25519** (classical) — `confium_composite::build_ed25519_component`
+- **ECDSA-P256** (classical) — `confium_composite::build_p256_component`
+
+PQ algorithms (ML-DSA-65, SLH-DSA) land when the underlying FIPS 204/205 crates ship. Today you can deploy hybrid classical-classical (Ed25519 + P256) to bridge between systems that only support one.
+
+## Quickstart
+
+### Generate keys (one of each algorithm)
+
+```sh
+# Generate an Ed25519 keypair
+openssl genpkey -algorithm ed25519 -out ed25519.key
+openssl pkey -in ed25519.key -pubout -out ed25519.pub
+
+# Generate an ECDSA-P256 keypair
+openssl genpkey -algorithm ec -pkeyopt ec_paramgen_curve:P-256 -out p256.key
+openssl pkey -in p256.key -pubout -out p256.pub
+```
+
+### Composite-sign via CLI
+
+```sh
+# Extract raw key bytes for the CLI (in production, keep keys in HSM)
+openssl pkey -in ed25519.key -outform DER 2>/dev/null | tail -c 32 > ed25519.key.bin
+openssl ec -in p256.key -outform DER 2>/dev/null | tail -c 32 > p256.key.bin
+
+confium pki composite-sign \
+    --message "release-v1.0.0.tar.gz" \
+    --ed25519-key ed25519.key.bin \
+    --p256-key p256.key.bin \
+    --out composite-sig.hex
+```
+
+### Verify
+
+```sh
+# Verify the Ed25519 component
+confium verify composite \
+    --signature composite-sig.hex \
+    --algorithm ed25519 \
+    --message "release-v1.0.0.tar.gz" \
+    --public-key ed25519.pub
+
+# Verify the ECDSA-P256 component
+confium verify composite \
+    --signature composite-sig.hex \
+    --algorithm ecdsa-p256 \
+    --message "release-v1.0.0.tar.gz" \
+    --public-key p256.pub
+```
+
+Both components must verify for the composite to be considered valid.
+
+## When to use composite
+
+| Scenario | Use composite? |
+|----------|----------------|
+| Long-lived signatures (5+ years) | Yes — PQ migration insurance |
+| Short-lived signatures (minutes) | No — overhead not worth it |
+| Cross-system interop | Yes — bridge old + new systems |
+| Performance-critical | No — composites are 2×+ larger |
+
+## Verifier policy
+
+By default, verifiers require ALL components to pass (strict). For migration scenarios where you want to accept EITHER component, you can configure the verifier:
+
+```rust
+// Rust: relaxed policy (either component verifies = overall valid)
+use confium_composite::CompositeSignature;
+
+let result = sig.verify(&message, |alg, pk, msg, sig| {
+    // Try Ed25519 first, fall back to P256
+    if confium_composite::ed25519_verifier(alg, pk, msg, sig).is_ok() {
+        return Ok(());
+    }
+    confium_composite::p256_verifier(alg, pk, msg, sig)
+});
+```
+
+This is **less secure** — only use it for transitional scenarios where one algorithm might be deprecated soon.
+
+## Storage
+
+Composite signatures are JSON-serialized for portability:
+
+```json
+{
+  "components": [
+    {
+      "algorithm": "Ed25519",
+      "public_key": "hex...",
+      "signature": "hex..."
+    },
+    {
+      "algorithm": "ECDSA-P256",
+      "public_key": "hex...",
+      "signature": "hex..."
+    }
+  ]
+}
+```
+
+Each component carries its own public key. Verifiers don't need to know which key belongs to which algorithm in advance.
+
+## Future: ML-DSA composites
+
+When FIPS 204 (ML-DSA) crates ship, the API will extend to:
+
+```rust
+let composite = CompositeSignature::new(vec![
+    build_ed25519_component(&classical_key, &message)?,
+    build_ml_dsa_65_component(&pq_key, &message)?,
+]);
+```
+
+The verifier API stays the same. Your existing composite-sign tooling will work unchanged — just add the PQ component.
+
+## See also
+
+- [Composite signatures spec](https://www.confium.org/specs/82-composite-signatures)
+- [Threshold CA issue](./threshold-ca-issue.mdx)
+- [PKI product docs](https://www.confium.org/pki/)
+- [NIST PQC standardization](https://csrc.nist.gov/projects/post-quantum-cryptography)

--- a/docs/cookbook/deploy-signerd-k8s.mdx
+++ b/docs/cookbook/deploy-signerd-k8s.mdx
@@ -1,0 +1,157 @@
+---
+title: Deploy signerd on Kubernetes
+description: Production signerd deployment with operator, HSM, and monitoring
+audience: devsecops
+---
+
+# Deploy signerd on Kubernetes
+
+**Problem:** You want to run a 3-replica signerd cluster in production, with HSM-backed shares, monitoring, and graceful upgrades.
+
+## Solution
+
+Confium ships:
+
+- A [production K8s manifest](https://github.com/confium/confium/blob/main/deploy/k8s/production/00-confium.yaml) with everything pre-wired
+- A [Helm chart](https://github.com/confium/confium/tree/main/deploy/helm/confium) for parameterized installs
+- A [Terraform module](https://github.com/confium/terraform-confium) for infra-as-code
+
+This recipe walks through the manifest path.
+
+## Step 1: Apply the manifest
+
+```sh
+kubectl apply -f https://confium.org/deploy/k8s/production/00-confium.yaml
+```
+
+This brings up:
+
+- 1 coordinator (Deployment)
+- 3 signerd replicas (StatefulSet with PVC per replica)
+- 1 log-server (StatefulSet)
+- RBAC, ConfigMaps, PDBs, NetworkPolicies, HPAs
+
+```sh
+kubectl -n confium-system get pods -w
+# NAME                                    READY   STATUS    RESTARTS   AGE
+# confium-coordinator-7d4f5b6c8-x9k2j     1/1     Running   0          1m
+# confium-log-server-0                    1/1     Running   0          1m
+# confium-signerd-0                       1/1     Running   0          1m
+# confium-signerd-1                       1/1     Running   0          1m
+# confium-signerd-2                       1/1     Running   0          1m
+```
+
+## Step 2: Run the DKG ceremony
+
+The signerd pods start without shares. You need to run a DKG to generate the initial 2-of-3 threshold key.
+
+### Option A: Manual via kubectl exec
+
+```sh
+kubectl -n confium-system exec -it confium-signerd-0 -- bash
+
+# Inside the pod
+confium threshold dkg \
+    --threshold 2 \
+    --parties 3 \
+    --scheme cmp20 \
+    --out /tmp/shares.json
+
+# Distribute shares to the other 2 pods
+kubectl -n confium-system cp \
+    confium-signerd-0:/tmp/shares.json /tmp/shares.json
+# Parse and distribute per-party shares to signerd-1, signerd-2
+```
+
+### Option B: Operator-driven (recommended)
+
+Install the [K8s bundle](https://github.com/confium/confium/blob/main/deploy/k8s/bundle.yaml) which adds the Confium operator. Then:
+
+```sh
+kubectl apply -f - <<EOF
+apiVersion: confium.org/v1
+kind: ThresholdKey
+metadata:
+  name: production-signing-key
+  namespace: confium-system
+spec:
+  threshold: 2
+  party_count: 3
+  scheme: cmp20
+  share_storage:
+    backend: hsm
+    hsm_config_ref: signerd-hsm-config
+EOF
+```
+
+The operator runs the DKG across the signerd replicas and distributes shares automatically.
+
+## Step 3: Wire up HSM
+
+For production, shares MUST live under HSM protection (not on PVC). Confium supports PKCS#11, OpenPGP card, TPM 2.0, AWS KMS, GCP KMS, Azure Key Vault.
+
+```sh
+# Example: PKCS#11 HSM via SoftHSM2 (dev), or a real HSM in prod
+kubectl -n confium-system create secret generic signerd-hsm-config \
+    --from-literal=pkcs11_module=/usr/lib/softhsm/libsofthsm2.so \
+    --from-literal=pkcs11_token_label=confium-signerd \
+    --from-literal=pkcs11_pin=$(kubectl get secret hsm-pin -o jsonpath='{.data.pin}' | base64 -d)
+```
+
+Patch the StatefulSet to mount the HSM config + device:
+
+```sh
+kubectl -n confium-system patch statefulset confium-signerd --type=json \
+    -p='[{
+      "op": "add",
+      "path": "/spec/template/spec/volumes/-",
+      "value": {
+        "name": "hsm-config",
+        "secret": { "secretName": "signerd-hsm-config" }
+      }
+    }, {
+      "op": "add",
+      "path": "/spec/template/spec/containers/0/volumeMounts/-",
+      "value": {
+        "name": "hsm-config",
+        "mountPath": "/etc/confium/hsm"
+      }
+    }]'
+```
+
+For a real HSM, also mount the device node (e.g., `/dev/usb/hiddev0`).
+
+## Step 4: Monitoring
+
+Prometheus scrapes each pod's `/metrics` automatically (annotations are in the manifest). Import the [Confium Grafana dashboards](https://github.com/confium/confium/tree/main/deploy/grafana).
+
+Key alerts to configure:
+- `confium_signerd_active_sessions == 0` for >5 min → cluster not signing
+- `rate(confium_signerd_sessions_total{status="failed"}[5m]) > 0.05` → high failure rate
+- `count(confium_signerd_active_sessions == 0) >= 1` → quorum at risk
+
+See [prometheus-monitoring.mdx](./prometheus-monitoring.mdx) for the full alert runbook.
+
+## Step 5: Upgrading
+
+```sh
+# Bump image version
+kubectl -n confium-system set image statefulset/confium-signerd \
+    signerd=ghcr.io/confium/signerd:v0.4.0
+
+# Watch the rolling update
+kubectl -n confium-system rollout status statefulset/confium-signerd
+# statefulset rolling update successfully rolled out
+
+# Roll back if anything fails
+kubectl -n confium-system rollout undo statefulset/confium-signerd
+```
+
+The PDB (`minAvailable: 2`) ensures 2 signerd replicas stay available throughout the rollout — quorum preserved.
+
+## See also
+
+- [Production K8s manifest](https://github.com/confium/confium/blob/main/deploy/k8s/production/)
+- [Backup and restore shares](./backup-shares.mdx)
+- [Prometheus monitoring](./prometheus-monitoring.mdx)
+- [Reference deployments](https://github.com/confium/confium/blob/main/deploy/k8s/production/README.md)

--- a/docs/cookbook/ots-bitcoin-anchoring.mdx
+++ b/docs/cookbook/ots-bitcoin-anchoring.mdx
@@ -1,0 +1,105 @@
+---
+title: OTS anchoring to Bitcoin
+description: Anchor transparency log heads to Bitcoin for crypto-economic immutability
+audience: compliance, ca-operator
+---
+
+# Anchor transparency log heads to Bitcoin via OTS
+
+**Problem:** Your transparency log is append-only by social contract. How do you make it cryptographically immutable — so retroactive modification requires breaking Bitcoin?
+
+## Solution
+
+Use **OpenTimestamps (OTS)** to anchor each tree head to a Bitcoin transaction. Once anchored, modifying log history requires rewriting Bitcoin — economically infeasible.
+
+## How it works
+
+1. Log server computes the latest tree head every N minutes (default: 60).
+2. Log server submits the head's hash to an OTS calendar API.
+3. The calendar aggregates many hashes into a single Bitcoin transaction (paid by the calendar operator).
+4. Calendar returns a `.ots` proof file pointing to the Bitcoin block that commits to the hash.
+5. Verifier downloads the proof and checks it against the Bitcoin header chain.
+
+## Quickstart
+
+The log-server ships with OTS anchoring built-in. Enable via config:
+
+```toml
+# log-server.toml
+[log]
+identity = "confium-prod"
+data_path = "/var/lib/confium/log.db"
+
+[anchor]
+cadence_minutes = 60
+calendar_url = "https://a.pool.opentimestamps.org"
+```
+
+Run:
+
+```sh
+docker run -d \
+    -p 7878:7878 \
+    -v $(pwd)/log-server.toml:/etc/confium/log-server.toml \
+    -v log-data:/var/lib/confium \
+    ghcr.io/confium/log-server:latest
+```
+
+Every 60 minutes, the server will:
+- Compute the current tree head
+- Submit it to the OTS calendar
+- Store the resulting `.ots` proof alongside the log
+
+## Verification
+
+```sh
+# Get the head at a specific sequence
+confium transparency head --seq 1000 --db log.db --out head.json
+
+# Get the OTS proof for that head
+confium transparency ots --seq 1000 --db log.db --out head.ots
+
+# Verify against Bitcoin headers (requires Bitcoin Core or a header service)
+ots verify head.ots
+# Success! Bitcoin block 856123 commits to sha256:abc...
+```
+
+## Tradeoffs
+
+| Setting | Pros | Cons |
+|---------|------|------|
+| `cadence_minutes = 60` (default) | Low BTC fees | 1hr "vulnerable window" where a rewrite is undetectable |
+| `cadence_minutes = 10` | Small window | 6× more calendar API calls + BTC fees |
+| `cadence_minutes = 240` | Very low fees | 4hr vulnerable window |
+
+For most use cases 60 minutes is a reasonable balance. For high-value logs (e.g., root CA logs), 10 minutes is worth the cost.
+
+## Calendar services
+
+The default calendar (`https://a.pool.opentimestamps.org`) is a free public service. For production:
+
+- **Run your own calendar** — pays BTC fees yourself, fully under your control. See [opentimestamps-calendar-server](https://github.com/opentimestamps/calendar-server).
+- **Use a paid calendar** — better SLAs. List at <https://opentimestamps.org/>.
+
+## Bitcoin verification
+
+To verify an OTS proof, the client needs Bitcoin headers:
+
+- **Run a full node** (~500 GB) — most secure
+- **Run a pruned node** (~10 GB) — same security, less history
+- **Use a header service** (Blockstream, Blockchair, etc.) — convenient but trusted
+
+For high-value verification (e.g., a regulator auditing a CA), use a full node.
+
+## Limitations
+
+- **Anchoring doesn't prevent** a determined adversary from double-anchoring — but they can't rewrite history without rewriting Bitcoin.
+- **Calendar availability** — if your calendar goes down, you can't anchor until it's back. Mitigation: use multiple calendars.
+- **Proof size** — `.ots` files are typically 1-3 KB but can be larger if the calendar delayed inclusion.
+
+## See also
+
+- [OTS anchoring spec](https://www.confium.org/specs/44-ots-anchoring)
+- [Local transparency log](./local-transparency-log.mdx)
+- [Run a witness](./run-a-witness.mdx)
+- [OpenTimestamps](https://opentimestamps.org/)

--- a/docs/cookbook/pkcs11-hsm-replacement.mdx
+++ b/docs/cookbook/pkcs11-hsm-replacement.mdx
@@ -1,0 +1,122 @@
+---
+title: Drop-in PKCS#11 HSM replacement
+description: Use Confium as the threshold signing layer behind your existing PKCS#11 consumer
+audience: ca-operator, security-engineer
+---
+
+# Drop-in PKCS#11 HSM replacement
+
+**Problem:** Your application consumes an HSM via PKCS#11. You want the security of threshold signing without rewriting the application.
+
+## Solution
+
+`confium-pkcs11-server` is a drop-in PKCS#11 module that dispatches sign / verify / decrypt calls into a Confium threshold signing cluster. The application sees a normal PKCS#11 token; behind the scenes, every signing op requires T-of-N quorum.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ Application (e.g., OpenSSL, Java JCE, Thunderbird)                  │
+└────────────────────────────────┬───────────────────────────────────┘
+                                 │  PKCS#11 v3.0 API
+                                 ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ confium-pkcs11-server                                              │
+│ (drop-in module)                                                   │
+└────────────────────────────────┬───────────────────────────────────┘
+                                 │  Internal RPC
+                                 ▼
+┌────────────────────────────────────────────────────────────────────┐
+│ Confium coordinator + signerd cluster (2-of-3 CMP20)               │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+The application never sees Confium directly. It just talks PKCS#11.
+
+## Quickstart
+
+### 1. Stand up the signing cluster
+
+See [deploy-signerd-k8s.mdx](./deploy-signerd-k8s.mdx). You need a working `confium-coordinator` + N signerd replicas before installing the PKCS#11 server.
+
+### 2. Install the PKCS#11 module
+
+```sh
+docker pull ghcr.io/confium/pkcs11-server:latest
+
+# Run as a local daemon; the PKCS#11 module will RPC to it
+docker run -d \
+    --name confium-pkcs11 \
+    -p 2345:2345 \
+    -v $(pwd)/pkcs11.toml:/etc/confium/pkcs11.toml \
+    ghcr.io/confium/pkcs11-server:latest
+```
+
+### 3. Configure
+
+```toml
+# pkcs11.toml
+[server]
+listen = "127.0.0.1:2345"
+
+[token."Production Signing Key"]
+label = "Production Signing Key"
+threshold_key_id = "production-signing-key"
+coordinator_url = "http://confium-coordinator:7000"
+
+[token."Backup Signing Key"]
+label = "Backup Signing Key"
+threshold_key_id = "backup-signing-key"
+coordinator_url = "http://confium-coordinator:7000"
+```
+
+### 4. Install the client module
+
+The PKCS#11 module is a stub library your application loads. It forwards calls to the local `confium-pkcs11-server`.
+
+```sh
+# Linux
+sudo cp libconfium_pkcs11.so /usr/lib/pkcs11/
+sudo ldconfig
+
+# Configure OpenSSL to use it
+sudo tee /etc/openssl-pkcs11.conf <<EOF
+[pkcs11]
+module = /usr/lib/pkcs11/libconfium_pkcs11.so
+init = 1
+EOF
+```
+
+### 5. Use it
+
+Your application's PKCS#11 calls now dispatch into Confium:
+
+```sh
+# OpenSSL: use the Confium-backed token
+openssl req -engine pkcs11 -keyform engine \
+    -key 'pkcs11:token=Production Signing Key' \
+    -new -x509 -days 365 -out cert.pem
+
+# The signing op requires the threshold quorum (2-of-3 signerd
+# replicas must respond). OpenSSL sees it as a normal PKCS#11 sign.
+```
+
+## What this gives you
+
+- **No application rewrite** — any PKCS#11 consumer works unchanged.
+- **Threshold security** — no single HSM compromise can forge signatures.
+- **Audit trail** — every signing op goes through the coordinator's audit log.
+- **Policy enforcement** — attribute-based policies apply to every sign (e.g., "only sign from 9am-5pm ET").
+
+## Limitations
+
+- **Latency** — every PKCS#11 sign op now requires a threshold ceremony (~200ms-2s depending on scheme + network). Applications that sign thousands of ops per second will be slower.
+- **Key generation** — PKCS#11 `C_GenerateKeyPair` doesn't map cleanly to threshold DKG. Use `confium threshold dkg` separately, then register the resulting key as a token.
+- **Algorithm support** — Confium currently supports ECDSA-P256 and Ed25519 via PKCS#11. RSA support is on the roadmap.
+
+## See also
+
+- [PKCS#11 server spec](https://www.confium.org/specs/83-pkcs11-server)
+- [Threshold CA lifecycle](./threshold-ca-issue.mdx)
+- [Deploy signerd on Kubernetes](./deploy-signerd-k8s.mdx)
+- [PKI product docs](https://www.confium.org/pki/)

--- a/docs/cookbook/prometheus-monitoring.mdx
+++ b/docs/cookbook/prometheus-monitoring.mdx
@@ -1,0 +1,104 @@
+---
+title: Monitor Confium with Prometheus
+description: Scrape metrics from signerd, coordinator, log-server, and verify-server
+audience: devsecops
+---
+
+# Monitor Confium with Prometheus
+
+**Problem:** You've deployed Confium in production. How do you know it's healthy?
+
+## Solution
+
+Every Confium service exposes a `/metrics` endpoint in Prometheus format. Scrape them with your existing Prometheus instance; dashboards ship in [`deploy/grafana/`](https://github.com/confium/confium/tree/main/deploy/grafana).
+
+## Service-by-service metrics
+
+### `confium-signerd`
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `confium_signerd_sessions_total{scheme,status}` | counter | Sessions started/completed/failed |
+| `confium_signerd_active_sessions` | gauge | Currently in-flight sessions |
+| `confium_signerd_session_duration_seconds{scheme}` | histogram | Per-scheme signing latency |
+| `confium_signerd_share_load_errors_total` | counter | Failed to load share from HSM |
+| `confium_signerd_coordinator_reconnects_total` | counter | Times reconnected to coordinator |
+
+### `confium-coordinator`
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `confium_coordinator_sessions_total{scheme,status}` | counter | Sessions orchestrated |
+| `confium_coordinator_parties_registered` | gauge | Currently-registered signerd parties |
+| `confium_coordinator_round_duration_seconds{scheme}` | histogram | Per-round latency |
+| `confium_coordinator_policy_rejections_total{reason}` | counter | Sessions rejected by policy |
+
+### `confium-log-server`
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `confium_log_appends_total` | counter | Log entries appended |
+| `confium_log_tree_size` | gauge | Current tree size |
+| `confium_log_proof_requests_total` | counter | Inclusion proof requests |
+| `confium_log_anchor_total{status}` | counter | OTS anchoring attempts |
+| `confium_log_anchor_success_total` | counter | OTS anchoring successes |
+| `confium_log_gossip_failures_total{witness}` | counter | Witness gossip failures |
+
+### `confium-verify-server`
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `confium_verify_requests_total{algorithm,valid}` | counter | Verification requests |
+| `confium_verify_request_duration_seconds{algorithm}` | histogram | Verification latency |
+| `confium_verify_cache_hits_total` | counter | LRU cache hits |
+| `confium_verify_cache_misses_total` | counter | LRU cache misses |
+
+## Prometheus scrape config
+
+See [`deploy/docker-compose/prometheus.yml`](https://github.com/confium/confium/blob/main/deploy/docker-compose/prometheus.yml) for a complete example. Key parts:
+
+```yaml
+scrape_configs:
+  - job_name: 'signerd'
+    static_configs:
+      - targets:
+          - 'signerd-1:7000'
+          - 'signerd-2:7000'
+          - 'signerd-3:7000'
+    metrics_path: /metrics
+
+  - job_name: 'log-server'
+    static_configs:
+      - targets: ['log-server:7878']
+    metrics_path: /metrics
+```
+
+## Grafana dashboards
+
+Pre-built dashboards ship in [`deploy/grafana/`](https://github.com/confium/confium/blob/main/deploy/grafana/):
+
+- `confium-coordinator.json` — orchestration health
+- `confium-signerd.json` — signing sessions
+- `confium-log-server.json` — transparency log
+
+Import via:
+```sh
+kubectl -n monitoring create cm confium-dashboards \
+    --from-file=deploy/grafana/
+kubectl -n monitoring label cm confium-dashboards grafana_dashboard=1
+```
+
+## Alerting recommendations
+
+| Alert | Trigger | Runbook |
+|-------|---------|---------|
+| Signing session failure rate > 5% | `rate(confium_signerd_sessions_total{status="failed"}[5m]) / rate(confium_signerd_sessions_total[5m]) > 0.05` | Check HSM connectivity, share validity |
+| Signerd quorum at risk | `count(confium_signerd_active_sessions == 0) >= N - T + 1` | Quorum minimum violated; investigate down signers |
+| Log anchor failure | `rate(confium_log_anchor_success_total[1h]) / rate(confium_log_anchor_total[1h]) < 0.95` | OTS calendar outage; check network |
+| Witness gossip failure | `rate(confium_log_gossip_failures_total[10m]) > 0.1` | Witness offline; check witness health |
+
+## See also
+
+- [Production K8s deployment](https://github.com/confium/confium/blob/main/deploy/k8s/production/README.md)
+- [Deploy signerd on Kubernetes](./deploy-signerd-k8s.mdx)
+- [Backup shares](./backup-shares.mdx)

--- a/docs/cookbook/public-verify-endpoint.mdx
+++ b/docs/cookbook/public-verify-endpoint.mdx
@@ -1,0 +1,74 @@
+---
+title: Public HTTP verification endpoint
+description: Deploy a stateless HTTP verify service for non-WASM clients
+audience: web-developer, devsecops
+---
+
+# Public HTTP verification endpoint
+
+**Problem:** You want to let clients (curl, server-to-server, IoT) verify Confium signatures without running WASM.
+
+## Solution
+
+Deploy `confium-verify-server` as a stateless HTTP service.
+
+### Quickstart via Docker
+
+```sh
+docker pull ghcr.io/confium/verify-server:latest
+docker run -p 8080:8080 ghcr.io/confium/verify-server:latest
+
+# Verify a composite signature
+curl -X POST http://localhost:8080/v1/composite/verify \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "message": "aGVsbG8=",
+      "signature": "hex...",
+      "public_key": "hex..."
+    }'
+
+# {
+#   "valid": true,
+#   "checked_components": 1,
+#   "algorithm": "ed25519"
+# }
+```
+
+### Endpoints
+
+| Path | Method | Body | Returns |
+|------|--------|------|---------|
+| `/v1/composite/verify` | POST | `{message, signature, public_key}` | `{valid, checked_components, algorithm}` |
+| `/v1/transparency/inclusion/verify` | POST | `{proof, entry}` | `{valid, sequence}` |
+| `/v1/pki/cert-chain/verify` | POST | `{leaf, intermediates[], anchor}` | `{valid, path_length}` |
+| `/v1/batch/verify` | POST | `[{...}, {...}, ...]` | `[{...}, {...}, ...]` |
+| `/health/live` | GET | — | `200 OK` |
+| `/health/ready` | GET | — | `200 OK` |
+| `/metrics` | GET | — | Prometheus format |
+
+### Production deployment
+
+See [`deploy/k8s/production/00-confium.yaml`](https://github.com/confium/confium/blob/main/deploy/k8s/production/00-confium.yaml) for a complete Kubernetes deployment with:
+- Multi-replica Deployment
+- Service + Ingress
+- NetworkPolicy (allow ingress from anywhere)
+- HPA (scale on RPS)
+- TLS via cert-manager
+- Prometheus scrape annotations
+
+### Caching
+
+`verify-server` keeps an in-memory LRU cache of `(hash(message||signature), result)` keyed by SHA-256. Default size: 10,000 entries. Hit rate visible in `/metrics`.
+
+Cache is per-instance; if you scale horizontally, identical requests may hit different instances. For higher hit rates, put a shared cache (Redis) in front.
+
+### Rate limiting
+
+The service itself doesn't rate-limit; it's designed to sit behind Cloudflare / nginx / similar. A single instance handles ~10K req/sec on a 2-vCPU instance for Ed25519 verifications; slower for ECDSA-P256.
+
+## See also
+
+- [Verify in browser](./verify-in-browser.mdx) — for clients that CAN run WASM
+- [Batch verification at scale](./batch-verification.mdx) — for high-throughput use cases
+- [Verify product docs](https://www.confium.org/verify/)
+- [HTTP verify spec](https://www.confium.org/specs/62-http-verify)

--- a/docs/cookbook/refresh-shares.mdx
+++ b/docs/cookbook/refresh-shares.mdx
@@ -1,0 +1,74 @@
+---
+title: Refresh shares without re-keying
+description: Herzberg proactive security — rotate shares without changing the public key
+audience: security-engineer
+---
+
+# Refresh shares without re-keying
+
+**Problem:** You have a 2-of-3 threshold key in production. Shares have been around long enough that you want to rotate them — but re-doing the DKG would change the public key, breaking every existing signature.
+
+## Solution
+
+**Herzberg proactive security** (a.k.a. share refresh) lets parties collaboratively compute new shares of the *same* secret. The public key doesn't change. Old shares become useless once the refresh completes.
+
+```sh
+# Existing shares
+ls shares/
+# party1.json  party2.json  party3.json
+
+# Run refresh ceremony (all N parties must participate)
+confium threshold refresh \
+    --shares shares/party1.json shares/party2.json shares/party3.json \
+    --threshold 2 \
+    --parties 3 \
+    --scheme cmp20 \
+    --out-dir shares-refreshed/
+
+ls shares-refreshed/
+# party1.json  party2.json  party3.json
+```
+
+The output is a new set of share files. Verify the public key didn't change:
+
+```sh
+jq -r '.public_key' shares/party1.json
+jq -r '.public_key' shares-refreshed/party1.json
+# Both should be identical.
+```
+
+## Why this matters
+
+Without refresh:
+- A slow-compromising adversary who collects T shares over time eventually forges signatures.
+- Compromise of one share per year → key compromised after T years.
+
+With refresh on a quarterly cadence:
+- The adversary must compromise T shares within a single quarter (3 months).
+- Compromise across quarters yields nothing — old shares don't combine with new ones.
+
+## Ceremony
+
+In production, refresh is a multi-party ceremony:
+
+1. Each party generates a random polynomial `f_i(x)` of degree `T-1` where `f_i(0) = 0`.
+2. Each party privately sends `f_i(j)` to party `j`.
+3. Each party computes their new share: `x_j' = x_j + Σ_i f_i(j)`.
+4. The sum of new shares equals the sum of old shares (since `Σ f_i(0) = 0`), so the public key doesn't change.
+
+The CLI implements this in-process for testing. Production deployments use `confium-coordinator` to orchestrate.
+
+## Cadence recommendations
+
+| Use case | Refresh cadence |
+|----------|-----------------|
+| Internal CA root | Quarterly |
+| Production signing key | Monthly |
+| High-value custody | Weekly |
+| Development / test | Never (overhead > benefit) |
+
+## See also
+
+- [Threshold-sign-with-CMP20](./threshold-sign-with-cmp20.mdx)
+- [Large-quorum-ceremony](./large-quorum-ceremony.mdx)
+- [Backup-shares](./backup-shares.mdx)

--- a/docs/cookbook/run-a-witness.mdx
+++ b/docs/cookbook/run-a-witness.mdx
@@ -1,0 +1,108 @@
+---
+title: Run a third-party witness
+description: Operate a transparency log witness to detect forks
+audience: compliance, ca-operator
+---
+
+# Run a third-party witness
+
+**Problem:** You want to provide third-party oversight of a Confium transparency log so its operator can't silently rewrite history.
+
+## Why run a witness?
+
+A transparency log is append-only by social contract — the log operator *could* reissue past entries to cover mis-issuance. The defense against this is **witness gossip**:
+
+1. Multiple independent witnesses fetch the latest tree head from the log.
+2. Each witness signs the head and republishes the signature.
+3. If the log serves different heads to different witnesses, the fork becomes publicly visible.
+
+By running a witness you:
+- Provide a public good (helps the ecosystem detect bad operators)
+- Build trust in logs you depend on (your clients can verify against YOUR witness signature)
+- Earn reputation as a transparency-log auditor
+
+## Quickstart
+
+```sh
+docker pull ghcr.io/confium/log-monitor:latest
+
+# Configure which logs to witness
+cat > witnesses.toml <<EOF
+[witness]
+identity = "your-org-witness"
+listen = "0.0.0.0:7879"
+storage_path = "/var/lib/confium/witness.db"
+
+[witness.private_key]
+# Ed25519 private key (32 bytes, hex). Generate fresh for your witness.
+hex = "abcd...generate_your_own..."
+
+[[logs]]
+id = "confium-default"
+url = "https://log.confium.org"
+poll_interval_seconds = 60
+
+[[logs]]
+id = "your-org-internal"
+url = "https://log.internal.yourorg.com"
+poll_interval_seconds = 30
+EOF
+
+docker run -d \
+    -p 7879:7879 \
+    -v $(pwd)/witnesses.toml:/etc/confium/witnesses.toml \
+    -v witness-data:/var/lib/confium \
+    ghcr.io/confium/log-monitor:latest \
+    --config /etc/confium/witnesses.toml
+```
+
+The witness will poll each configured log, sign observed heads, and publish signatures at `http://your-witness:7879/heads/{log_id}`.
+
+## Publishing witness signatures
+
+Other witnesses and monitors fetch your signed heads via:
+
+```sh
+curl http://your-witness:7879/heads/confium-default | jq
+# {
+#   "log_id": "confium-default",
+#   "tree_size": 4823,
+#   "root_hash": "sha256:abc...",
+#   "timestamp": 1723046400,
+#   "witness_signature": "..."
+# }
+```
+
+## Fork detection
+
+A monitor fetches the same head from the log directly and from N witnesses. If two sources disagree on `(tree_size, root_hash)`, that's a fork — the log operator served different heads to different observers.
+
+```sh
+# Compare log head vs witness head
+LOG_HEAD=$(curl -s https://log.confium.org/head | jq -r '.root_hash')
+WITNESS_HEAD=$(curl -s http://your-witness:7879/heads/confium-default | jq -r '.root_hash')
+
+if [ "$LOG_HEAD" != "$WITNESS_HEAD" ]; then
+    echo "⚠️ Fork detected! Log says $LOG_HEAD, witness says $WITNESS_HEAD"
+fi
+```
+
+## Trust model
+
+- **Witness identity:** Each witness has a long-lived Ed25519 keypair. Clients pin witness public keys out-of-band (DNS TXT record, documentation, transparency log of witness keys).
+- **Witness honesty:** A witness that signs a head it didn't actually observe is useless. Reputable witnesses publish their polling cadence + storage.
+- **Witness cartel:** If all witnesses collude with the log operator, fork detection fails. Use multiple INDEPENDENT witnesses (different orgs, different jurisdictions).
+
+## Operational concerns
+
+- **Storage:** Witness DB grows with log size; plan for it.
+- **Uptime:** A witness that's down can't sign heads. Deploy with high availability.
+- **Key rotation:** Rotate witness signing key annually. Publish the new key in the same place you published the old one.
+- **Auditing:** Publish your witness's storage state periodically so others can verify you're being honest.
+
+## See also
+
+- [Witness gossip spec](https://www.confium.org/specs/43-witness-gossip)
+- [Local transparency log](./local-transparency-log.mdx)
+- [OTS Bitcoin anchoring](./ots-bitcoin-anchoring.mdx)
+- [Transparency product docs](https://www.confium.org/transparency/)


### PR DESCRIPTION
## Summary

Adds 9 task-focused recipes referenced from the cookbook index. Cookbook now has 15 recipes total (was 6).

### New recipes

- `refresh-shares.mdx` — Herzberg proactive security without re-keying
- `public-verify-endpoint.mdx` — `confium-verify-server` HTTP deployment with full API reference
- `prometheus-monitoring.mdx` — Per-service metric catalog + alert runbook
- `backup-shares.mdx` — 3 backup strategies (KMS-encrypted / volume snapshot / HSM-stored) + restore procedures
- `deploy-signerd-k8s.mdx` — full K8s deployment with operator + HSM wiring
- `run-a-witness.mdx` — third-party witness for transparency log fork detection
- `ots-bitcoin-anchoring.mdx` — crypto-economic immutability via OTS to Bitcoin
- `pkcs11-hsm-replacement.mdx` — drop-in HSM replacement via `confium-pkcs11-server`
- `composite-sign-pq-migration.mdx` — PQ migration with hybrid signatures

Each recipe:
- States the problem in one sentence
- Shows minimum reproducible setup
- Shows copy-paste-runnable solution
- Notes edge cases / pitfalls
- Links to deeper docs (specs, API reference, related recipes)

## Test plan

- [ ] All MDX files render
- [ ] Cross-links work
- [ ] Code samples are syntactically valid
