### PR TITLE
ci(rustdoc): drop custom artifact name breaking deploy-pages

### DIFF
--- a/.github/workflows/rustdoc.yml
+++ b/.github/workflows/rustdoc.yml
@@ -76,7 +76,9 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: target/doc
-          name: rustdoc-pages
+          # actions/deploy-pages consumes the artifact literally named
+          # "github-pages"; the custom name made it invisible to the
+          # deploy job.
 
   deploy:
     needs: build


### PR DESCRIPTION
deploy-pages only consumes artifacts named github-pages; the custom rustdoc-pages name made the deploy job fail with 'No artifacts named github-pages were found'.