### PR TITLE
fix(ci): drop aarch64 static binary from release-binary

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -32,35 +32,22 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-unknown-linux-musl, aarch64-unknown-linux-musl
+          targets: x86_64-unknown-linux-musl
 
       # musl-tools provides x86_64-linux-musl-gcc which the `ring`
       # crate's build script needs for static Linux builds.
-      # gcc-aarch64-linux-gnu + rustup target add gives us aarch64
-      # cross-compile capability for arm64 static binaries.
-      - name: Install musl + aarch64 cross toolchain
+      - name: Install musl toolchain
         run: |
           sudo apt-get update
-          sudo apt-get install -y musl-tools gcc-aarch64-linux-gnu
-          # Install the aarch64 musl toolchain via the rust-musl-cross project's prebuilt
-          # The simplest path: use the musl.cc prebuilt cross-compiler
-          curl -L https://musl.cc/aarch64-linux-musl-cross.tgz | tar xz -C /tmp
-          echo "/tmp/aarch64-linux-musl-cross/bin" >> $GITHUB_PATH
-          # Tell cargo/cc-rs where to find the linker for aarch64 musl
-          echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc" >> $GITHUB_ENV
-          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc" >> $GITHUB_ENV
+          sudo apt-get install -y musl-tools
 
       - name: Build x86_64 (musl, static)
         run: cargo build --release --target x86_64-unknown-linux-musl -p confium-cli
-
-      - name: Build aarch64 (musl, static)
-        run: cargo build --release --target aarch64-unknown-linux-musl -p confium-cli
 
       - name: Package binaries
         run: |
           mkdir -p dist
           tar -czf dist/confium-linux-x86_64.tar.gz -C target/x86_64-unknown-linux-musl/release confium
-          tar -czf dist/confium-linux-aarch64.tar.gz -C target/aarch64-unknown-linux-musl/release confium
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
musl.cc prebuilt download was unreliable. Multi-arch Docker images already cover arm64. Static binary artifact is x86_64-only for now.