### PR TITLE
refactor: declare 2 more orphans (wasm signer, transparency test_vectors)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,7 @@ version = "0.4.7"
 dependencies = [
  "chrono",
  "criterion",
+ "hex",
  "proptest",
  "serde",
  "serde_json",

--- a/crates/confium-transparency/Cargo.toml
+++ b/crates/confium-transparency/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = { workspace = true }
 chrono = { workspace = true }
 sha2 = { workspace = true }
 subtle = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/crates/confium-transparency/src/lib.rs
+++ b/crates/confium-transparency/src/lib.rs
@@ -38,6 +38,7 @@ pub mod ers;
 pub mod merkle;
 pub mod ots;
 pub mod proof;
+pub mod test_vectors;
 pub mod witness;
 
 #[cfg(test)]

--- a/crates/confium-transparency/src/test_vectors.rs
+++ b/crates/confium-transparency/src/test_vectors.rs
@@ -73,10 +73,7 @@ pub fn generate_vector(n: u64) -> TestVector {
                 },
             })
             .collect();
-        proofs.push(InclusionProofJson {
-            sequence: i,
-            steps,
-        });
+        proofs.push(InclusionProofJson { sequence: i, steps });
     }
 
     let artifact_hashes: Vec<String> = (0..n).map(|i| hex::encode([i as u8; 32])).collect();
@@ -239,7 +236,10 @@ mod tests {
     fn power_of_two_tree_has_clean_proofs() {
         let vector = generate_vector(8);
         for proof in &vector.inclusion_proofs {
-            assert!(proof.steps.len() <= 4, "8-entry tree has at most 4 proof steps");
+            assert!(
+                proof.steps.len() <= 4,
+                "8-entry tree has at most 4 proof steps"
+            );
         }
     }
 }

--- a/crates/confium-wasm/src/lib.rs
+++ b/crates/confium-wasm/src/lib.rs
@@ -44,6 +44,12 @@ mod pki;
 #[cfg(feature = "verify-pki")]
 pub use pki::{Certificate, SignedData};
 
+#[cfg(feature = "sign")]
+mod signer;
+
+#[cfg(feature = "sign")]
+pub use signer::{Cmp20Signer, Gg18Signer};
+
 /// Package version (mirrors the Cargo version).
 #[wasm_bindgen]
 pub fn version() -> String {

--- a/crates/confium-wasm/src/signer.rs
+++ b/crates/confium-wasm/src/signer.rs
@@ -117,8 +117,8 @@ impl Gg18Signer {
     /// Run a GG18 DKG.
     #[wasm_bindgen]
     pub fn keygen(&self, threshold: u32, party_count: u32) -> Result<JsValue, JsValue> {
-        let kg = confium_tc_gg18::inprocess::keygen(threshold, party_count as usize)
-            .map_err(map_err)?;
+        let kg =
+            confium_tc_gg18::inprocess::keygen(threshold, party_count as usize).map_err(map_err)?;
         let obj = js_sys::Object::new();
         let shares = js_sys::Array::new();
         for s in kg.shares {


### PR DESCRIPTION
## Summary

- Continues the orphan sweep from TODO.complete/55, /56, /62, /64.
- Brings 2 more dead-code-by-omission orphans online.

### Declared

- **`crates/confium-wasm/src/signer.rs`** (158L): WASI-target CMP20/GG18 threshold signer surface for edge worker hosts (Cloudflare Workers, Fastly Compute@Edge, Vercel Edge, Deno, Bun, Wasmtime, Wasmer, WasmEdge). Declared as `#[cfg(feature = "sign")] pub mod signer;` in lib.rs.
- **`crates/confium-transparency/src/test_vectors.rs`** (245L): Deterministic test-vector generator used by binding verification suites (Ruby, Python, WASM, Go). Adds `TestVector` struct + `generate_vector` / `generate_suite` / `verify_vector` / `suite_to_json` functions. Declared as `pub mod test_vectors;`. Required adding `hex = { workspace = true }` to transparency deps.

### Verification

- `cargo build -p confium-wasm` — default verifier build unchanged
- `cargo build -p confium-wasm --features sign` — pulls in tc-cmp20/-gg18/-frost-p256/-elgamal-p256, builds clean
- `cargo build -p confium-transparency` — clean
- `cargo test --workspace` — 1838 passed, 0 failed (was 1829, +9 test_vectors tests)

## Test plan

- [x] `cargo build -p confium-wasm` — clean
- [x] `cargo build -p confium-wasm --features sign` — clean
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo test --workspace` — 1838 passed, 0 failed
