### PR TITLE
feat(python): bring tc.rs orphan online + fix standalone workspace

### DIFF
--- a/crates/confium-python/Cargo.lock
+++ b/crates/confium-python/Cargo.lock
@@ -3,41 +3,6 @@
 version = 4
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,35 +75,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
-name = "confium-api"
-version = "0.3.0"
-dependencies = [
- "confium-macros",
- "inventory",
-]
-
-[[package]]
 name = "confium-attributes"
-version = "0.3.1"
+version = "0.4.7"
 dependencies = [
- "serde",
- "serde_json",
  "thiserror",
 ]
 
 [[package]]
 name = "confium-composite"
-version = "0.3.1"
+version = "0.4.7"
 dependencies = [
  "ed25519-dalek",
  "p256",
@@ -150,55 +95,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "confium-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c04ce5720fe1ce32a7b4809e2d6325f39ce9cd5795f4bd2a53c45fcfc5eae02"
-dependencies = [
- "aes-gcm",
- "inventory",
- "libloading",
- "rand",
- "snafu",
- "zeroize",
-]
-
-[[package]]
 name = "confium-deployment"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "chrono",
- "data-encoding",
  "serde",
  "serde_json",
- "snafu",
  "thiserror",
  "toml",
- "url",
-]
-
-[[package]]
-name = "confium-macros"
-version = "0.3.0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "confium-net"
-version = "0.3.0"
-dependencies = [
- "confium-api",
- "inventory",
- "snafu",
- "url",
 ]
 
 [[package]]
 name = "confium-pki"
-version = "0.3.1"
+version = "0.4.7"
 dependencies = [
  "chrono",
  "data-encoding",
@@ -206,20 +115,17 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "snafu",
- "spki",
  "thiserror",
  "x509-cert",
 ]
 
 [[package]]
 name = "confium-python"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "chrono",
  "confium-attributes",
  "confium-composite",
- "confium-core",
  "confium-deployment",
  "confium-pki",
  "confium-tc-cmp20",
@@ -233,28 +139,21 @@ dependencies = [
  "pyo3",
  "serde_json",
  "sha2",
-]
-
-[[package]]
-name = "confium-store"
-version = "0.3.0"
-dependencies = [
- "confium-api",
- "inventory",
- "snafu",
+ "subtle",
 ]
 
 [[package]]
 name = "confium-tc"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "chrono",
- "confium-api",
- "confium-net",
- "confium-store",
- "data-encoding",
+ "confium-tc-core",
  "hmac",
  "inventory",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "rand_core",
  "serde",
  "serde_json",
  "sha2",
@@ -265,69 +164,82 @@ dependencies = [
 
 [[package]]
 name = "confium-tc-cmp20"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "confium-tc",
  "crypto-bigint",
  "elliptic-curve",
+ "inventory",
+ "num-bigint",
+ "p256",
+ "rand",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
+name = "confium-tc-core"
+version = "0.4.7"
+dependencies = [
+ "chrono",
  "hex",
+ "hmac",
  "inventory",
  "p256",
+ "rand_core",
+ "serde",
+ "serde_json",
  "sha2",
  "snafu",
+ "subtle",
+ "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "confium-tc-elgamal-p256"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
- "elliptic-curve",
  "p256",
  "serde",
- "sha2",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "confium-tc-frost-p256"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "elliptic-curve",
- "hex",
  "p256",
  "rand_core",
- "serde",
- "sha2",
  "thiserror",
+ "zeroize",
 ]
 
 [[package]]
 name = "confium-tc-gg18"
-version = "0.3.0"
+version = "0.4.7"
 dependencies = [
  "confium-tc",
  "crypto-bigint",
  "elliptic-curve",
- "hex",
  "inventory",
  "p256",
  "sha2",
- "snafu",
  "zeroize",
 ]
 
 [[package]]
 name = "confium-transparency"
-version = "0.4.0"
+version = "0.4.7"
 dependencies = [
  "chrono",
- "data-encoding",
+ "hex",
  "serde",
  "serde_json",
  "sha2",
- "snafu",
+ "subtle",
  "thiserror",
 ]
 
@@ -371,17 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -451,17 +353,6 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 3.0.3",
 ]
 
 [[package]]
@@ -560,15 +451,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
-name = "form_urlencoded"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -612,16 +494,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -687,108 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_collections"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
-dependencies = [
- "displaydoc",
- "potential_utf",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locale_core"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
-dependencies = [
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
-
-[[package]]
-name = "icu_properties"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_properties_data",
- "icu_provider",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
-
-[[package]]
-name = "icu_provider"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
-dependencies = [
- "displaydoc",
- "icu_locale_core",
- "writeable",
- "yoke",
- "zerofrom",
- "zerotrie",
- "zerovec",
-]
-
-[[package]]
-name = "idna"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
-dependencies = [
- "idna_adapter",
- "smallvec",
- "utf8_iter",
-]
-
-[[package]]
-name = "idna_adapter"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,15 +575,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -849,22 +610,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "litemap"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
-
-[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,6 +631,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "rand",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,12 +664,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "p256"
@@ -929,12 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -951,31 +704,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "potential_utf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
-dependencies = [
- "zerovec",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1260,12 +992,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "smallvec"
-version = "1.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
-
-[[package]]
 name = "snafu"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,12 +1023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,17 +1051,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,16 +1074,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -1456,34 +1155,6 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
-name = "url"
-version = "2.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
- "serde",
-]
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -1611,12 +1282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "writeable"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,67 +1296,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "yoke"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
-dependencies = [
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
-]
-
-[[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
- "synstructure",
 ]
 
 [[package]]
@@ -1708,39 +1329,6 @@ name = "zeroize_derive"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "zerotrie"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.11.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confium-python"
-version.workspace = true
+version = "0.4.7"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Ribose Open <open.source@ribose.com>"]
@@ -22,6 +22,10 @@ confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
 confium-pki = { path = "../confium-pki", version = "0.4.0", features = ["cms"] }
 confium-attributes = { path = "../confium-attributes", version = "0.4.0" }
 confium-deployment = { path = "../confium-deployment", version = "0.4.0" }
+confium-tc-cmp20 = { path = "../confium-tc-cmp20", version = "0.4.0" }
+confium-tc-elgamal-p256 = { path = "../confium-tc-elgamal-p256", version = "0.4.0" }
+confium-tc-frost-p256 = { path = "../confium-tc-frost-p256", version = "0.4.0" }
+confium-tc-gg18 = { path = "../confium-tc-gg18", version = "0.4.0" }
 pyo3 = { version = "0.22", features = ["extension-module"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/confium-python/src/deployment.rs
+++ b/crates/confium-python/src/deployment.rs
@@ -6,7 +6,7 @@
 //! - [`validate_manifest`] — validate a manifest's internal consistency.
 
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList, PyString};
+use pyo3::types::{PyList, PyString};
 
 use confium_deployment::{validate_manifest as rust_validate, Manifest as RustManifest,
     parse_manifest as rust_parse, manifest_to_toml as rust_to_toml};

--- a/crates/confium-python/src/lib.rs
+++ b/crates/confium-python/src/lib.rs
@@ -22,6 +22,7 @@ pub mod deployment;
 pub mod ers;
 pub mod ots;
 pub mod pki;
+pub mod tc;
 pub mod transparency;
 pub mod version;
 pub mod xmldsig;
@@ -40,6 +41,7 @@ fn confium(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     ers::register_module(py, m)?;
     ots::register_module(py, m)?;
     pki::register_module(py, m)?;
+    tc::register_module(py, m)?;
     transparency::register_module(py, m)?;
     xmldsig::register_module(py, m)?;
 

--- a/crates/confium-python/src/xmldsig.rs
+++ b/crates/confium-python/src/xmldsig.rs
@@ -6,7 +6,6 @@
 //! - [`xmldsig_canonicalize_exclusive`] — Exclusive C14N (RFC 3741)
 
 use pyo3::prelude::*;
-use pyo3::types::PyString;
 
 /// Canonicalize XML per RFC 3076 (Canonical XML 1.0).
 ///


### PR DESCRIPTION
## Summary

- Brings the `crates/confium-python/src/tc.rs` orphan (391 lines) online.
- Fixes a broken standalone-workspace declaration that prevented `cd crates/confium-python && cargo check` from working.

### What changed

1. **Standalone workspace fix**: `Cargo.toml` used `version.workspace = true` but the `[workspace]` block was empty. Replaced with hardcoded `version = "0.4.7"` (current workspace version).

2. **`tc.rs` orphan declared**: added `pub mod tc;` to `lib.rs` and wired `tc::register_module(py, m)?;` into the `#[pymodule]` entry point. Added the four required path-deps: `confium-tc-cmp20`, `confium-tc-elgamal-p256`, `confium-tc-frost-p256`, `confium-tc-gg18`.

3. **Cleanup of pre-existing unused imports**: removed unused `PyDict` from `deployment.rs`, removed unused `PyString` import from `xmldsig.rs`.

### What is NOT fixed

- `errors.rs` orphan (40 lines) remains blocked by Rust's orphan rule (both `From` and `PyErr` are foreign). Documented in orphan-rule-blocks-pyerr-from-impls memory.
- ~55 pre-existing clippy warnings in the Python crate (mostly "useless conversion to `PyErr`" and one "items after a test module" lint). Predate this PR, out of scope for orphan cleanup, and not gated by main CI since the Python crate isn't a workspace member.

## Test plan

- [x] `cd crates/confium-python && cargo check` — clean (was failing on the workspace-inheritance error)
- [x] `cargo build --workspace` — main workspace unaffected
- [x] No Rust-side tests added (Python crate uses pytest after maturin builds the extension)
