### PR TITLE
docs: update stale test + crate counts after recent growth

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,12 +148,12 @@ struct MyPlugin;
 
 == Workspace
 
-65 crates, 1730+ tests, 0 failures.
+65 crates, 1848+ tests, 0 failures.
 
 [source,sh]
 ----
 cargo build --workspace      # builds all 65 crates
-cargo test --workspace       # 1730+ tests pass
+cargo test --workspace       # 1848+ tests pass
 cargo clippy --workspace --all-targets -- -D warnings
 ----
 

--- a/docs/bindings/parity.mdx
+++ b/docs/bindings/parity.mdx
@@ -81,7 +81,7 @@ main Rust workspace.
 
 ### Rust
 
-The native API. Every other binding wraps this. Source: the 44-crate
+The native API. Every other binding wraps this. Source: the 65-crate
 workspace at the repo root.
 
 ## See also

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -70,7 +70,7 @@ cargo build --workspace
 cargo test --workspace
 ```
 
-The suite covers 1700+ unit and integration tests across all 65 crates.
+The suite covers 1848+ unit and integration tests across all 65 crates.
 
 ## Verifying the install
 


### PR DESCRIPTION
## Summary

- README.adoc and docs had stale test/crate counts after recent growth.

### What changed

- **README.adoc**: 1730+ → 1848+ tests (actual count after the orphan-cleanup sprint that added ~120 tests).
- **docs/installation.mdx**: 1700+ → 1848+ tests.
- **docs/bindings/parity.mdx**: "44-crate workspace" → "65-crate workspace" (the 44-crate count was from before the v0.4 product-restructuring arc).

## Test plan

- [x] `grep -rEn "1730\+|1700\+|44-crate" docs/ README.adoc` — only the corrected sites match
- [x] No code changes, docs only
