### PR TITLE
bench(transparency): add append benchmark to regression-track the incremental path

### DIFF
--- a/crates/confium-benchmarks/benches/transparency.rs
+++ b/crates/confium-benchmarks/benches/transparency.rs
@@ -1,12 +1,24 @@
 //! Transparency log benches.
 //!
 //! Measures:
+//! - `MerkleTree::append` (incremental O(log N) path) at tree sizes
+//!   100, 1000, 10000
 //! - `MerkleTree::root` computation at sizes 100, 1000, 10000
 //! - `MerkleTree::inclusion_proof(seq)` + verify round-trip
 //! - `MerkleTree::consistency_proof(old_size)` + verify round-trip
 
 use confium_transparency::{ArtifactType, MerkleEntry, MerkleTree};
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+
+fn pinned_entry(i: u64, ts: chrono::DateTime<chrono::Utc>) -> MerkleEntry {
+    let mut entry = MerkleEntry::new(
+        i,
+        ArtifactType::CertificateIssuance,
+        [(i as u8).wrapping_mul(7); 32],
+    );
+    entry.timestamp = ts;
+    entry
+}
 
 fn build_tree(n: usize) -> MerkleTree {
     let mut tree = MerkleTree::new();
@@ -15,15 +27,36 @@ fn build_tree(n: usize) -> MerkleTree {
     // to the corresponding prefix of the larger tree.
     let ts = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 1, 1, 0, 0, 0).unwrap();
     for i in 0..n {
-        let mut entry = MerkleEntry::new(
-            i as u64,
-            ArtifactType::CertificateIssuance,
-            [(i as u8).wrapping_mul(7); 32],
-        );
-        entry.timestamp = ts;
-        tree.append(entry);
+        tree.append(pinned_entry(i as u64, ts));
     }
     tree
+}
+
+fn bench_append(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transparency_append");
+    // Throughput is leaves appended per iteration.
+    group.throughput(Throughput::Elements(1));
+
+    for size in [100usize, 1_000, 10_000] {
+        // Pre-build to `size`, then measure appending the NEXT leaf —
+        // the incremental path's cost at that tree size.
+        let mut tree = build_tree(size);
+        let ts = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 1, 1, 0, 0, 0).unwrap();
+        let seq = std::cell::Cell::new(size as u64);
+        group.bench_with_input(BenchmarkId::new("next_leaf", size), &(), |b, _| {
+            b.iter_batched(
+                || pinned_entry(seq.get(), ts),
+                |entry| {
+                    let t = black_box(&mut tree);
+                    t.append(entry);
+                    // Advance so each appended leaf is unique.
+                    seq.set(seq.get() + 1);
+                },
+                criterion::BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
 }
 
 fn bench_root(c: &mut Criterion) {
@@ -116,6 +149,7 @@ fn bench_consistency_proof(c: &mut Criterion) {
 
 criterion_group!(
     benches,
+    bench_append,
     bench_root,
     bench_inclusion_proof,
     bench_consistency_proof


### PR DESCRIPTION
## Summary

- Adds a `transparency_append` benchmark to regression-track the incremental O(log N) append path (PR #203). Nothing in the perf suite exercised `append` — a future regression back to a full rebuild would go unnoticed by CI.

### Design

`transparency_append/next_leaf/{100,1000,10000}`: pre-build the tree to `size`, then measure appending the next leaf via `iter_batched` (entry construction excluded from timing; `seq` advances per iteration so each leaf is unique).

### Current numbers (`--quick`, M1) — flat across sizes

| Size | Time |
|------|------|
| 100 | 6.8 µs |
| 1000 | 6.5 µs |
| 10000 | 6.5 µs |

No N-scaling — confirms the incremental path. Also extracts the `pinned_entry` helper (was inline in `build_tree`).

## Test plan

- [x] `cargo bench -p confium-benchmarks --bench transparency` — passes, 0 errors
- [x] `cargo clippy -p confium-benchmarks --all-targets -- -D warnings` — 0 warnings
- [x] `cargo fmt --all --check` — clean
