### PR TITLE
refactor: declare frost-ed25519 inprocess + transparency witness modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,6 +1598,7 @@ name = "confium-tc-elgamal-p256"
 version = "0.4.7"
 dependencies = [
  "p256",
+ "proptest",
  "serde",
  "thiserror 1.0.69",
  "zeroize",

--- a/crates/confium-tc-frost-ed25519/src/lib.rs
+++ b/crates/confium-tc-frost-ed25519/src/lib.rs
@@ -49,6 +49,7 @@
 pub mod dkg;
 pub mod error;
 pub mod group;
+pub mod inprocess;
 pub mod polynomial;
 pub mod sign;
 pub mod transcript;

--- a/crates/confium-transparency/src/lib.rs
+++ b/crates/confium-transparency/src/lib.rs
@@ -38,6 +38,7 @@ pub mod ers;
 pub mod merkle;
 pub mod ots;
 pub mod proof;
+pub mod witness;
 
 pub use entry::*;
 pub use merkle::*;

--- a/crates/confium-transparency/src/witness.rs
+++ b/crates/confium-transparency/src/witness.rs
@@ -73,11 +73,7 @@ impl Witness {
     ///
     /// `tree` is the current tree state (used to brute-force verify
     /// consistency via root recomputation).
-    pub fn receive_head(
-        &mut self,
-        head: TreeHead,
-        tree: &MerkleTree,
-    ) -> Result<(), WitnessError> {
+    pub fn receive_head(&mut self, head: TreeHead, tree: &MerkleTree) -> Result<(), WitnessError> {
         if let Some(old) = self.latest_head() {
             if head.tree_size > old.tree_size {
                 tree.verify_consistency(
@@ -143,7 +139,11 @@ mod tests {
     fn build_tree(n: u64) -> MerkleTree {
         let mut tree = MerkleTree::new();
         for i in 0..n {
-            tree.append(MerkleEntry::new(i, ArtifactType::ThresholdSignature, [i as u8; 32]));
+            tree.append(MerkleEntry::new(
+                i,
+                ArtifactType::ThresholdSignature,
+                [i as u8; 32],
+            ));
         }
         tree
     }
@@ -181,7 +181,11 @@ mod tests {
         };
         w.receive_head(head1, &tree).unwrap();
 
-        tree.append(MerkleEntry::new(5, ArtifactType::ThresholdSignature, [5; 32]));
+        tree.append(MerkleEntry::new(
+            5,
+            ArtifactType::ThresholdSignature,
+            [5; 32],
+        ));
         let head2 = TreeHead {
             tree_size: 6,
             root_hash: tree.root(),
@@ -225,7 +229,11 @@ mod tests {
         };
         w.receive_head(head1, &tree).unwrap();
 
-        tree.append(MerkleEntry::new(1, ArtifactType::ThresholdSignature, [1; 32]));
+        tree.append(MerkleEntry::new(
+            1,
+            ArtifactType::ThresholdSignature,
+            [1; 32],
+        ));
         let head2 = TreeHead {
             tree_size: 2,
             root_hash: tree.root(),
@@ -233,7 +241,11 @@ mod tests {
         };
         w.receive_head(head2, &tree).unwrap();
 
-        tree.append(MerkleEntry::new(2, ArtifactType::ThresholdSignature, [2; 32]));
+        tree.append(MerkleEntry::new(
+            2,
+            ArtifactType::ThresholdSignature,
+            [2; 32],
+        ));
         let head3 = TreeHead {
             tree_size: 3,
             root_hash: tree.root(),


### PR DESCRIPTION
## Summary

- Declares 2 more orphaned modules in their crate `lib.rs` roots, bringing 10 previously-dead tests online.
- `crates/confium-tc-frost-ed25519/src/inprocess.rs` (62L, 2 tests) — in-process synchronous driver for FROST-ed25519 DKG and signing. Closes the threshold-EdDSA matrix gap (CMP20 and GG18 already had in-process drivers; FROST-ed25519 did not).
- `crates/confium-transparency/src/witness.rs` (~289L, 8 tests) — witness gossip protocol: third-party witnesses track tree heads and gossip them to detect split-view attacks. Tracks `TODO.roadmap/101-witness-gossip-protocol.md`.

No code changes to the modules themselves — they were already complete and tested in isolation, just unreachable from the crate root.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test -p confium-tc-frost-ed25519 inprocess` — 2 passed
- [x] `cargo test -p confium-transparency witness` — 8 passed
- [x] `cargo test --workspace` — 1778 passed, 0 failed (was 1768)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
