### PR TITLE
ci(fuzz,perf): fix target/mode errors found by dispatch verification

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -36,6 +36,9 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rust-src
+          # cargo-fuzz builds sanitizer targets for both libc flavors;
+          # the musl target isn't shipped with the default profile.
+          targets: x86_64-unknown-linux-musl,x86_64-unknown-linux-gnu
 
       - name: Install cargo-fuzz
         uses: taiki-e/install-action@v2
@@ -56,10 +59,15 @@ jobs:
         working-directory: fuzz
         # cargo-fuzz passes -Zsanitizer, nightly-only. The repo's
         # rust-toolchain.toml pins stable and overrides the action's
-        # default, so force nightly via RUSTUP_TOOLCHAIN.
+        # default, so force nightly via RUSTUP_TOOLCHAIN. The gnu
+        # target is used because musl's static libc is incompatible
+        # with the sanitizer runtime.
         env:
           RUSTUP_TOOLCHAIN: nightly
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=60
+        run: >-
+          cargo fuzz run ${{ matrix.target }}
+          --target x86_64-unknown-linux-gnu
+          -- -max_total_time=60
 
       - name: Collect artifacts
         if: failure()

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -48,10 +48,12 @@ jobs:
           key: ${{ runner.os }}-perf-${{ hashFiles('Cargo.lock') }}
 
       - name: Run benchmarks on PR
-        # @v3's pinned runner release no longer exists upstream (the
-        # installer 404s). v5 tracks the current runner.
+        # v5 requires an explicit `mode`: `walltime` for criterion
+        # wall-clock benches (this workspace), `simulation` for
+        # CodSpeed-instrumented builds.
         uses: CodSpeedHQ/action@v5
         with:
+          mode: walltime
           # confium-benchmarks uses criterion; CodSpeed wraps it.
           run: cargo bench -p confium-benchmarks
           token: ${{ secrets.CODSPEED_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to PR #208. Dispatching the fixed workflows on main surfaced two follow-on errors:

- **fuzz**: the nightly override worked, but the build failed because (a) the `x86_64-unknown-linux-musl` target cargo-fuzz builds for isn't shipped by default, and (b) musl's static libc conflicts with the sanitizer runtime. Installs both libc targets and builds for `x86_64-unknown-linux-gnu`.
- **perf**: CodSpeed v5 requires an explicit `mode` input; criterion wall-clock benches map to `mode: walltime`.

## Test plan

- [x] actionlint clean
- [ ] Post-merge dispatch of fuzz + perf verifies green