### PR TITLE
ci(rustdoc): install libtss2-dev for the real-tss feature

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -39,6 +39,11 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install native TSS2 dev libraries
+        # --all-features pulls confium-store-tpm's `real-tss` feature,
+        # whose tss-esapi-sys build script requires tss2-sys.pc.
+        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
+
       - name: Configure cargo cache
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Debian package name is libtss2-dev (tss2-dev doesn't exist). Needed because --all-features enables confium-store-tpm's tss-esapi, whose -sys crate requires tss2-sys.pc.