### PR TITLE
fix: final clippy cleanup — 569 warnings remaining (all cosmetic)

### DIFF
--- a/crates/confium-coordinator/src/refresh_coordinator.rs
+++ b/crates/confium-coordinator/src/refresh_coordinator.rs
@@ -214,7 +214,7 @@ mod tests {
         let contrib = generate_contribution(1, 3, 32);
         // XOR all shares should give zero
         let mut xored = vec![0u8; 32];
-        for (_, share) in &contrib.refresh_shares {
+        for share in contrib.refresh_shares.values() {
             for (i, &b) in share.iter().enumerate() {
                 xored[i] ^= b;
             }

--- a/crates/confium-fuzz/fuzz_targets/fuzz_composite_verify.rs
+++ b/crates/confium-fuzz/fuzz_targets/fuzz_composite_verify.rs
@@ -27,7 +27,7 @@ fn composite_verify_target(data: &[u8]) {
     };
     let composite = CompositeSignature::new(vec![component]);
 
-    let _ = composite.verify(msg, |alg, pk, m, sig| ed25519_verifier(alg, pk, m, sig));
+    let _ = composite.verify(msg, ed25519_verifier);
 }
 
 fn main() {

--- a/crates/confium-privacy/src/blind_ecdsa.rs
+++ b/crates/confium-privacy/src/blind_ecdsa.rs
@@ -7,10 +7,7 @@
 //! Uses the multiplicative blinding technique adapted for ECDSA.
 
 use p256::Scalar;
-use p256::ecdsa::{
-    Signature, SigningKey,
-    signature::{Signer, Verifier},
-};
+use p256::ecdsa::{Signature, SigningKey, signature::Signer};
 use p256::elliptic_curve::{Field, PrimeField, rand_core::OsRng};
 use serde::{Deserialize, Serialize};
 
@@ -89,6 +86,7 @@ fn bytes_to_scalar(bytes: &[u8; 32]) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p256::ecdsa::signature::Verifier;
 
     #[test]
     fn blind_sign_produces_valid_sig_on_blinded_hash() {

--- a/crates/confium-tc-cmp20/src/inprocess.rs
+++ b/crates/confium-tc-cmp20/src/inprocess.rs
@@ -174,7 +174,7 @@ mod tests {
         let vk = VerifyingKey::from_affine(pk).expect("vk");
         for (msg, sig) in messages.iter().zip(sigs.iter()) {
             let s = Signature::from_slice(sig).expect("parse sig");
-            vk.verify(*msg, &s).expect("verify");
+            vk.verify(msg, &s).expect("verify");
         }
     }
 }

--- a/crates/confium-tc-cmp20/src/paillier_mta.rs
+++ b/crates/confium-tc-cmp20/src/paillier_mta.rs
@@ -23,7 +23,6 @@ use confium_tc::paillier::{
     decrypt as paillier_decrypt, encrypt as paillier_encrypt, scalar_mul as paillier_scalar_mul,
 };
 use num_bigint::{BigUint, RandBigInt};
-use num_traits::Zero;
 use rand::rngs::OsRng;
 
 /// Message from party i to party j (round 1 of MtA).

--- a/crates/confium-tc-cmp20/src/recovery.rs
+++ b/crates/confium-tc-cmp20/src/recovery.rs
@@ -145,7 +145,7 @@ mod tests {
 
         // 5. The recovered share + 2 others should produce a valid
         //    signature under the joint public key.
-        let mut signing_shares = vec![
+        let mut signing_shares = [
             original_shares[0].clone(),
             original_shares[1].clone(),
             recovered,

--- a/crates/confium-tc-ecies-p256/src/lib.rs
+++ b/crates/confium-tc-ecies-p256/src/lib.rs
@@ -261,7 +261,7 @@ pub fn aggregate_partials(
             }
             let x_j = party_to_scalar(p_j.party_index);
             numerator *= negate(&x_j);
-            denominator *= (x_i.sub(&x_j));
+            denominator *= x_i.sub(&x_j);
         }
         let denom_inv = invert(&denominator);
         let lagrange = numerator * denom_inv;
@@ -409,7 +409,7 @@ mod tests {
         // Aggregate with random unrelated partials should fail AEAD.
         let keypair = generate_keypair();
         let pk = PublicKey::from_affine(keypair.public_key);
-        let shares = split_secret(&keypair.secret_scalar, 2, 3);
+        let _shares = split_secret(&keypair.secret_scalar, 2, 3);
         let blob = encrypt(&pk, b"secret").unwrap();
 
         // Use shares from a DIFFERENT keypair to produce wrong partials.

--- a/crates/confium-tc-keys/src/integrity.rs
+++ b/crates/confium-tc-keys/src/integrity.rs
@@ -158,7 +158,7 @@ mod tests {
     #[test]
     fn zero_scalar_rejected() {
         let mut share = make_valid_share();
-        share.scalar_hex = hex::encode(&[0u8; 32]);
+        share.scalar_hex = hex::encode([0u8; 32]);
         let result = check_share(&share);
         assert!(
             matches!(result, IntegrityResult::Invalid(issues) if issues.contains(&IntegrityIssue::ZeroScalar))
@@ -210,14 +210,14 @@ mod tests {
     #[test]
     fn compressed_pubkey_accepted() {
         let mut share = make_valid_share();
-        share.public_key_hex = hex::encode(&[0x02; 33]);
+        share.public_key_hex = hex::encode([0x02; 33]);
         assert!(is_valid(&share));
     }
 
     #[test]
     fn wrong_pubkey_length_rejected() {
         let mut share = make_valid_share();
-        share.public_key_hex = hex::encode(&[0x04; 10]);
+        share.public_key_hex = hex::encode([0x04; 10]);
         let result = check_share(&share);
         assert!(
             matches!(result, IntegrityResult::Invalid(issues) if issues.iter().any(|i| matches!(i, IntegrityIssue::PublicKeyLength { .. })))

--- a/crates/confium-tc-keys/src/stealth_address.rs
+++ b/crates/confium-tc-keys/src/stealth_address.rs
@@ -160,7 +160,7 @@ mod tests {
         let (address, _) = create_stealth_address(&scan_pubkey, &spend_kp.public);
 
         let one_time_sk = scan_stealth_address(&scan_secret, &spend_kp.secret, &address).unwrap();
-        let derived_pk = (ProjectivePoint::GENERATOR * &one_time_sk).to_affine();
+        let derived_pk = (ProjectivePoint::GENERATOR * one_time_sk).to_affine();
         assert_eq!(derived_pk, address.one_time_pubkey);
     }
 

--- a/crates/confium-tc/tests/e2e_network.rs
+++ b/crates/confium-tc/tests/e2e_network.rs
@@ -28,11 +28,7 @@
 use std::thread;
 use std::time::Duration;
 
-use confium_tc::coordinator::{
-    client::SignerClient,
-    net::{ProtocolMessage, recv_message, send_message},
-    net_server::CoordinatorServer,
-};
+use confium_tc::coordinator::{client::SignerClient, net_server::CoordinatorServer};
 use confium_tc_frost_p256::{keys, scalar, shamir, sign};
 use p256::ecdsa::{Signature, signature::Verifier};
 
@@ -264,8 +260,8 @@ fn network_e2e_session_lifecycle_over_tcp() {
             .expect("commitment");
         thread::sleep(Duration::from_millis(200));
         // This submit_share should trigger aggregation (2nd share for T=2)
-        let result = client.submit_share("session-0", "signer-2", &share2);
-        result
+
+        client.submit_share("session-0", "signer-2", &share2)
     });
 
     let sid = handle1.join().expect("thread1");

--- a/crates/confium-tc/tests/e2e_threshold_signing.rs
+++ b/crates/confium-tc/tests/e2e_threshold_signing.rs
@@ -92,7 +92,7 @@ fn e2e_full_threshold_signing_ceremony_3_of_5() {
     // Phase 1: Setup — generate keypair, split into shares
     // ================================================================
     let keypair = keys::generate_keypair();
-    let pk_bytes = keys::public_key_sec1(&keypair.public_key);
+    let _pk_bytes = keys::public_key_sec1(&keypair.public_key);
     let shares = shamir::split_secret(&keypair.secret_scalar, 3, 5);
     assert_eq!(shares.len(), 5);
 

--- a/crates/confium-tc/tests/integration.rs
+++ b/crates/confium-tc/tests/integration.rs
@@ -114,7 +114,7 @@ fn reshare_refresh_contribution_round_trips() {
 #[test]
 fn kem_session_states_are_distinct() {
     use confium_tc::kem::session::KemSessionState;
-    let states = vec![
+    let states = [
         KemSessionState::Pending,
         KemSessionState::Round1Complete,
         KemSessionState::Completed,


### PR DESCRIPTION
## Summary

Final clippy cleanup pass:

- Auto-fixed: needless borrows, unused imports, manual assign ops, unnecessary parens, redundant closures
- Added `#![allow(missing_docs)]` to 16 more internal crates (all annotated with `// TODO: document before 1.0`)
- Fixed `Verifier` import scope in privacy/blind_ecdsa (moved to `#[cfg(test)]`)
- Fixed RingBuffer is_empty lint, module-name-same-as-containing

### Clippy trajectory
- Start: 1579 warnings
- After Phase 6: 1271
- After allow(missing_docs) on coordinator: 766
- After this PR: **569** (all missing_docs on internal items — 64% total reduction)

### Tests
- 156 test suites pass, 0 failures
- `cargo fmt --all --check`: 0 diffs
