### PR TITLE
fix(security): constant-time comparison for all hash equality checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,6 +1183,7 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "sled",
+ "subtle",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1733,6 +1734,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "subtle",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -1784,6 +1786,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "subtle",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/crates/confium-log-monitor/Cargo.toml
+++ b/crates/confium-log-monitor/Cargo.toml
@@ -22,6 +22,7 @@ clap = { workspace = true }
 serde = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+subtle = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/confium-log-monitor/src/verify.rs
+++ b/crates/confium-log-monitor/src/verify.rs
@@ -31,10 +31,14 @@ pub fn verify_consistency(
         proof.new_size,
         new_head.tree_size
     );
-    ensure!(
-        proof.new_root == new_head.root,
-        "proof new_root doesn't match head root"
-    );
+    // Constant-time comparison of the hex-encoded roots. Both sides
+    // are public, but hashing primitives should never short-circuit
+    // compare — defense in depth.
+    use subtle::ConstantTimeEq;
+    let proof_root_bytes = hex::decode(&proof.new_root).unwrap_or_default();
+    let head_root_bytes = hex::decode(&new_head.root).unwrap_or_default();
+    let root_ok: bool = proof_root_bytes.ct_eq(&head_root_bytes).into();
+    ensure!(root_ok, "proof new_root doesn't match head root");
 
     // RFC 6962 consistency verification: walk the proof hashes
     // starting from the leftmost subtree of old_size, combining
@@ -107,7 +111,9 @@ pub fn verify_inclusion(
             hash_pair(&current, &sib_arr)
         };
     }
-    ensure!(&current == root, "inclusion proof doesn't reach root");
+    use subtle::ConstantTimeEq;
+    let root_ok: bool = current.ct_eq(root).into();
+    ensure!(root_ok, "inclusion proof doesn't reach root");
     Ok(())
 }
 

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -25,6 +25,7 @@ confium-deployment = { path = "../confium-deployment", version = "0.4.0" }
 pyo3 = { version = "0.22", features = ["extension-module"] }
 serde_json = "1"
 sha2 = "0.10"
+subtle = "2"
 chrono = "0.4"
 hex = "0.4"
 ed25519-dalek = "2"

--- a/crates/confium-python/src/transparency.rs
+++ b/crates/confium-python/src/transparency.rs
@@ -353,7 +353,9 @@ fn verify_inclusion_with_leaf(
         };
     }
 
-    if current == root_hash {
+    use subtle::ConstantTimeEq;
+    let ok: bool = current.ct_eq(&root_hash).into();
+    if ok {
         Ok(())
     } else {
         Err(pyo3::exceptions::PyValueError::new_err(format!(

--- a/crates/confium-transparency/Cargo.toml
+++ b/crates/confium-transparency/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
+subtle = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/confium-transparency/src/merkle.rs
+++ b/crates/confium-transparency/src/merkle.rs
@@ -235,7 +235,8 @@ impl MerkleTree {
                 Side::Right => hash_internal(current, step.sibling),
             };
         }
-        if current == root {
+        use subtle::ConstantTimeEq;
+        if current.ct_eq(&root).into() {
             Ok(())
         } else {
             Err(MerkleError::InclusionFailed(entry.sequence))
@@ -427,7 +428,10 @@ impl MerkleTree {
         let computed_old_root = self.root_at_size(old_size);
         let computed_new_root = self.root();
 
-        if computed_old_root == old_root && computed_new_root == new_root {
+        use subtle::ConstantTimeEq;
+        let old_ok: bool = computed_old_root.ct_eq(&old_root).into();
+        let new_ok: bool = computed_new_root.ct_eq(&new_root).into();
+        if old_ok && new_ok {
             Ok(())
         } else {
             Err(MerkleError::ConsistencyFailed {

--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -65,6 +65,7 @@ chrono = { workspace = true }
 # Verifier-only deps — all WASM-friendly, no filesystem, no threads.
 sha2 = { workspace = true }
 p256 = { version = "0.13", features = ["ecdsa"] }
+subtle = { workspace = true }
 
 # WASM needs the `js` feature on getrandom so it falls back to
 # `crypto.getRandomValues` in the browser. Without it, getrandom fails to

--- a/crates/confium-wasm/src/transparency.rs
+++ b/crates/confium-wasm/src/transparency.rs
@@ -144,7 +144,8 @@ impl InclusionProof {
                 confium_transparency::merkle::Side::Right => hash_internal(current, step.sibling),
             };
         }
-        Ok(current == root_arr)
+        use subtle::ConstantTimeEq;
+        Ok(current.ct_eq(&root_arr).into())
     }
 }
 
@@ -302,5 +303,6 @@ pub fn verify_inclusion_with_head(
             confium_transparency::merkle::Side::Right => hash_internal(current, step.sibling),
         };
     }
-    Ok(current == root_arr)
+    use subtle::ConstantTimeEq;
+    Ok(current.ct_eq(&root_arr).into())
 }


### PR DESCRIPTION
## Summary

- Closes P0 #55 from `TODO.complete/53-remaining-work-catalog.md`: the constant-time comparison audit.
- Replaces Rust's short-circuiting `==` on `[u8; 32]` hash bytes with `subtle::ConstantTimeEq::ct_eq` at **7 timing-leak sites** across 5 crates. The `==` impl returns false on the first mismatched byte, leaking information about the real root hash to an attacker who can measure verification timing byte-by-byte.

### Sites fixed

- `confium-transparency/src/merkle.rs:238` — `verify_inclusion`
- `confium-transparency/src/merkle.rs:430` — `verify_consistency`
- `confium-wasm/src/transparency.rs:147` — `InclusionProof::verify`
- `confium-wasm/src/transparency.rs:305` — `verify_inclusion_with_head`
- `confium-python/src/transparency.rs:356` — inclusion verify
- `confium-log-monitor/src/verify.rs:35` — `verify_consistency` (hex strings decoded then `ct_eq`'d)
- `confium-log-monitor/src/verify.rs:110` — `verify_inclusion`

### Sites inspected and left as-is (safe)

- `confium-pki/src/cms/verify.rs:53,65` — cert serial / SKI byte comparisons are public identifiers, not secrets
- ed25519-dalek and p256 internal `verify()`: already constant-time
- p256 `Scalar` / `AffinePoint` `==`: constant-time by design

### Out of scope (sibling repo)

`confium-ruby/ext/confium_native/src/transparency.rs:224,258` has the same pattern; the Ruby gem lives in a sibling git repo and will be addressed in a separate PR.

## Test plan

- [x] `cargo build --workspace` — clean
- [x] `cargo test --workspace` — 1778 passed, 0 failed (no behavior change for honest callers)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
