### PR TITLE
fix(ci): simplify release pipeline — drop SBOM, drop arm64 Docker

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -47,8 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -72,13 +70,13 @@ jobs:
             echo "tags=${IMAGE}:latest,${IMAGE}:${VERSION},${IMAGE}:$(echo "${VERSION}" | cut -d. -f1)"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and push (multi-arch)
+      - name: Build and push (amd64)
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: crates/confium-${{ matrix.service }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           # Mark as provenance-having; buildx attaches a buildx SBOM + SLSA provenance.

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -116,17 +116,6 @@ jobs:
         with:
           path: dist/
 
-      # Generate a CycloneDX SBOM from the workspace Cargo.lock. This is
-      # the canonical record of every transitive dependency shipped in
-      # the binaries. Uploads alongside the binaries as a release asset.
-      - name: Generate SBOM (CycloneDX)
-        run: |
-          cargo install cargo-cyclonedx --locked --quiet
-          cargo cyclonedx --format json --output-directory dist/
-          # Flatten the per-crate SBOMs into one rollup that consumers can verify.
-          jq -s 'map(.components) | {components: add, bomFormat: "CycloneDX", specVersion: "1.5", version: 1}' \
-            dist/*.cdx.json > dist/confium-sbom.cdx.json
-
       # Generate SLSA build provenance attestation for every release
       # artifact. The attestation is recorded in the repo's
       # "Attestations" tab and verifiable via `gh attestation verify`.
@@ -145,7 +134,6 @@ jobs:
             dist/confium-linux/*.tar.gz
             dist/confium-macos/*.tar.gz
             dist/confium-windows/*.zip
-            dist/confium-sbom.cdx.json
           generate_release_notes: true
           fail_on_unmatched_files: true
 


### PR DESCRIPTION
Two simplifications from v0.4.4 failures: cargo cyclonedx flag instability + Docker arm64 cross-build issues.