### PR TITLE
perf(transparency): O(log N) verify_consistency + fix broken consistency bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,7 @@ dependencies = [
 name = "confium-benchmarks"
 version = "0.4.7"
 dependencies = [
+ "chrono",
  "confium-composite",
  "confium-tc-cmp20",
  "confium-tc-frost-p256",

--- a/crates/confium-benchmarks/Cargo.toml
+++ b/crates/confium-benchmarks/Cargo.toml
@@ -18,6 +18,7 @@ confium-transparency = { path = "../confium-transparency", version = "0.4.0" }
 confium-tc-cmp20 = { path = "../confium-tc-cmp20", version = "0.4.0" }
 confium-tc-gg18 = { path = "../confium-tc-gg18", version = "0.4.0" }
 confium-tc-frost-p256 = { path = "../confium-tc-frost-p256", version = "0.4.0" }
+chrono = { workspace = true }
 criterion = { workspace = true }
 ed25519-dalek = { workspace = true }
 p256 = { workspace = true }

--- a/crates/confium-benchmarks/benches/transparency.rs
+++ b/crates/confium-benchmarks/benches/transparency.rs
@@ -5,17 +5,22 @@
 //! - `MerkleTree::inclusion_proof(seq)` + verify round-trip
 //! - `MerkleTree::consistency_proof(old_size)` + verify round-trip
 
-use confium_transparency::{ArtifactType, Hash, MerkleEntry, MerkleTree};
+use confium_transparency::{ArtifactType, MerkleEntry, MerkleTree};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 
 fn build_tree(n: usize) -> MerkleTree {
     let mut tree = MerkleTree::new();
+    // Pin the timestamp so a prefix tree built separately (e.g. the
+    // old tree for consistency benchmarks) has identical leaf hashes
+    // to the corresponding prefix of the larger tree.
+    let ts = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 1, 1, 0, 0, 0).unwrap();
     for i in 0..n {
-        let entry = MerkleEntry::new(
+        let mut entry = MerkleEntry::new(
             i as u64,
             ArtifactType::CertificateIssuance,
             [(i as u8).wrapping_mul(7); 32],
         );
+        entry.timestamp = ts;
         tree.append(entry);
     }
     tree
@@ -77,7 +82,10 @@ fn bench_consistency_proof(c: &mut Criterion) {
     for size in [100usize, 1_000, 10_000] {
         let half = size / 2;
         let tree = build_tree(size);
-        let old_root = tree.root_at_size_for_bench(half);
+        // The old tree is just the first `half` entries of the same
+        // deterministic sequence — its root is the expected old_root.
+        let old_tree = build_tree(half);
+        let old_root = old_tree.root();
         let new_root = tree.root();
         let proof = tree.consistency_proof(half).unwrap();
 
@@ -104,19 +112,6 @@ fn bench_consistency_proof(c: &mut Criterion) {
         );
     }
     group.finish();
-}
-
-// The production crate doesn't expose `root_at_size` publicly (it's a
-// private impl detail). For benchmarks we just recompute the full root;
-// the verify_consistency hot path is what we actually want to measure.
-trait MerkleTreeBenchExt {
-    fn root_at_size_for_bench(&self, size: usize) -> Hash;
-}
-
-impl MerkleTreeBenchExt for MerkleTree {
-    fn root_at_size_for_bench(&self, _size: usize) -> Hash {
-        self.root()
-    }
 }
 
 criterion_group!(

--- a/crates/confium-transparency/src/merkle.rs
+++ b/crates/confium-transparency/src/merkle.rs
@@ -393,24 +393,15 @@ impl MerkleTree {
     /// Compute the Merkle root of the first `size` leaves. Used by
     /// [`verify_consistency`](Self::verify_consistency) for brute-force
     /// verification by recomputing the old tree's root directly.
+    ///
+    /// O(log N): delegates to [`subtree_root`](Self::subtree_root), whose
+    /// frontier decomposition reads each perfect-subtree root from the
+    /// cached levels in O(1).
     fn root_at_size(&self, size: usize) -> Hash {
         if size == 0 || size > self.leaf_hashes.len() {
             return [0u8; 32];
         }
-        let mut level: Vec<Hash> = self.leaf_hashes[..size].to_vec();
-        while level.len() > 1 {
-            let mut next = Vec::with_capacity(level.len() / 2 + 1);
-            let mut iter = level.iter();
-            loop {
-                match (iter.next(), iter.next()) {
-                    (Some(l), Some(r)) => next.push(hash_internal(*l, *r)),
-                    (Some(l), None) => next.push(*l),
-                    _ => break,
-                }
-            }
-            level = next;
-        }
-        level[0]
+        self.subtree_root(0, size)
     }
 
     /// Verify a consistency proof (RFC 6962 §2.1.2).


### PR DESCRIPTION
## Summary

- `verify_consistency` drops from O(N) to O(log N) — the last remaining hot path in the transparency Merkle tree.
- Fixes a pre-existing panic in the consistency-verify bench (reproduced on main; the bench could never pass).

### 1. `root_at_size` was O(size)

It rebuilt the entire prefix tree by hashing every level; `verify_consistency` calls it once per verification. Now it delegates to `subtree_root(0, size)`, whose frontier decomposition reads each perfect-subtree root from the cached levels in O(1) (the mechanism from PR #200).

Equivalence: the RFC 6962 split-recursion root and the level-by-level odd-promotion root produce identical hashes. Verified empirically for every prefix size 1..=64 of a 64-leaf tree, plus the existing consistency round-trip tests.

### 2. The consistency-verify bench has been panicking since it was written

```
thread 'main' panicked at benches/transparency.rs:101:
ConsistencyFailed { expected: ..., actual: ... }
```

Root cause: the bench's `MerkleTreeBenchExt::root_at_size_for_bench` stub returned the **full** root instead of the root at `old_size`, so verification could never succeed. Additionally `build_tree` used system timestamps, so a separately-built old tree would have different leaf hashes anyway.

Fix: pin the entry timestamp in `build_tree` (deterministic leaves), build the old tree as `build_tree(half)` and use its real root, delete the stub trait. Added the `chrono` dev-dep.

### Benchmarks (verify path)

| Size | Time |
|------|------|
| 100 | 1.53 µs |
| 1000 | 3.72 µs |
| 10000 | 3.00 µs |

100× more leaves → ~2× slower (10k within noise). Log scaling confirmed. The bench suite now passes end-to-end for the first time, which also un-breaks the CI bench job.

## Test plan

- [x] `cargo test -p confium-transparency` — 54 passed (incl. consistency round-trips)
- [x] Empirical check: `root_at_size(n)` == fresh tree root for all n in 1..=64
- [x] `cargo test --workspace` — 1848 passed, 0 failed
- [x] `cargo clippy -p confium-benchmarks -p confium-transparency --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
- [x] `cargo bench -p confium-benchmarks --bench transparency` — passes (was panicking)
