### PR TITLE
perf(transparency): O(1) perfect_subtree_root via cached levels

### DIFF
--- a/crates/confium-transparency/src/merkle.rs
+++ b/crates/confium-transparency/src/merkle.rs
@@ -349,17 +349,36 @@ impl MerkleTree {
     }
 
     /// Compute the root of a PERFECT binary subtree of `size` leaves
-    /// starting at `start`. `size` must be a power of 2. Used by
-    /// [`subtree_root`](Self::subtree_root) for each entry in the
-    /// compact frontier decomposition.
+    /// starting at `start`. `size` must be a power of 2 and `start` a
+    /// multiple of `size` (the alignment the consistency recursion
+    /// guarantees). Used by [`subtree_root`](Self::subtree_root) for each
+    /// entry in the compact frontier decomposition.
+    ///
+    /// O(1): reads the subtree root straight out of the cached tree
+    /// levels — an aligned perfect subtree of `size = 2^j` leaves rooted
+    /// at leaf offset `start` has its root at
+    /// `levels[j][start / 2^j]`. Falls back to rehashing from the leaves
+    /// when the cache is unavailable (empty tree edge cases).
     fn perfect_subtree_root(&self, start: usize, size: usize) -> Hash {
         debug_assert!(
             size.is_power_of_two(),
             "perfect_subtree_root: size must be pow2"
         );
+        debug_assert!(
+            start % size == 0,
+            "perfect_subtree_root: start must be size-aligned"
+        );
         if size == 1 {
             return self.leaf_hashes[start];
         }
+        let j = size.trailing_zeros() as usize; // log2(size)
+        if let Some(level) = self.levels.get(j) {
+            let idx = start / size;
+            if let Some(&h) = level.get(idx) {
+                return h;
+            }
+        }
+        // Cache miss (shouldn't happen for valid ranges) — recompute.
         let mut level: Vec<Hash> = self.leaf_hashes[start..start + size].to_vec();
         while level.len() > 1 {
             let mut next = Vec::with_capacity(level.len() / 2);


### PR DESCRIPTION
## Summary

- Follow-up to the TODO.complete/60 inclusion-proof optimization: `consistency_proof` had the same O(N) rehashing problem, now fixed via the cached tree levels.

### What changed

`perfect_subtree_root(start, size)` rehashed `size` leaves on every call. The consistency-proof recursion calls it once per frontier entry, so `consistency_proof` was O(N) hashing per call.

The tree already caches every intermediate level (added in the earlier inclusion-proof optimization). An aligned perfect subtree of `size = 2^j` leaves rooted at leaf offset `start` has its root at `levels[j][start / 2^j]` — reading it is O(1).

The alignment invariant holds: `consistency_rec` only ever calls `subtree_root` with `(start, size)` where `start` is a multiple of `size` (induction over the recursion: `k'` divides `k` for the pow2 split). The frontier decomposition inside `subtree_root` keeps offsets aligned the same way. Guarded by `debug_assert`s; falls back to the original rehash path defensively.

### Benchmark

`transparency_consistency_proof/build/100`: **1.06 µs** after the change. Scaling is now bounded by the recursion depth (O(log N)) rather than tree size.

## Test plan

- [x] `cargo test -p confium-transparency` — 54 passed (including the consistency round-trips at sizes 1–16 which would catch a wrong root)
- [x] `cargo test --workspace` — 1848 passed, 0 failed
- [x] `cargo clippy -p confium-transparency --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo bench -p confium-benchmarks --bench transparency` — runs clean
