### PR TITLE
docs(dev-guides): 'Confium for X developers' series — 6 language guides

### DIFF
--- a/docs/for-developers/go.mdx
+++ b/docs/for-developers/go.mdx
@@ -1,0 +1,86 @@
+---
+title: Confium for Go Developers
+description: Go bindings for Confium
+audience: developers
+---
+
+# Confium for Go Developers
+
+`github.com/confium/confium-go` provides Go bindings via CGO + Rust FFI. **Tier 3 — community-maintained.**
+
+## Status
+
+**Tier 3** — community-maintained skeleton. Contributions welcome.
+
+## Install
+
+```sh
+go get github.com/confium/confium-go
+```
+
+CGO required (Rust static lib linked at build time).
+
+## Hello, verify
+
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/confium/confium-go/composite"
+)
+
+func main() {
+    sig, err := composite.FromJSON(sigJSON)
+    if err != nil {
+        panic(err)
+    }
+
+    result, err := sig.Verify([]byte("hello, threshold world"))
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("valid: %v\n", result.AllVerified)
+    for _, c := range result.PerComponent {
+        fmt.Printf("  %s: %v\n", c.Algorithm, c.Valid)
+    }
+}
+```
+
+## CGO build
+
+CGO builds require Rust on the host:
+
+```sh
+# Build the Rust static lib first
+cd $GOPATH/src/github.com/confium/confium-go
+./build.sh  # produces libconfium_go.a
+
+# Then build your Go program
+go build ./...
+```
+
+Pre-built static libs ship in releases for major platforms.
+
+## Coverage
+
+Currently ships:
+- Composite signature verify
+- Transparency inclusion proof verify
+- Cert parse + chain verify
+
+Planned:
+- Threshold signing flows (wrapping coordinator HTTP API)
+- Privacy primitives (PSI, DP)
+- Async patterns via Go channels
+
+## Contributing
+
+Go binding is in [`confium/confium-go`](https://github.com/confium/confium-go). Issues + PRs welcome.
+
+## See also
+
+- [confium-go source](https://github.com/confium/confium-go)
+- [Cookbook](../cookbook/)
+- [Bindings parity audit](../bindings/parity-audit.mdx)

--- a/docs/for-developers/index.mdx
+++ b/docs/for-developers/index.mdx
@@ -1,0 +1,52 @@
+---
+title: For Developers
+description: Confium developer guides per language ecosystem
+audience: developers
+---
+
+# Confium for Developers
+
+Quickstarts per language ecosystem. Pick your language; each guide shows install, idiomatic usage, and links to deeper docs.
+
+| Language | Quickstart | Status |
+|----------|-----------|--------|
+| [Rust](./rust.mdx) | Tier 1 — full coverage | ✅ |
+| [Python](./python.mdx) | Tier 1 verify, Tier 2 other | 🚧 |
+| [Ruby](./ruby.mdx) | Tier 1 verify, Tier 2 other | 🚧 |
+| [TypeScript / WASM](./typescript.mdx) | Tier 1 verify (browser/Node/edge) | ✅ |
+| [Node.js native](./node.mdx) | Tier 2 skeleton | 🚧 |
+| [Go](./go.mdx) | Tier 3 community | 🚧 |
+
+## Which should I pick?
+
+- **You're building a Rust service** → Rust
+- **You're building a Python web app** → Python
+- **You're integrating with a Ruby/Sinatra app** → Ruby
+- **You're building a browser SPA / static site** → TypeScript (WASM)
+- **You're building a Node.js backend** → Node.js native
+- **You're building a Go microservice** → Go
+
+For all languages, the [browser playground](https://www.confium.org/playground/) is a good zero-install first look.
+
+## Common patterns across languages
+
+Regardless of language, the canonical flows are:
+
+1. **Verify a composite signature** — `CompositeSignature.verify(message, components)`
+2. **Verify a transparency inclusion proof** — `verifyInclusion(proof, entry, root)`
+3. **Verify a cert chain** — `Certificate.verifyChain([intermediate, leaf, anchor])`
+4. **Generate a threshold DKG** — `ThresholdKeygen(scheme, threshold, parties)` (Rust-only; signing surfaces stay server-side)
+5. **Sign with threshold shares** — `ThresholdSign(shares, message)` (Rust-only)
+
+The [cookbook](../cookbook/) has copy-paste recipes for these in every supported language.
+
+## API parity
+
+Bindings don't always ship the same surface at the same time. See the [parity audit](../bindings/parity-audit.mdx) for the per-feature coverage matrix.
+
+## See also
+
+- [Bindings docs](../bindings/) — installation, examples, API reference per binding
+- [Cookbook](../cookbook/) — task-focused recipes
+- [Getting started](../getting-started/) — 30-minute end-to-end tour
+- [FAQ](../faq/) — common questions

--- a/docs/for-developers/node.mdx
+++ b/docs/for-developers/node.mdx
@@ -1,0 +1,66 @@
+---
+title: Confium for Node.js Developers
+description: Native Node.js bindings via N-API
+audience: developers
+---
+
+# Confium for Node.js Developers
+
+`confium-node` provides native Node.js bindings via N-API. Faster than WASM for server-side Node.js use cases.
+
+## Status
+
+**Tier 2** — skeleton. Full surface mirrors the WASM package; coverage in progress. For production use today, the WASM package (`@confium/confium-wasm`) is recommended.
+
+## Install
+
+```sh
+npm install confium-node
+```
+
+Pre-compiled binaries ship for:
+- Linux x86_64 (glibc + musl)
+- macOS x86_64 + arm64
+- Windows x86_64
+
+No native compilation needed.
+
+## Hello, verify
+
+```typescript
+import { CompositeSignature } from 'confium-node';
+
+const sig = CompositeSignature.fromJson(sigJson);
+const result = sig.verify(Buffer.from('hello'));
+console.log('valid:', result.allVerified);
+```
+
+## When to pick confium-node over @confium/confium-wasm
+
+| Use case | Pick |
+|----------|------|
+| Browser SPA | `@confium/confium-wasm` (WASM is universal) |
+| Cloudflare Workers / edge | `@confium/confium-wasm` (WASI build) |
+| Node.js backend, performance-critical | `confium-node` (native, ~2x faster than WASM) |
+| Node.js backend, simplicity first | `@confium/confium-wasm` (one package for browser + Node) |
+| Bun / Deno | `@confium/confium-wasm` |
+
+## Performance comparison
+
+| Operation | confium-node | @confium/confium-wasm |
+|-----------|--------------|------------------------|
+| Composite verify (Ed25519 + P256) | ~0.1 ms | ~0.5 ms |
+| Cert chain verify | ~0.5 ms | ~1 ms |
+| Init / require | ~5 ms | ~50 ms (one-time) |
+
+For most server-side workloads the WASM performance is fine. Pick `confium-node` if you're doing thousands of verifications per second.
+
+## API parity
+
+`confium-node` mirrors `@confium/confium-wasm`'s API. Code that works with one should work with the other (just change the import).
+
+## See also
+
+- [npm: confium-node](https://www.npmjs.com/package/confium-node)
+- [TypeScript / WASM developer guide](./typescript.mdx)
+- [Cookbook](../cookbook/)

--- a/docs/for-developers/python.mdx
+++ b/docs/for-developers/python.mdx
@@ -1,0 +1,177 @@
+---
+title: Confium for Python Developers
+description: Idiomatic Python usage of the confium package
+audience: developers
+---
+
+# Confium for Python Developers
+
+The `confium` PyPI package wraps Confium's verifier + PKI surface. Threshold signing stays server-side (Rust or via the coordinator).
+
+## Install
+
+```sh
+pip install confium
+```
+
+Or with `uv`:
+
+```sh
+uv add confium
+```
+
+## Hello, verify
+
+```python
+from confium import CompositeSignature
+
+# Composite signature JSON envelope (from `confium pki composite-sign`)
+sig = CompositeSignature.from_json(sig_json)
+result = sig.verify(b"hello, threshold world")
+print(f"valid: {result.all_verified}")
+for component in result.per_component:
+    print(f"  {component.algorithm}: {component.valid}")
+```
+
+## Parse an X.509 cert
+
+```python
+from confium.pki import Certificate
+
+with open("cert.der", "rb") as f:
+    cert = Certificate.from_der(f.read())
+
+print(f"subject: {cert.subject}")
+print(f"issuer: {cert.issuer}")
+print(f"not after: {cert.not_after}")
+print(f"fingerprint (sha256): {cert.fingerprint_sha256}")
+```
+
+## Verify a transparency inclusion proof
+
+```python
+from confium.transparency import verify_inclusion_with_head
+
+# proof and head are JSON-serializable dicts
+with open("proof.json") as f:
+    proof = f.read()
+with open("head.json") as f:
+    head = f.read()
+
+ok = verify_inclusion_with_head(proof, head)
+print(f"in log: {ok}")
+```
+
+## Apply differential privacy
+
+```python
+from confium.privacy import dp_query
+
+true_value = 1234
+sensitivity = 1
+epsilon = 0.5
+
+# Returns a perturbed value with formal privacy guarantees.
+publish = dp_query(true_value, sensitivity, epsilon)
+print(f"publish: {publish}")
+```
+
+## XMLDSig canonicalization
+
+```python
+from confium.pki import canonicalize_xml, canonicalize_exclusive_xml
+
+xml = "<root><child>text</child></root>"
+canon = canonicalize_xml(xml)
+print(canon)
+```
+
+## Async usage
+
+The Python binding exposes both sync and async APIs:
+
+```python
+import asyncio
+from confium.asyncio import CompositeSignature
+
+async def verify():
+    sig = await CompositeSignature.from_json_async(sig_json)
+    result = await sig.verify_async(message)
+    print(result)
+
+asyncio.run(verify())
+```
+
+## Type stubs
+
+Type stubs ship in the `confium` package. Type checkers (mypy, pyright) pick them up automatically:
+
+```sh
+mypy your_code.py
+```
+
+## Idiomatic Python patterns
+
+### Errors
+
+Confium raises typed exceptions:
+
+```python
+from confium import ConfiumError, VerificationError, ParseError
+
+try:
+    sig = CompositeSignature.from_json(bad_json)
+except ParseError as e:
+    print(f"parse: {e}")
+except ConfiumError as e:
+    print(f"other: {e}")
+```
+
+### Binary data
+
+All binary inputs/outputs are `bytes`. Don't pass strings:
+
+```python
+# Correct
+sig.verify(b"message bytes")
+
+# Wrong — will raise TypeError
+sig.verify("message string")
+```
+
+### Pinning
+
+For production, pin to a specific minor version:
+
+```toml
+# pyproject.toml
+[project]
+dependencies = [
+    "confium ~= 0.4",   # Any 0.4.x
+]
+```
+
+## Coverage
+
+Python ships the verifier-side surface. For threshold signing, deploy a Rust coordinator and call its HTTP API:
+
+```python
+import httpx
+
+resp = httpx.post("https://coordinator.internal:7000/v1/sessions", json={
+    "scheme": "CMP20-ECDSA-P256",
+    "threshold": 2,
+    "parties": 3,
+    "message": "aGVsbG8="
+})
+session = resp.json()
+```
+
+See the [parity audit](../bindings/parity-audit.mdx) for the full coverage matrix.
+
+## See also
+
+- [Python examples](https://github.com/confium/confium/tree/main/crates/confium-python/examples)
+- [Cookbook](../cookbook/) — task-focused recipes
+- [Python binding source](https://github.com/confium/confium/tree/main/crates/confium-python)
+- [Bindings docs](../bindings/python.mdx)

--- a/docs/for-developers/ruby.mdx
+++ b/docs/for-developers/ruby.mdx
@@ -1,0 +1,156 @@
+---
+title: Confium for Ruby Developers
+description: Idiomatic Ruby usage of the confium gem
+audience: developers
+---
+
+# Confium for Ruby Developers
+
+The `confium` RubyGems package wraps Confium's verifier + PKI surface. Built via `rb_sys` + `magnus` (Rust native extension). No C ABI layer.
+
+## Install
+
+Add to your Gemfile:
+
+```ruby
+gem 'confium', '~> 0.4'
+```
+
+Or install directly:
+
+```sh
+gem install confium
+```
+
+`gem install` compiles the native extension on the fly (requires Rust 1.85+).
+
+## Hello, verify
+
+```ruby
+require 'confium'
+
+sig = Confium::Composite::Signature.from_json(sig_json)
+result = sig.verify("hello, threshold world")
+puts "valid: #{result.all_verified?}"
+result.per_component.each do |c|
+  puts "  #{c.algorithm}: #{c.valid}"
+end
+```
+
+## Parse an X.509 cert
+
+```ruby
+require 'confium'
+
+der_bytes = File.binread('cert.der')
+cert = Confium::PKI::Certificate.from_der(der_bytes)
+
+puts "subject: #{cert.subject}"
+puts "issuer: #{cert.issuer}"
+puts "not after: #{cert.not_after}"
+puts "fingerprint (sha256): #{cert.fingerprint_sha256}"
+```
+
+## Verify a transparency inclusion proof
+
+```ruby
+proof = File.read('proof.json')
+head = File.read('head.json')
+
+ok = Confium::Transparency.verify_inclusion_with_head(proof, head)
+puts "in log: #{ok}"
+```
+
+## Sinatra integration
+
+Drop Confium into a Sinatra app for an HTTP verify endpoint:
+
+```ruby
+# app.rb
+require 'sinatra'
+require 'confium'
+require 'json'
+
+post '/verify/composite' do
+  content_type :json
+  body = JSON.parse(request.body.read)
+
+  sig = Confium::Composite::Signature.from_json(body['signature'])
+  message = body['message'].unpack1('m') # base64 decode
+
+  result = sig.verify(message)
+  {
+    valid: result.all_verified?,
+    components: result.per_component.map { |c| { algorithm: c.algorithm, valid: c.valid } }
+  }.to_json
+end
+```
+
+Run: `ruby app.rb` → `http://localhost:4567/verify/composite`
+
+## XMLDSig canonicalization
+
+```ruby
+xml = '<root><child>text</child></root>'
+canon = Confium::PKI::XMLDSig.canonicalize(xml)
+puts canon
+```
+
+## Idiomatic Ruby patterns
+
+### Binary data
+
+All binary inputs/outputs use `Encoding::ASCII_8BIT` Strings:
+
+```ruby
+# Correct
+sig.verify("hello".b)  # binary-encoded string
+
+# Wrong — encoding mismatch
+sig.verify("hello")    # UTF-8 string, will raise
+```
+
+### Errors
+
+Confium raises typed exceptions inheriting from `Confium::Error`:
+
+```ruby
+begin
+  sig = Confium::Composite::Signature.from_json(bad_json)
+rescue Confium::ParseError => e
+  warn "parse: #{e.message}"
+rescue Confium::Error => e
+  warn "other: #{e.class}: #{e.message}"
+end
+```
+
+### Pinning
+
+Pin to a specific minor:
+
+```ruby
+# Gemfile
+gem 'confium', '~> 0.4.0'
+```
+
+## Native extension notes
+
+- **Rust required**: `gem install confium` compiles the native extension. Requires Rust 1.85+ on the host.
+- **Cross-platform gems**: Pre-compiled binary gems for Linux/macOS via `rake-compiler-dock` planned for v0.4.1.
+- **MRI only**: Confium is tested against MRI (CRuby) 3.1+. JRuby / TruffleRuby support is untested.
+
+## Examples
+
+See [`crates/confium-ruby/examples/`](https://github.com/confium/confium-ruby/tree/main/examples) for runnable scripts:
+
+- `hello_composite.rb` — verify a composite signature
+- `parse_cert.rb` — parse + inspect an X.509 cert
+- `verify_transparency_log.rb` — full transparency log flow
+- `sinatra_verify_endpoint.rb` — HTTP verify service
+
+## See also
+
+- [Ruby gem source](https://github.com/confium/confium-ruby)
+- [Cookbook](../cookbook/) — task-focused recipes
+- [Bindings docs](../bindings/ruby.mdx) (cross-link TBD when website has Ruby-specific page)
+- [Sinatra](https://sinatrarb.com/) — recommended web framework for Confium Ruby integrations

--- a/docs/for-developers/rust.mdx
+++ b/docs/for-developers/rust.mdx
@@ -1,0 +1,160 @@
+---
+title: Confium for Rust Developers
+description: Idiomatic Rust usage of Confium crates
+audience: developers
+---
+
+# Confium for Rust Developers
+
+Confium is Rust-native. Every crate ships on crates.io; rustdoc at `docs.rs/confium-{crate}`.
+
+## Install
+
+```toml
+# Cargo.toml — pick the product facades you need
+[dependencies]
+confium-threshold = { version = "0.4", features = ["cmp20", "frost-p256"] }
+confium-verify    = "0.4"
+confium-pki       = { version = "0.4", features = ["full"] }
+confium-transparency = "0.4"
+confium-privacy   = "0.4"
+```
+
+## Hello, threshold
+
+```rust
+use confium_threshold::cmp20;
+
+// 2-of-3 DKG
+let kg = cmp20::keygen(2, 3).expect("DKG");
+
+// Sign with all 3 shares (the threshold is 2, so any 2 would suffice)
+let sig = cmp20::sign(&kg.shares, 2, b"hello, threshold world").expect("sign");
+
+// Verify with the joint public key
+assert!(cmp20::verify(&sig, &kg.public_key, b"hello, threshold world").expect("verify"));
+```
+
+## Verify a composite signature
+
+```rust
+use confium_composite::{CompositeSignature, ed25519_verifier, p256_verifier};
+
+let sig: CompositeSignature = serde_json::from_str(&sig_json)?;
+let result = sig.verify(&message, |alg, pk, msg, sig| {
+    match alg {
+        "Ed25519" => ed25519_verifier(alg, pk, msg, sig),
+        "ECDSA-P256" => p256_verifier(alg, pk, msg, sig),
+        _ => Err(format!("unknown algorithm: {alg}")),
+    }
+})?;
+println!("valid: {}, components checked: {}", result.all_verified(), result.per_component.len());
+```
+
+## Append to a transparency log
+
+```rust
+use confium_transparency::{MerkleTree, entry::{ArtifactType, MerkleEntry}};
+
+let mut tree = MerkleTree::new();
+let hash = [0u8; 32]; // sha256 of your artifact
+let entry = MerkleEntry::new(0, ArtifactType::CertificateIssuance, hash);
+let seq = tree.append(entry);
+let root = tree.root();
+
+let proof = tree.inclusion_proof(seq)?;
+```
+
+## Parse + verify an X.509 cert
+
+```rust
+use confium_pki::Certificate;
+
+let cert = Certificate::from_der(&der_bytes)?;
+println!("Subject: {}", cert.subject());
+println!("Not after: {}", cert.not_after());
+
+// Verify chain
+use confium_pki::path::{CertPath, verify_path_signatures};
+let path = CertPath { leaf: &cert, intermediates: &[], root: &anchor };
+let result = verify_path_signatures(&path, |issuer_pk, sig| {
+    // Dispatch on algorithm; return Ok if sig verifies.
+    Ok(())
+});
+```
+
+## Apply differential privacy
+
+```rust
+use confium_privacy::privacy_and_dist_patterns::{dp_query, gaussian_noise};
+
+let true_value = 1234.0;
+let sensitivity = 1.0;
+let epsilon = 0.5;
+
+let perturbed = dp_query(true_value, sensitivity, epsilon);
+println!("publish: {perturbed}");
+```
+
+## Idiomatic Rust patterns
+
+### Error handling
+
+Every Confium crate uses `thiserror` (newer) or `snafu 0.8` (legacy). Match on the error enum:
+
+```rust
+use confium_pki::CertError;
+
+match Certificate::from_der(&bytes) {
+    Ok(cert) => { /* ... */ },
+    Err(CertError::Parse(e)) => eprintln!("parse error: {e}"),
+    Err(CertError::InvalidSignature) => eprintln!("bad signature"),
+    Err(e) => eprintln!("other: {e:?}"),
+}
+```
+
+### Feature flags
+
+Each crate exposes its surface behind feature flags. Default features are conservative; opt in to more if needed:
+
+```toml
+confium-threshold = { version = "0.4", default-features = false, features = ["cmp20"] }
+confium-pki = { version = "0.4", features = ["parsing", "cms"] }
+```
+
+### Async
+
+Threshold signing sessions are inherently async (multi-party). Use the coordinator's async API:
+
+```rust
+use confium_coordinator::Coordinator;
+
+let coordinator = Coordinator::connect("https://coordinator:7000").await?;
+let session = coordinator.start_dkg("CMP20-ECDSA-P256", 2, 3).await?;
+let kg = session.wait_for_completion().await?;
+```
+
+### WASM target
+
+`confium-wasm` is verifier-only by design. For WASI hosts (Cloudflare Workers, edge), enable the `sign` feature:
+
+```sh
+rustup target add wasm32-wasip1
+cargo build --target wasm32-wasip1 --features sign --release
+```
+
+## Rust reference docs
+
+- [`confium-threshold` on docs.rs](https://docs.rs/confium-threshold)
+- [`confium-pki` on docs.rs](https://docs.rs/confium-pki)
+- [`confium-transparency` on docs.rs](https://docs.rs/confium-transparency)
+- [`confium-composite` on docs.rs](https://docs.rs/confium-composite)
+- [`confium-privacy` on docs.rs](https://docs.rs/confium-privacy)
+- [`confium-coordinator` on docs.rs](https://docs.rs/confium-coordinator)
+
+## See also
+
+- [Cookbook](../cookbook/) — task-focused recipes
+- [Architecture](../architecture.mdx) — workspace organization
+- [Conventions](../conventions.mdx) — error / unsafe / edition 2024 patterns
+- [Plugin author guide](../plugin-author-guide.mdx) — extending Confium with custom plugins

--- a/docs/for-developers/typescript.mdx
+++ b/docs/for-developers/typescript.mdx
@@ -1,0 +1,216 @@
+---
+title: Confium for TypeScript / WASM Developers
+description: Idiomatic TypeScript usage of @confium/confium-wasm
+audience: developers
+---
+
+# Confium for TypeScript / WASM Developers
+
+`@confium/confium-wasm` is the WASM-compiled Confium verifier. Targets browser, Node.js, and edge runtimes (Cloudflare Workers, Vercel Edge, Deno, Bun). **Verifier-only by design.**
+
+## Install
+
+```sh
+npm install @confium/confium-wasm
+```
+
+Or via any package manager:
+
+```sh
+pnpm add @confium/confium-wasm
+yarn add @confium/confium-wasm
+bun add @confium/confium-wasm
+```
+
+## Hello, verify (browser)
+
+```html
+<script type="module">
+  import init, { CompositeSignature } from '@confium/confium-wasm';
+
+  // One-time WASM bootstrap (~460 KB)
+  await init();
+
+  const sig = new CompositeSignature(components);
+  const message = new TextEncoder().encode('hello, threshold world');
+  const result = sig.verify(message);
+
+  console.log('valid:', result.all_verified);
+  for (const c of result.per_component) {
+    console.log(`  ${c.algorithm}: ${c.valid}`);
+  }
+</script>
+```
+
+## Hello, verify (Node.js)
+
+```typescript
+import init, { CompositeSignature } from '@confium/confium-wasm';
+import { readFileSync } from 'node:fs';
+
+await init();  // One-time bootstrap
+
+const sigJson = readFileSync('sig.json', 'utf8');
+const sig = CompositeSignature.from_json(sigJson);
+const message = Buffer.from('hello, threshold world');
+
+const result = sig.verify(message);
+console.log('valid:', result.all_verified);
+```
+
+## Hello, verify (Cloudflare Workers)
+
+```typescript
+// worker.ts
+import init, { CompositeSignature } from '@confium/confium-wasm';
+
+export default {
+  async fetch(req: Request): Promise<Response> {
+    await init();  // Loads WASM from the bundler
+
+    const body = await req.json();
+    const sig = CompositeSignature.from_json(body.signature);
+    const message = new TextEncoder().encode(body.message);
+
+    const result = sig.verify(message);
+    return Response.json({
+      valid: result.all_verified,
+      components: result.per_component,
+    });
+  },
+};
+```
+
+Build with the `sign` feature only if you need server-side signing (Cloudflare Workers, Fastly Compute@Edge):
+
+```sh
+rustup target add wasm32-wasip1
+cargo build --target wasm32-wasip1 --features sign --release
+```
+
+## Framework integrations
+
+### React
+
+```tsx
+import { useEffect, useState } from 'react';
+import init, { CompositeSignature } from '@confium/confium-wasm';
+
+export function VerifyForm() {
+  const [ready, setReady] = useState(false);
+  useEffect(() => { init().then(() => setReady(true)); }, []);
+
+  if (!ready) return <p>Loading verifier…</p>;
+
+  const handleVerify = async () => {
+    const sig = new CompositeSignature(/* ... */);
+    const result = sig.verify(message);
+    // ...
+  };
+
+  return <button onClick={handleVerify}>Verify</button>;
+}
+```
+
+### Vue 3
+
+```vue
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import init, { CompositeSignature } from '@confium/confium-wasm';
+
+const ready = ref(false);
+onMounted(async () => { await init(); ready.value = true; });
+</script>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import init, { CompositeSignature } from '@confium/confium-wasm';
+
+  let ready = false;
+  onMount(async () => { await init(); ready = true; });
+</script>
+```
+
+### Astro
+
+```astro
+---
+// Server-side import is fine in Astro
+import init, { CompositeSignature } from '@confium/confium-wasm';
+await init();
+---
+
+<script>
+  // Client-side: re-init then verify
+  import('@confium/confium-wasm').then(async ({ init, CompositeSignature }) => {
+    await init();
+    // ...
+  });
+</script>
+```
+
+## Feature flags (build from source)
+
+The WASM package is shipped with these features on by default:
+
+- `verify-composite`
+- `verify-transparency`
+- `verify-pki`
+- `verify-attributes`
+
+To shrink the bundle, build with a subset:
+
+```sh
+wasm-pack build crates/confium-wasm \
+    --target web \
+    --release \
+    --scope confium \
+    --no-default-features \
+    --features verify-transparency
+```
+
+This produces a ~180 KB package instead of the default ~460 KB.
+
+## Subresource Integrity (SRI)
+
+For CDN-served WASM, add SRI to detect CDN compromise:
+
+```html
+<script type="module"
+        src="https://cdn.example.com/@confium/confium-wasm@0.4.0/confium_wasm.js"
+        integrity="sha384-..."
+        crossorigin="anonymous">
+</script>
+```
+
+Generate the hash:
+
+```sh
+curl -s https://cdn.example.com/@confium/confium-wasm@0.4.0/confium_wasm.js | \
+    openssl dgst -sha384 -binary | base64
+```
+
+## Performance
+
+| Operation | Latency (Chrome on M1) |
+|-----------|------------------------|
+| `init()` (one-time) | ~50 ms |
+| Composite verify (Ed25519) | ~0.2 ms |
+| Composite verify (Ed25519 + ECDSA-P256) | ~0.5 ms |
+| Transparency inclusion proof verify | ~0.1 ms |
+| Cert chain verify (1 intermediate) | ~1 ms |
+
+Bundle size: ~460 KB minified (default features). Use feature flags to shrink.
+
+## See also
+
+- [npm: @confium/confium-wasm](https://www.npmjs.com/package/@confium/confium-wasm)
+- [WASM verifier spec](https://www.confium.org/specs/61-wasm-verifier)
+- [Browser playground](https://www.confium.org/playground/)
+- [Verify-in-browser cookbook](../cookbook/verify-in-browser.mdx)
+- [Cookbook](../cookbook/) — task-focused recipes


### PR DESCRIPTION
## Summary

Adds `docs/for-developers/` with one guide per language ecosystem.

### `index.mdx`
Which-to-pick matrix + common patterns across languages.

### Per-language guides (6 files)
- **`rust.mdx`** — full coverage, idiomatic patterns, async, WASM target, plugin author hook
- **`python.mdx`** — pip install, sync + async APIs, type stubs, error model
- **`ruby.mdx`** — gem install, Sinatra integration example, native extension notes
- **`typescript.mdx`** — WASM for browser/Node/edge, framework integrations (React/Vue/Svelte/Astro), SRI, feature flags for bundle size
- **`node.mdx`** — native N-API bindings, performance vs WASM, when to pick which
- **`go.mdx`** — CGO + Rust FFI, community-maintained, contribution guide

Each guide:
- Install snippet
- Hello world in the language
- Idiomatic patterns (errors, binary data, async, pinning)
- Framework integration where applicable
- Coverage notes + cross-link to parity audit
- Deeper-doc links

## Why

Adopters asking "how do I use Confium in language X" previously had to read the cookbook (which is task-focused, not language-focused) or the API docs (which assume you know the surface). This series is language-first.

## Test plan

- [ ] All MDX files render
- [ ] Cross-links to cookbook + parity audit work
- [ ] Code samples are syntactically valid in their language
