### PR TITLE
test(composite): bring orphan wycheproof.rs online behind feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,6 +1027,7 @@ version = "0.4.7"
 dependencies = [
  "confium-transparency",
  "ed25519-dalek",
+ "hex",
  "p256",
  "proptest",
  "rand_core 0.6.4",

--- a/crates/confium-composite/Cargo.toml
+++ b/crates/confium-composite/Cargo.toml
@@ -18,6 +18,13 @@ keywords = ["crypto", "composite", "pqc", "signature", "confium"]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+[features]
+default = []
+# Wycheproof adversarial test vector integration. Off by default —
+# the vectors are 6 MB of JSON that callers download from
+# https://github.com/google/wycheproof on demand.
+wycheproof = ["dep:hex"]
+
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -26,6 +33,7 @@ sha2 = { workspace = true }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 rand_core = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa"] }
+hex = { version = "0.4", optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }

--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -37,6 +37,9 @@ pub mod pq;
 #[cfg(test)]
 mod props;
 
+#[cfg(feature = "wycheproof")]
+pub mod wycheproof;
+
 /// Algorithm identifier for Ed25519 components.
 pub const ED25519: &str = "Ed25519";
 /// Algorithm identifier for ECDSA-P256 components (NIST P-256 + SHA-256).

--- a/crates/confium-composite/src/wycheproof.rs
+++ b/crates/confium-composite/src/wycheproof.rs
@@ -56,9 +56,9 @@ struct TestCase {
     tc_id: u64,
     #[allow(dead_code)]
     comment: String,
-    msg: String,           // hex
-    sig: String,           // hex (DER for ECDSA)
-    result: String,        // "valid" | "invalid" | "acceptable"
+    msg: String,    // hex
+    sig: String,    // hex (DER for ECDSA)
+    result: String, // "valid" | "invalid" | "acceptable"
     #[allow(dead_code)]
     flags: Option<Vec<String>>,
 }
@@ -66,7 +66,10 @@ struct TestCase {
 /// Load a Wycheproof ECDSA-P256 JSON file and run every test case
 /// through `confium_composite`'s verifier. Returns the count of
 /// (passed, failed, acceptable).
-pub fn run_ecdsa_p256(path: &Path, verifier: impl Fn(&[u8], &[u8], &[u8]) -> bool) -> (usize, usize, usize) {
+pub fn run_ecdsa_p256(
+    path: &Path,
+    verifier: impl Fn(&[u8], &[u8], &[u8]) -> bool,
+) -> (usize, usize, usize) {
     let raw = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(_) => return (0, 0, 0),

--- a/crates/confium-composite/src/wycheproof.rs
+++ b/crates/confium-composite/src/wycheproof.rs
@@ -52,11 +52,14 @@ struct TestGroup {
 #[derive(Debug, Deserialize)]
 struct TestCase {
     #[serde(rename = "tcId")]
+    #[allow(dead_code)]
     tc_id: u64,
+    #[allow(dead_code)]
     comment: String,
     msg: String,           // hex
     sig: String,           // hex (DER for ECDSA)
     result: String,        // "valid" | "invalid" | "acceptable"
+    #[allow(dead_code)]
     flags: Option<Vec<String>>,
 }
 


### PR DESCRIPTION
## Summary

- Brings the last composite orphan (`crates/confium-composite/src/wycheproof.rs`, 113 lines) online behind a feature flag.
- Continues the orphan sweep from TODO.complete/55 (composite orphans) and TODO.complete/56 (transparency/frost-ed25519 orphans).

### Changes

The orphan was gated at the file level with `#![cfg(feature = "wycheproof")]` but no such feature existed in Cargo.toml. When manually enabled, it failed with 8 errors (unresolved `hex`, cascading `[u8]: Sized` errors) plus dead-code warnings.

- **Cargo.toml**: add `wycheproof = ["dep:hex"]` feature (off by default — vectors are 6 MB of JSON downloaded on demand) and `hex = { version = "0.4", optional = true }` dep.
- **lib.rs**: declare `#[cfg(feature = "wycheproof")] pub mod wycheproof;`.
- **wycheproof.rs**: mark `tc_id`, `comment`, `flags` fields with `#[allow(dead_code)]` so they're available for future diagnostic output without breaking `-D warnings`.

## Test plan

- [x] `cargo build -p confium-composite` — default (wycheproof off), clean
- [x] `cargo build -p confium-composite --features wycheproof` — wycheproof on, hex pulled in, clean
- [x] `cargo clippy -p confium-composite --all-targets --features wycheproof -- -D warnings` — 0 warnings
- [x] `cargo test -p confium-composite --features wycheproof` — passes (1 wycheproof test runs)
