### PR TITLE
fix(ci): release pipeline — aarch64 musl cross-toolchain + trivy 0.24.0

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -90,7 +90,7 @@ jobs:
       # Trivy vuln scan. CRITICAL findings fail the workflow; HIGH gets
       # reported but does not block the push (which already happened).
       - name: Trivy vuln scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ steps.tags.outputs.image }}:latest
           format: sarif

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -36,10 +36,19 @@ jobs:
 
       # musl-tools provides x86_64-linux-musl-gcc which the `ring`
       # crate's build script needs for static Linux builds.
-      - name: Install musl toolchain
+      # gcc-aarch64-linux-gnu + rustup target add gives us aarch64
+      # cross-compile capability for arm64 static binaries.
+      - name: Install musl + aarch64 cross toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools
+          sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
+          # Install the aarch64 musl toolchain via the rust-musl-cross project's prebuilt
+          # The simplest path: use the musl.cc prebuilt cross-compiler
+          curl -L https://musl.cc/aarch64-linux-musl-cross.tgz | tar xz -C /tmp
+          echo "/tmp/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
+          # Tell cargo/cc-rs where to find the linker for aarch64 musl
+          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV
 
       - name: Build x86_64 (musl, static)
         run: cargo build --release --target x86_64-unknown-linux-musl -p confium-cli


### PR DESCRIPTION
## Summary

Two fixes for the v0.4.0 release pipeline failures.

### 1. `release-binary.yml` — aarch64 musl cross-toolchain
`musl-tools` only provides `x86_64-linux-musl-gcc`. The `ring` crate's build script needs `aarch64-linux-musl-gcc` for the arm64 static build. Install the prebuilt `aarch64-linux-musl-cross` from musl.cc, set `CC_aarch64_unknown_linux_musl` and `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` so cargo + ring's build script find the cross-linker.

### 2. `docker-release.yml` — trivy-action pin
`aquasecurity/trivy-action@0.28.0` doesn't exist on the marketplace. Pin to `0.24.0` (a known good version).

## Why v0.4.0 release partially failed

- WASM publish to npm: **succeeded** (`@confium/confium-wasm@0.4.0` is live)
- Linux x86_64 binary: succeeded (after musl-tools fix)
- Linux aarch64 binary: failed (missing aarch64 musl)
- macOS x86_64 + arm64 binaries: succeeded
- Windows binary: succeeded
- Docker images (3 services): failed at workflow setup (trivy-action version)

This PR fixes both. Next v0.4.x tag push (or v0.4.1) should produce all artifacts.

## Test plan

- [ ] PR merges
- [ ] Push v0.4.1 (or workflow_dispatch) to validate
