### PR TITLE
docs(crates): fix API references in composite, frost-p256, transparency deep dives

### DIFF
--- a/docs/crates/composite.mdx
+++ b/docs/crates/composite.mdx
@@ -25,25 +25,30 @@ Use `confium-composite` when:
 
 ## Public API
 
-The crate exposes a `CompositeSignature` value type and a
-`CompositeVerifier` that dispatches per-component verification to
-pluggable per-algorithm verifiers.
+The crate exposes a `CompositeSignature` value type. Verification
+takes a closure that dispatches per component — you supply the
+verifier for each algorithm the composite contains.
 
 ```rust
-use confium_composite::{CompositeSignature, CompositeVerifier, VerifierCallback};
+use confium_composite::{CompositeSignature, ed25519_verifier, ED25519};
 
 let composite: CompositeSignature = /* ... */;
-let verifier = CompositeVerifier::new()
-    .with("1.3.101.112", my_ed25519_verifier)       // Ed25519
-    .with("1.2.840.10045.4.3.2", my_ecdsa_verifier) // ECDSA-P256
-    .with("2.16.840.1.101.3.4.3.18", my_ml_dsa_65_verifier);
+let result = composite.verify(&message, |alg, pk, msg, sig| {
+    if alg == ED25519 {
+        ed25519_verifier(alg, pk, msg, sig)
+    } else {
+        // Route other algorithms to their verifiers.
+        Err(format!("no verifier for {alg}"))
+    }
+})?;
 
-let valid: bool = verifier.verify(&composite, &message)?;
+// result.all_verified — true iff every component verified
+// result.per_component — Vec<ComponentResult> with per-algorithm detail
 ```
 
-Per-algorithm verifiers implement the `VerifierCallback` trait, so
-you can route verification through any crypto backend (Botan plugin,
-OpenSSL provider, in-process crate).
+Built-in verifiers ship for Ed25519 (`ed25519_verifier`) and
+ECDSA-P256 (`p256_verifier`). Route other algorithms through your
+own backend (Botan plugin, OpenSSL provider) inside the closure.
 
 ## Verification semantics
 
@@ -55,17 +60,17 @@ A composite signature is **valid** if and only if:
    jurisdictional policy may require ≥1 classical + ≥1 PQ algorithm).
 
 A missing verifier for any component is a hard failure, not a
-soft-accept. Configure `CompositeVerifier` to include every algorithm
-the deployment expects to encounter.
+soft-accept. Include every algorithm the deployment expects to
+encounter in your verify closure.
 
 ## Security notes
 
 - **No silent downgrade**: if a verifier is missing for a component,
   verification fails. The crate never silently accepts on the
   subset of components it can verify.
-- **Callback isolation**: per-algorithm verifiers run as isolated
-  callbacks. A panic or error in one does not corrupt the others;
-  each result is collected and AND-reduced at the end.
+- **Callback isolation**: per-algorithm verification runs as isolated
+  closure invocations. An error in one does not short-circuit the
+  others; each result is collected and AND-reduced at the end.
 - **Constant-time where it matters**: the per-algorithm verifiers
   supplied by the caller are responsible for their own constant-time
   guarantees. The composite layer does not introduce branches that

--- a/docs/crates/frost-p256.mdx
+++ b/docs/crates/frost-p256.mdx
@@ -21,29 +21,33 @@ Use `confium-tc-frost-p256` when:
 - You are building a Mode 2 PKI drop-in that must produce signatures
   indistinguishable from single-key ECDSA-P256.
 
+For production threshold ECDSA signing where the secret is never
+reconstructed, prefer `confium-tc-cmp20` (which implements the MtA
+sub-protocol this crate defers).
+
 ## Public API
 
 ```rust
-use confium_tc_frost_p256::FrostP256;
+use confium_tc_frost_p256::{generate_keypair, recover_secret,
+    sign_message, split_secret};
 
 // Generate a keypair.
-let kp = FrostP256::generate_keypair()?;
+let kp = generate_keypair();
+// kp.secret_scalar — p256::Scalar (zeroized on drop)
+// kp.public_key    — p256::AffinePoint
 
 // Split into 5 shares, threshold 3.
-let shares = FrostP256::split_secret(&kp.private_key, 3, 5)?;
+let shares = split_secret(&kp.secret_scalar, 3, 5);
 
 // Recover the secret from any 3 shares.
-let recovered = FrostP256::recover_secret(&[
-    shares[0].as_ref(),
-    shares[2].as_ref(),
-    shares[4].as_ref(),
-])?;
-assert_eq!(recovered, kp.private_key);
+let subset: Vec<&_> = vec![&shares[0], &shares[2], &shares[4]];
+let recovered = recover_secret(&subset).expect("recover");
+assert_eq!(recovered, kp.secret_scalar);
 
 // Sign with the original key.
-let sig = FrostP256::sign(&kp.private_key, b"threshold test")?;
-// sig.der     — DER-encoded ECDSA signature (RFC 3279)
-// sig.fixed   — fixed-length (r || s) encoding
+let signed = sign_message(&kp, b"threshold test").expect("sign");
+// signed.der_bytes   — DER-encoded ECDSA signature (RFC 3279)
+// signed.fixed_bytes — fixed-length (r || s) encoding
 ```
 
 ## Shamir secret sharing
@@ -70,12 +74,12 @@ is overdetermined and the crate verifies consistency.
 - **Share format**: shares are `(x, y)` pairs over the P-256 scalar
   field. The crate serializes them as fixed-length byte arrays.
 - **No network code**: the crate is pure crypto. Multi-party session
-  orchestration is provided by `confium-tc-coordinator`.
+  orchestration is provided by `confium-coordinator`.
 
 ## Related
 
 - [Threshold signing example](../examples/threshold-signing.mdx) —
   end-to-end demo using this crate.
-- [`confium-tc-coordinator`](https://docs.rs/confium-coordinator) — for multi-party
+- [`confium-coordinator`](https://docs.rs/confium-coordinator) — for multi-party
   sessions across network boundaries.
-- [`confium-tc-reshare`](https://docs.rs/confium-tc-core) — proactive share refresh.
+- [`confium-tc-core` reshare](https://docs.rs/confium-tc-core) — proactive share refresh.

--- a/docs/crates/transparency.mdx
+++ b/docs/crates/transparency.mdx
@@ -39,10 +39,16 @@ For a consistency proof between two tree sizes:
 
 ```rust
 let proof: Vec<[u8; 32]> = tree.consistency_proof(old_size)?;
-confium_transparency::MerkleTree::verify_consistency(
+tree.verify_consistency(
     old_root, new_root, old_size, new_size, &proof,
 )?;
 ```
+
+Note: `verify_consistency` is a method on the tree (not a static
+function) — the current implementation brute-force-verifies by
+recomputing the root at `old_size`, so it needs the tree's leaf
+hashes. External proof-only verification (no tree) is planned for
+a follow-up.
 
 ## Leaf hashing
 


### PR DESCRIPTION
## Summary

- Fixes API references in three crate deep-dive docs that showed non-existent or wrong-shaped APIs.

### What changed

**`docs/crates/composite.mdx`**: showed `CompositeVerifier::new().with(...)` builder and a `VerifierCallback` trait — neither exists. The real API is a closure passed to `CompositeSignature::verify(message, closure)`, with built-in `ed25519_verifier` / `p256_verifier` helpers. Rewrote the Public API section and adjusted the related prose.

**`docs/crates/frost-p256.mdx`**: same issue as the example doc fixed in PR #196 — `FrostP256::generate_keypair()` etc. on a non-existent struct. Real API is free functions (`generate_keypair`, `split_secret`, `recover_secret`, `sign_message`). Field names corrected (`secret_scalar`, `der_bytes`/`fixed_bytes`).

**`docs/crates/transparency.mdx`**: showed `MerkleTree::verify_consistency(...)` as an associated-function call. It's actually a `&self` method — the current implementation brute-force-verifies by recomputing the root at `old_size`, so it needs the tree. Fixed the snippet and noted the external-proof-only gap.

## Test plan

- [x] Docs-only change, no code
