### PR TITLE
fix(tc-core): declare 4 orphaned modules — 39 dead tests now run

### DIFF
--- a/crates/confium-tc-core/src/error_codes.rs
+++ b/crates/confium-tc-core/src/error_codes.rs
@@ -92,7 +92,9 @@ impl ErrorCode {
     pub fn description(&self) -> &'static str {
         match self {
             Self::SessionNotFound => "The requested session does not exist.",
-            Self::InvalidSessionState => "The session is not in the required state for this operation.",
+            Self::InvalidSessionState => {
+                "The session is not in the required state for this operation."
+            }
             Self::ThresholdNotMet => "Not enough shares have been submitted to meet the threshold.",
             Self::DuplicateSubmission => "This signer has already submitted to this session.",
             Self::SessionExpired => "The session's unlock window has elapsed.",

--- a/crates/confium-tc-core/src/lib.rs
+++ b/crates/confium-tc-core/src/lib.rs
@@ -11,8 +11,11 @@
 #![allow(rustdoc::private_intra_doc_links)]
 #![allow(rustdoc::invalid_html_tags)]
 
+pub mod commitment;
 pub mod error;
+pub mod error_codes;
 pub mod message;
+pub mod nonce;
 pub mod party;
 pub mod registry;
 pub mod schemes;
@@ -20,6 +23,7 @@ pub mod session;
 pub mod share;
 pub mod share_adapter;
 pub mod share_envelope;
+pub mod unified_error;
 
 pub use error::Error;
 pub use error::Result;

--- a/crates/confium-tc-core/src/nonce.rs
+++ b/crates/confium-tc-core/src/nonce.rs
@@ -34,8 +34,8 @@ pub fn derive_nonce_share(
     message_hash: &[u8; 32],
     party_idx: u32,
 ) -> Scalar {
-    let mut mac = HmacSha256::new_from_slice(&secret_share.to_repr())
-        .expect("HMAC accepts any key length");
+    let mut mac =
+        HmacSha256::new_from_slice(&secret_share.to_repr()).expect("HMAC accepts any key length");
     mac.update(message_hash);
     mac.update(&party_idx.to_be_bytes());
     let result = mac.finalize().into_bytes();
@@ -91,8 +91,8 @@ fn reduce_mod_order(bytes: &[u8; 32]) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use p256::elliptic_curve::rand_core::OsRng;
     use p256::elliptic_curve::Field;
+    use p256::elliptic_curve::rand_core::OsRng;
 
     fn random_scalar() -> Scalar {
         Scalar::random(&mut OsRng)

--- a/crates/confium-tc-core/src/unified_error.rs
+++ b/crates/confium-tc-core/src/unified_error.rs
@@ -21,9 +21,18 @@ pub enum UnifiedError {
 #[derive(Debug)]
 pub enum SessionErrorKind {
     NotFound(String),
-    InvalidState { session: String, current: String, expected: String },
-    ThresholdNotMet { have: usize, need: u32 },
-    DuplicateSubmission { signer: String },
+    InvalidState {
+        session: String,
+        current: String,
+        expected: String,
+    },
+    ThresholdNotMet {
+        have: usize,
+        need: u32,
+    },
+    DuplicateSubmission {
+        signer: String,
+    },
     Expired(String),
     SigningFailed(String),
 }
@@ -57,7 +66,11 @@ pub enum StoreErrorKind {
 
 #[derive(Debug)]
 pub enum ConfigErrorKind {
-    InvalidValue { field: String, value: String, expected: String },
+    InvalidValue {
+        field: String,
+        value: String,
+        expected: String,
+    },
     MissingField(String),
     FileError(String),
 }
@@ -71,7 +84,9 @@ impl fmt::Display for UnifiedError {
             Self::Crypto(e) => write!(f, "crypto error: {e:?}"),
             Self::Store(e) => write!(f, "store error: {e:?}"),
             Self::Config(e) => write!(f, "config error: {e:?}"),
-            Self::RateLimited { retry_after_secs } => write!(f, "rate limited, retry after {retry_after_secs}s"),
+            Self::RateLimited { retry_after_secs } => {
+                write!(f, "rate limited, retry after {retry_after_secs}s")
+            }
             Self::Backpressure { active, max } => write!(f, "at capacity: {active}/{max}"),
             Self::Unauthorized { reason } => write!(f, "unauthorized: {reason}"),
             Self::NotFound { resource } => write!(f, "not found: {resource}"),
@@ -111,22 +126,24 @@ impl UnifiedError {
     }
 
     pub fn is_retryable(&self) -> bool {
-        matches!(self,
-            Self::Session(SessionErrorKind::ThresholdNotMet { .. }) |
-            Self::Network(NetworkErrorKind::Timeout) |
-            Self::RateLimited { .. } |
-            Self::Backpressure { .. }
+        matches!(
+            self,
+            Self::Session(SessionErrorKind::ThresholdNotMet { .. })
+                | Self::Network(NetworkErrorKind::Timeout)
+                | Self::RateLimited { .. }
+                | Self::Backpressure { .. }
         )
     }
 
     pub fn is_client_error(&self) -> bool {
-        matches!(self,
-            Self::Session(SessionErrorKind::NotFound(_)) |
-            Self::Session(SessionErrorKind::DuplicateSubmission { .. }) |
-            Self::Session(SessionErrorKind::Expired(_)) |
-            Self::Policy(_) |
-            Self::Unauthorized { .. } |
-            Self::NotFound { .. }
+        matches!(
+            self,
+            Self::Session(SessionErrorKind::NotFound(_))
+                | Self::Session(SessionErrorKind::DuplicateSubmission { .. })
+                | Self::Session(SessionErrorKind::Expired(_))
+                | Self::Policy(_)
+                | Self::Unauthorized { .. }
+                | Self::NotFound { .. }
         )
     }
 
@@ -153,16 +170,24 @@ impl UnifiedError {
         Self::Session(SessionErrorKind::NotFound(id.into()))
     }
     pub fn rate_limited(retry_after: u64) -> Self {
-        Self::RateLimited { retry_after_secs: retry_after }
+        Self::RateLimited {
+            retry_after_secs: retry_after,
+        }
     }
     pub fn unauthorized(reason: &str) -> Self {
-        Self::Unauthorized { reason: reason.into() }
+        Self::Unauthorized {
+            reason: reason.into(),
+        }
     }
     pub fn not_found(resource: &str) -> Self {
-        Self::NotFound { resource: resource.into() }
+        Self::NotFound {
+            resource: resource.into(),
+        }
     }
     pub fn internal(message: &str) -> Self {
-        Self::Internal { message: message.into() }
+        Self::Internal {
+            message: message.into(),
+        }
     }
 }
 
@@ -201,7 +226,10 @@ mod tests {
 
     #[test]
     fn backpressure_error() {
-        let e = UnifiedError::Backpressure { active: 10, max: 10 };
+        let e = UnifiedError::Backpressure {
+            active: 10,
+            max: 10,
+        };
         assert!(e.is_retryable());
         assert!(!e.is_client_error());
         assert_eq!(e.code(), 2002);
@@ -209,8 +237,14 @@ mod tests {
 
     #[test]
     fn crypto_error_codes() {
-        assert_eq!(UnifiedError::Crypto(CryptoErrorKind::InvalidSignature).code(), 4001);
-        assert_eq!(UnifiedError::Crypto(CryptoErrorKind::InvalidShare).code(), 4002);
+        assert_eq!(
+            UnifiedError::Crypto(CryptoErrorKind::InvalidSignature).code(),
+            4001
+        );
+        assert_eq!(
+            UnifiedError::Crypto(CryptoErrorKind::InvalidShare).code(),
+            4002
+        );
     }
 
     #[test]


### PR DESCRIPTION
confium-tc-core/src/lib.rs was missing  declarations for 4 source files that existed in the directory but were never compiled:

-  (hash-based commitment scheme)
-  (typed error code catalog)
-  (threshold nonce derivation)
-  (unified error hierarchy)

Adding the 4 declarations brings **39 previously-dead tests online**. Workspace test count: 1703 → 1742.