### PR TITLE
test(tc): batch-sign tests for gg18 and frost-ed25519 (parity with cmp20)

### DIFF
--- a/crates/confium-tc-frost-ed25519/src/inprocess.rs
+++ b/crates/confium-tc-frost-ed25519/src/inprocess.rs
@@ -59,4 +59,31 @@ mod tests {
         let shares = keygen(3, 5).expect("dkg");
         assert!(sign(&shares[..2], 3, b"msg").is_err());
     }
+
+    #[test]
+    fn sign_batch_produces_one_sig_per_message() {
+        let shares = keygen(2, 3).expect("dkg");
+        let messages: Vec<&[u8]> = vec![b"msg-a", b"msg-b", b"msg-c", b"msg-d"];
+        let sigs = sign_batch(&shares[..2], 2, &messages).expect("batch sign");
+        assert_eq!(sigs.len(), 4);
+        for s in &sigs {
+            assert!(!s.is_empty());
+        }
+    }
+
+    #[test]
+    fn sign_batch_empty_messages_returns_empty() {
+        let shares = keygen(2, 3).expect("dkg");
+        let sigs = sign_batch(&shares[..2], 2, &[]).expect("empty batch");
+        assert!(sigs.is_empty());
+    }
+
+    #[test]
+    fn sign_batch_propagates_signing_error() {
+        let shares = keygen(3, 5).expect("dkg");
+        // threshold is 3 but we only supply 2 shares — each sign call must fail.
+        let messages: Vec<&[u8]> = vec![b"a", b"b"];
+        let err = sign_batch(&shares[..2], 3, &messages);
+        assert!(err.is_err());
+    }
 }

--- a/crates/confium-tc-gg18/src/inprocess.rs
+++ b/crates/confium-tc-gg18/src/inprocess.rs
@@ -139,4 +139,44 @@ mod tests {
         let err = sign(&[corrupt], 1, b"msg");
         assert!(err.is_err());
     }
+
+    #[test]
+    fn sign_batch_produces_one_sig_per_message() {
+        let kg = keygen(2, 3).expect("dkg");
+        let messages: Vec<&[u8]> = vec![b"msg-a", b"msg-b", b"msg-c", b"msg-d"];
+        let sigs = sign_batch(&kg.shares[..2], 2, &messages).expect("batch sign");
+        assert_eq!(sigs.len(), 4);
+        for s in &sigs {
+            assert_eq!(s.len(), 64);
+        }
+    }
+
+    #[test]
+    fn sign_batch_all_verify_under_joint_public_key() {
+        let kg = keygen(2, 3).expect("dkg");
+        let messages: Vec<&[u8]> = vec![b"a", b"b", b"c"];
+        let sigs = sign_batch(&kg.shares[..2], 2, &messages).expect("batch sign");
+        let pk = decode_public_key(&kg.public_key).expect("pk");
+        let vk = VerifyingKey::from_affine(pk).expect("vk");
+        for (msg, sig) in messages.iter().zip(sigs.iter()) {
+            let s = Signature::from_slice(sig).expect("parse sig");
+            vk.verify(msg, &s).expect("verify");
+        }
+    }
+
+    #[test]
+    fn sign_batch_empty_messages_returns_empty() {
+        let kg = keygen(2, 3).expect("dkg");
+        let sigs = sign_batch(&kg.shares[..2], 2, &[]).expect("empty batch");
+        assert!(sigs.is_empty());
+    }
+
+    #[test]
+    fn sign_batch_propagates_signing_error() {
+        let kg = keygen(3, 5).expect("dkg");
+        // threshold is 3 but we only supply 2 shares — each sign call must fail.
+        let messages: Vec<&[u8]> = vec![b"a", b"b"];
+        let err = sign_batch(&kg.shares[..2], 3, &messages);
+        assert!(err.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

- Closes P3 #62 from `TODO.complete/53-remaining-work-catalog.md`: TC batch-sign test parity.
- The `sign_batch` API shipped in all three TC inprocess drivers (cmp20, gg18, frost-ed25519) in a prior session, but only CMP20 had batch tests. This PR adds matching coverage to GG18 and FROST-ed25519.

### Tests added

**GG18** (`crates/confium-tc-gg18/src/inprocess.rs`) — 4 new tests:
- `sign_batch_produces_one_sig_per_message`
- `sign_batch_all_verify_under_joint_public_key`
- `sign_batch_empty_messages_returns_empty`
- `sign_batch_propagates_signing_error`

**FROST-ed25519** (`crates/confium-tc-frost-ed25519/src/inprocess.rs`) — 3 new tests:
- `sign_batch_produces_one_sig_per_message`
- `sign_batch_empty_messages_returns_empty`
- `sign_batch_propagates_signing_error`

Did not duplicate the "verify under joint key" test for FROST-ed25519 because the inprocess module doesn't expose a public key decoder (Ed25519 joint key handling differs); the existing single-sign test already exercises verification.

## Test plan

- [x] `cargo test -p confium-tc-gg18 inprocess::` — 8 passed (was 4)
- [x] `cargo test -p confium-tc-frost-ed25519 inprocess::` — 5 passed (was 2)
- [x] `cargo clippy -p confium-tc-gg18 -p confium-tc-frost-ed25519 --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
