### PR TITLE
chore(pki): remove obsolete synthetic_cert() unimplemented stub

### DIFF
--- a/crates/confium-pki/src/path.rs
+++ b/crates/confium-pki/src/path.rs
@@ -86,15 +86,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cert::Certificate;
-
-    #[allow(dead_code)] // placeholder until real cert fixtures land
-    fn synthetic_cert() -> Certificate {
-        // We can't easily generate a real cert in pure-Rust no-deps mode.
-        // Path validation tests require real cert chains, which belong in
-        // integration tests. This module's logic is exercised there.
-        unimplemented!("use integration tests with real cert fixtures")
-    }
 
     #[test]
     fn empty_path_is_valid() {


### PR DESCRIPTION
## Summary

- Cleanup: removes the obsolete `synthetic_cert()` `unimplemented!()` stub from `crates/confium-pki/src/path.rs`.
- PR #173 (TODO.complete/58) landed real cert-chain integration tests in `tests/path_validation.rs` using rcgen. The stub helper is no longer needed.

Eliminates one of the three `unimplemented!()` call sites in production code. The other two are inside doc-comments (`confium-store/src/backend.rs:141`, `confium-tc-core/src/registry.rs:135`), which are intentional skeletal example demos.

## Test plan

- [x] `cargo test -p confium-pki` — passes
- [x] `cargo clippy -p confium-pki --all-targets -- -D warnings` — 0 warnings
