### PR TITLE
fix(ci): trivy-action@v0.36.0 — actual latest release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -90,7 +90,7 @@ jobs:
       # Trivy vuln scan. CRITICAL findings fail the workflow; HIGH gets
       # reported but does not block the push (which already happened).
       - name: Trivy vuln scan
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ${{ steps.tags.outputs.image }}:latest
           format: sarif


### PR DESCRIPTION
Previous attempts to pin trivy-action used non-existent versions (@0.24.0, @0.28.0). Latest is v0.36.0 per https://github.com/aquasecurity/trivy-action/releases.