### PR TITLE
test(composite): bring orphan proptest.rs online as test-only props module

### DIFF
--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -34,6 +34,9 @@ pub mod cache;
 pub mod cose;
 pub mod pq;
 
+#[cfg(test)]
+mod props;
+
 /// Algorithm identifier for Ed25519 components.
 pub const ED25519: &str = "Ed25519";
 /// Algorithm identifier for ECDSA-P256 components (NIST P-256 + SHA-256).

--- a/crates/confium-composite/src/props.rs
+++ b/crates/confium-composite/src/props.rs
@@ -1,8 +1,7 @@
 //! Property-based tests for composite signature verification.
 
 use crate::{
-    ComponentSignature, CompositeSignature, ED25519, build_ed25519_component,
-    ed25519_verifier,
+    ComponentSignature, CompositeSignature, ED25519, build_ed25519_component, ed25519_verifier,
 };
 use ed25519_dalek::SigningKey;
 use proptest::prelude::*;


### PR DESCRIPTION
## Summary

- Brings the `crates/confium-composite/src/proptest.rs` orphan (120 lines, 7 property tests) online as a test-only module.
- The orphan was flagged in TODO.complete/55 as needing a name fix because `mod proptest` shadowed the `proptest` crate, causing E0659 ("proptest is ambiguous") with the existing inline tests at `lib.rs:419`.

### Fix

Renamed `proptest.rs` → `props.rs` and declared it as `#[cfg(test)] mod props;` in lib.rs. The 7 property tests now run as part of `cargo test -p confium-composite`.

### Properties added

- `prop_verify_deterministic` — verifying a valid sig N times always succeeds
- `prop_tampered_signature_fails` — flipping any bit in sig fails verify
- `prop_tampered_message_fails` — flipping any bit in msg fails verify
- `prop_tampered_pubkey_fails` — flipping any bit in pk fails verify
- `prop_empty_composite_errors` — empty composite returns `CompositeError::Empty`
- `prop_component_count` — `component_count()` is always accurate
- `prop_algorithms_list` — `algorithms().len() == number of components`

## Test plan

- [x] `cargo test -p confium-composite` — 44 passed, 0 failed (was 37, +7)
- [x] `cargo clippy -p confium-composite --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
