### PR TITLE
docs: fix three CLI command references that don't exist

### DIFF
--- a/docs/install.mdx
+++ b/docs/install.mdx
@@ -34,7 +34,11 @@ Verify with:
 
 ```sh
 sha256sum -c confium-X.Y.Z-linux-x86_64.tar.gz.sha256
-confium verify --signature checksum.sig --public-key release-pubkey.pem checksum.sha256
+confium verify composite \
+    --message checksum.sha256 \
+    --signature checksum.sig.cose \
+    --algorithm ed25519 \
+    --public-key release-pubkey.pub
 ```
 
 The release pubkey is published in the repo's `SECURITY.md` and

--- a/docs/migrations/0.2-to-0.3.mdx
+++ b/docs/migrations/0.2-to-0.3.mdx
@@ -104,7 +104,7 @@ confium tc keygen --threshold 2 --parties 3
 
 New (umbrella commands):
 ```
-confium threshold keygen --threshold 2 --parties 3
+confium threshold dkg --threshold 2 --parties 3 --scheme cmp20
 ```
 
 Old commands still work as aliases for back-compat in 0.3.x. They'll be removed in 0.5.

--- a/docs/plugin-author-guide.mdx
+++ b/docs/plugin-author-guide.mdx
@@ -168,16 +168,20 @@ The output is `target/release/libmy_plugin.so` (Linux),
 
 ## Step 6: load and test
 
-Use the CLI to load your plugin and exercise it:
+For local testing, load the plugin via `libloading` in a test
+binary, or link it into the daemon. See
+`crates/confium-mock-plugin/` for a reference implementation and
+`crates/confium-test-harness/` for the NIST-style test vectors
+harness.
+
+Once the plugin is published to the registry (Step 7 below), the
+CLI can install and exercise it:
 
 ```sh
-confium load --path ./target/release/libmy_plugin.so --name my-hash
-confium hash --provider my-hash --algorithm sha256 --input "hello"
+confium install my-hash           # from the registry
+confium list
+confium info my-hash
 ```
-
-For automated testing, see `crates/confium-mock-plugin/` for a reference
-implementation and `crates/confium-test-harness/` for the NIST-style test
-vectors harness.
 
 ## Step 7: publish to the registry
 


### PR DESCRIPTION
## Summary

- Fixes three docs that showed CLI commands which aren't in the actual `confium-cli` surface.

### What changed

**`docs/install.mdx`** ("Verifying downloads"): showed bare `confium verify --signature ... --public-key ... checksum.sha256`. The CLI requires a subcommand; the right one is `confium verify composite` with `--message`/`--signature`/`--algorithm`/`--public-key` flags. Fixed.

**`docs/plugin-author-guide.mdx`** (Step 6 "load and test"): showed `confium load --path ...` and `confium hash --provider ...` — neither command exists. Local plugin testing uses `libloading` in a test binary (see `confium-mock-plugin` / `confium-test-harness`); the CLI's `install`/`info`/`list` commands operate on registry-published plugins. Rewrote the step to match.

**`docs/migrations/0.2-to-0.3.mdx`**: showed `confium threshold keygen` as the new command — the actual subcommand is `threshold dkg` (with `--scheme`). Fixed.

## Test plan

- [x] Docs-only change, no code
