### PR TITLE
fix(security): zeroize on Drop for core Share types + architecture doc fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1577,6 +1577,7 @@ dependencies = [
  "snafu 0.8.9",
  "subtle",
  "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]
@@ -1638,6 +1639,7 @@ dependencies = [
  "proptest",
  "rand_core 0.6.4",
  "thiserror 1.0.69",
+ "zeroize",
 ]
 
 [[package]]

--- a/TODO.complete/52-zeroize-on-share-types.md
+++ b/TODO.complete/52-zeroize-on-share-types.md
@@ -1,0 +1,67 @@
+# 52 — Zeroize on Drop for core Share types
+
+## Problem
+
+`confium-tc-core::Share` and `confium-tc-frost-p256::shamir::Share`
+held cryptographic secret bytes/scalars in memory without
+implementing `Zeroize` or `Drop`. When these types went out of
+scope, the secret data remained in heap memory until the allocator
+reused the page — potentially seconds to minutes.
+
+CMP20 and GG18 shares already had zeroize (via the `zeroize`
+crate). The core framework share type and the FROST-P256 Shamir
+share did not.
+
+## What was done
+
+### `confium-tc-core::Share`
+
+Added a manual `impl Drop for Share` that calls
+`zeroize::Zeroize::zeroize(&mut self.bytes)`. This wipes the
+secret-encoded share bytes before freeing the Vec.
+
+Added `zeroize = { workspace = true, features = ["zeroize_derive"] }`
+to `confium-tc-core/Cargo.toml`.
+
+Changed `into_bytes(self)` to `into_bytes(self) -> Vec<u8>` with
+`.clone()` — can't move out of a type that implements Drop.
+Slight performance cost (one extra allocation) but the security
+benefit (zeroize-on-drop) outweighs it.
+
+### `confium-tc-frost-p256::shamir::Share`
+
+Added a manual `impl Drop for Share` that calls
+`zeroize::Zeroize::zeroize(&mut self.y)` on the P-256 `Scalar`.
+The scalar field holds the actual secret share value.
+
+Added `zeroize = { workspace = true }` to
+`confium-tc-frost-p256/Cargo.toml`.
+
+### Architecture doc accuracy
+
+`docs/architecture.mdx`:
+- Fixed `confium-tc-coordinator` → `confium-coordinator` (old crate name).
+- Fixed "Every crate carries `#![forbid(unsafe_code)]`" to
+  accurately describe that most crates do, with documented exceptions.
+
+## Remaining zeroize gaps
+
+These types still lack zeroize-on-drop (lower priority — they hold
+partial signatures or decryption shares, not long-lived secrets):
+
+- `confium-tc-bls::Share`
+- `confium-crypto-vss::PedersenShare`
+- `confium-crypto-vss::PartialSig`
+- `confium-privacy::{PrfShare, PrgShare, DecryptionShare}`
+- `confium-tc-elgamal-p256::DecryptionShare`
+
+## Verification
+
+```sh
+cargo build --workspace   # clean
+cargo test --workspace    # 1703 passed, 0 failed
+```
+
+## Status
+
+Done. Core framework Share and FROST-P256 Share now zeroize on drop.

--- a/crates/confium-tc-core/Cargo.toml
+++ b/crates/confium-tc-core/Cargo.toml
@@ -33,6 +33,7 @@ rand_core = { workspace = true }
 hex = { workspace = true }
 inventory = { workspace = true }
 snafu = { workspace = true }
+zeroize = { workspace = true, features = ["zeroize_derive"] }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/confium-tc-core/src/share.rs
+++ b/crates/confium-tc-core/src/share.rs
@@ -19,10 +19,19 @@ use crate::error;
 /// `scheme` ties the share to the scheme that produced it (e.g.
 /// `"FROST-ed25519"`). `bytes` is the scheme-specific encoding of the
 /// share; the framework never inspects or reinterprets it.
+///
+/// The secret `bytes` field is zeroized on drop.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Share {
     scheme: String,
     bytes: Vec<u8>,
+}
+
+impl Drop for Share {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.bytes.zeroize();
+    }
 }
 
 impl Share {
@@ -42,7 +51,7 @@ impl Share {
     }
 
     pub fn into_bytes(self) -> Vec<u8> {
-        self.bytes
+        self.bytes.clone()
     }
 
     pub fn len(&self) -> usize {

--- a/crates/confium-tc-frost-p256/Cargo.toml
+++ b/crates/confium-tc-frost-p256/Cargo.toml
@@ -23,6 +23,7 @@ thiserror = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
 rand_core = { workspace = true }
 elliptic-curve = { workspace = true, features = ["pkcs8", "sec1"] }
+zeroize = { workspace = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/confium-tc-frost-p256/src/shamir.rs
+++ b/crates/confium-tc-frost-p256/src/shamir.rs
@@ -9,12 +9,20 @@ use p256::Scalar;
 use p256::elliptic_curve::PrimeField;
 
 /// A Shamir share: (x, y) where x is the party index and y is a scalar.
+/// The secret `y` field is zeroized on drop.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Share {
     /// Party index (the x-coordinate). Typically 1-based per FROST convention.
     pub x: u32,
     /// The share value (the y-coordinate).
     pub y: Scalar,
+}
+
+impl Drop for Share {
+    fn drop(&mut self) {
+        use zeroize::Zeroize;
+        self.y.zeroize();
+    }
 }
 
 /// Errors during Shamir operations.

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -78,7 +78,7 @@ for human inspection.
 
 Threshold cryptography protocols (FROST, CMP20, GG18) require multiple
 parties to exchange messages across rounds. The
-`confium-tc-coordinator` service orchestrates these sessions
+`confium-coordinator` service orchestrates these sessions
 asynchronously, so parties do not need to be online simultaneously.
 
 Sessions are identified by a session ID. Each party joins, submits
@@ -102,10 +102,13 @@ implementations are closed for modification. Examples:
 - `OpenpgpCardBackend` — OpenPGP card hardware backends
 - `ThresholdSigner` — threshold signing protocols
 
-### No unsafe code
+### No unsafe code (where possible)
 
-Every crate carries `#![forbid(unsafe_code)]`. All FFI is contained in
-`confium-core` and uses `#[unsafe(no_mangle)]` per edition 2024
+Most crates carry `#![forbid(unsafe_code)]` or `#![warn(unsafe_code)]`.
+Exceptions are documented with `#[allow(unsafe_code)]` and a comment
+explaining why (e.g., `confium-core` FFI entry points,
+`confium-coordinator` libc signal handling). All FFI in
+`confium-core` uses `#[unsafe(no_mangle)]` per edition 2024
 requirements.
 
 ### No vendor SDKs


### PR DESCRIPTION
## Summary

**Security:** `confium-tc-core::Share` and `confium-tc-frost-p256::shamir::Share` held cryptographic secret bytes/scalars without zeroizing on drop. Now both implement `Drop` that wipes the secret field before freeing.

**Docs:** Fixed architecture.mdx — stale crate name (`confium-tc-coordinator` → `confium-coordinator`) and inaccurate claim about `#![forbid(unsafe_code)]` on every crate.

## What changed
- `confium-tc-core/src/share.rs`: manual `impl Drop` that calls `zeroize` on `bytes` field
- `confium-tc-core/Cargo.toml`: added `zeroize` dep with `zeroize_derive` feature
- `confium-tc-frost-p256/src/shamir.rs`: manual `impl Drop` that calls `zeroize` on `Scalar` field
- `confium-tc-frost-p256/Cargo.toml`: added `zeroize` dep
- `docs/architecture.mdx`: fixed stale crate name + inaccurate unsafe_code claim

## Test plan
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 1703 passed, 0 failed
- [x] `cargo clippy --workspace --all-targets` — 0 warnings
