### PR TITLE
fix(docker): bump Rust base + add security-events perm for SARIF

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -32,6 +32,7 @@ permissions:
   # Required for SLSA build provenance attestation.
   id-token: write
   attestations: write
+  security-events: write
 
 env:
   REGISTRY: ghcr.io

--- a/crates/confium-log-server/Dockerfile
+++ b/crates/confium-log-server/Dockerfile
@@ -5,7 +5,7 @@
 # image = minimal attack surface.
 
 # --- build stage -----------------------------------------------------------
-FROM rust:1.85-bookworm AS builder
+FROM rust:1-bookworm AS builder
 
 WORKDIR /build
 # Cache deps separately from source for faster incremental builds.

--- a/crates/confium-signerd/Dockerfile
+++ b/crates/confium-signerd/Dockerfile
@@ -5,7 +5,7 @@
 # image = minimal attack surface.
 
 # --- build stage -----------------------------------------------------------
-FROM rust:1.85-bookworm AS builder
+FROM rust:1-bookworm AS builder
 
 WORKDIR /build
 # Cache deps separately from source for faster incremental builds.

--- a/crates/confium-verify-server/Dockerfile
+++ b/crates/confium-verify-server/Dockerfile
@@ -5,7 +5,7 @@
 # image = minimal attack surface.
 
 # --- build stage -----------------------------------------------------------
-FROM rust:1.85-bookworm AS builder
+FROM rust:1-bookworm AS builder
 
 WORKDIR /build
 # Cache deps separately from source for faster incremental builds.


### PR DESCRIPTION
## Summary

Two coupled fixes from v0.4.6 Docker build failures.

### 1. Rust version pin
`icu_collections/icu_locale_core/icu_normalizer` (transitive deps via cargo) require Rust 1.86+. The `rust:1.85-bookworm` pin in the Dockerfile was too old. Switch to `rust:1-bookworm` which tracks the latest stable Rust 1.x.

### 2. SARIF upload permission
Trivy SARIF upload to Security tab failed with "Resource not accessible by integration" — needs `security-events: write` permission on the workflow. Added it.

## Test plan

- [ ] PR merges
- [ ] v0.4.7 tag push produces working Docker images at ghcr.io/confium/{signerd,log-server,verify-server}:latest
