### PR TITLE
docs(cookbook): use openssl to verify threshold ECDSA signature

### DIFF
--- a/docs/cookbook/threshold-sign-with-cmp20.mdx
+++ b/docs/cookbook/threshold-sign-with-cmp20.mdx
@@ -25,11 +25,11 @@ confium threshold sign \
     --message "payload to sign" \
     --out signature.hex
 
-# 3. Verify
-confium verify ecdsa-p256 \
-    --message "payload to sign" \
-    --signature "$(cat signature.hex)" \
-    --public-key "$(jq -r .public_key shares.json)"
+# 3. Verify with openssl (Confium outputs standard P-256 ECDSA):
+openssl pkeyutl -verify -pubin \
+    -inkey <(jq -r .public_key shares.json | openssl pkey -pubin -inform DER) \
+    -sigfile <(xxd -r -p signature.hex) \
+    -in <(printf 'payload to sign' | openssl dgst -sha256 -binary)
 ```
 
 ## What's happening


### PR DESCRIPTION
## Summary

- Fixes `docs/cookbook/threshold-sign-with-cmp20.mdx` — the recipe showed a CLI command that doesn't exist (`confium verify ecdsa-p256`).

### What changed

Step 3 of the recipe (verify the threshold signature) used `confium verify ecdsa-p256 --message ... --signature ... --public-key ...`. There's no such command. The closest existing CLI command is `confium verify composite`, which expects COSE-encoded composite signatures — different input shape than the raw `(r, s)` ECDSA pair that `confium threshold sign` produces.

Confium's threshold signatures are standard ECDSA-P256, so any standards-compliant verifier works. Switched the recipe to `openssl pkeyutl -verify`, which is the canonical CLI verifier. The recipe's existing "What's happening" section already says "Any verifier (OpenSSL, browser, the p256 crate) accepts Confium signatures" — this change just makes step 3 match that claim.

## Test plan

- [x] Docs-only change, no code
