### PR TITLE
ci(rustdoc): correct Debian package name to libtss2-dev

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install native TSS2 dev libraries
         # --all-features pulls confium-store-tpm's `real-tss` feature,
         # whose tss-esapi-sys build script requires tss2-sys.pc.
-        run: sudo apt-get update && sudo apt-get install -y tss2-dev
+        run: sudo apt-get update && sudo apt-get install -y libtss2-dev
 
       - name: Configure cargo cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
tss2-dev doesn't exist in Ubuntu archives; the TSS2 dev headers ship as libtss2-dev (provides tss2-sys.pc). Needed for --all-features rustdoc builds that enable confium-store-tpm's tss-esapi.