### PR TITLE
fix(deps): migrate to p256 0.14 / elliptic-curve 0.14 / ecdsa 0.17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,13 +18,6 @@ updates:
       cargo-dependencies:
         patterns:
           - "*"
-    ignore:
-      # p256 0.14 removed the `expose-field` feature that
-      # confium-tc-cmp20 (and siblings) build against. Until the
-      # workspace migrates off `expose-field`, a p256 bump makes the
-      # whole update group unresolvable and fails every Dependabot
-      # run. Re-enable once the migration lands.
-      - dependency-name: "p256"
     commit-message:
       prefix: "chore(deps)"
       include: "scope"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1043,6 +1049,7 @@ name = "confium-coordinator"
 version = "0.4.7"
 dependencies = [
  "chrono",
+ "getrandom 0.4.3",
  "hex",
  "hmac 0.12.1",
  "p256",
@@ -1072,6 +1079,7 @@ dependencies = [
 name = "confium-crypto-vss"
 version = "0.4.7"
 dependencies = [
+ "getrandom 0.4.3",
  "hex",
  "num-bigint",
  "num-integer",
@@ -1089,6 +1097,7 @@ dependencies = [
 name = "confium-crypto-zk"
 version = "0.4.7"
 dependencies = [
+ "getrandom 0.4.3",
  "hex",
  "num-bigint",
  "num-traits",
@@ -1367,7 +1376,7 @@ dependencies = [
  "confium-pkcs11-server",
  "confium-tls-signer",
  "data-encoding",
- "der",
+ "der 0.7.10",
  "proptest",
  "rcgen",
  "serde",
@@ -1394,6 +1403,7 @@ name = "confium-privacy"
 version = "0.4.7"
 dependencies = [
  "chrono",
+ "getrandom 0.4.3",
  "hex",
  "hmac 0.12.1",
  "num-bigint",
@@ -1559,8 +1569,9 @@ version = "0.4.7"
 dependencies = [
  "confium-tc",
  "confium-transparency",
- "crypto-bigint",
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "elliptic-curve 0.14.1",
+ "getrandom 0.4.3",
  "inventory",
  "num-bigint",
  "p256",
@@ -1576,6 +1587,7 @@ name = "confium-tc-core"
 version = "0.4.7"
 dependencies = [
  "chrono",
+ "getrandom 0.4.3",
  "hex",
  "hmac 0.12.1",
  "inventory",
@@ -1596,6 +1608,7 @@ name = "confium-tc-ecies-p256"
 version = "0.4.7"
 dependencies = [
  "aes-gcm",
+ "getrandom 0.4.3",
  "p256",
  "serde",
  "sha2 0.10.9",
@@ -1606,6 +1619,7 @@ dependencies = [
 name = "confium-tc-elgamal-p256"
 version = "0.4.7"
 dependencies = [
+ "getrandom 0.4.3",
  "p256",
  "proptest",
  "serde",
@@ -1647,10 +1661,10 @@ dependencies = [
 name = "confium-tc-frost-p256"
 version = "0.4.7"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.14.1",
+ "getrandom 0.4.3",
  "p256",
  "proptest",
- "rand_core 0.6.4",
  "thiserror 1.0.69",
  "zeroize",
 ]
@@ -1660,8 +1674,9 @@ name = "confium-tc-gg18"
 version = "0.4.7"
 dependencies = [
  "confium-tc",
- "crypto-bigint",
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "elliptic-curve 0.14.1",
+ "getrandom 0.4.3",
  "inventory",
  "p256",
  "rand 0.8.7",
@@ -1676,6 +1691,7 @@ version = "0.4.7"
 dependencies = [
  "chrono",
  "confium-tc-core",
+ "getrandom 0.4.3",
  "hex",
  "p256",
  "rand_core 0.6.4",
@@ -1846,6 +1862,12 @@ checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2114,6 +2136,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2130,7 +2168,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.3",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2181,6 +2221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -2235,7 +2276,18 @@ dependencies = [
  "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -2327,13 +2379,26 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
  "rfc6979",
  "serdect",
- "signature",
- "spki",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2342,8 +2407,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2373,16 +2438,36 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array",
- "group",
- "pem-rfc7468",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
  "serdect",
  "subtle",
  "zeroize",
@@ -2503,6 +2588,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -2854,8 +2949,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3065,7 +3171,9 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -3874,15 +3982,16 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "primefield",
  "primeorder",
  "serdect",
- "sha2 0.10.9",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -3965,6 +4074,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4037,8 +4155,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -4169,13 +4297,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
 dependencies = [
- "elliptic-curve",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
  "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -4635,12 +4780,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -4868,10 +5013,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "serdect",
  "subtle",
  "zeroize",
@@ -5029,11 +5188,11 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "base16ct",
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -5120,6 +5279,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -5252,7 +5421,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5859,8 +6038,8 @@ dependencies = [
  "bitfield",
  "cfg-if",
  "digest 0.10.7",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "enumflags2",
  "getrandom 0.2.17",
  "hostname-validator",
@@ -5869,10 +6048,10 @@ dependencies = [
  "num-derive",
  "num-traits",
  "paste",
- "pkcs8",
+ "pkcs8 0.10.2",
  "regex",
  "semver",
- "signature",
+ "signature 2.2.0",
  "tss-esapi-sys",
  "x509-cert",
  "zeroize",
@@ -6871,6 +7050,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6883,10 +7073,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
  "const-oid 0.9.6",
- "der",
+ "der 0.7.10",
  "sha1 0.10.7",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "tls_codec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,11 +189,13 @@ tokio-util = { version = "0.7", features = ["codec"] }
 x509-cert = { version = "0.2", features = ["builder"] }
 der = "0.7"
 spki = "0.7"
-p256 = { version = "0.13", features = ["ecdsa", "pem", "arithmetic"] }
-p384 = "0.13"
-ecdsa = "0.16"
+p256 = { version = "0.14", features = ["ecdsa", "pem", "arithmetic"] }
+p384 = "0.14"
+ecdsa = "0.17"
 signature = "2"
-elliptic-curve = "0.13"
+elliptic-curve = { version = "0.14", features = ["getrandom"] }
+crypto-bigint = "0.7"
+getrandom = { version = "0.4", features = ["sys_rng"] }
 openpgp-card = "0.5"
 card-backend-pcsc = "0.5"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/confium-benchmarks/benches/composite_verify.rs
+++ b/crates/confium-benchmarks/benches/composite_verify.rs
@@ -12,6 +12,7 @@ use confium_composite::{
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use ed25519_dalek::SigningKey;
 use p256::ecdsa::SigningKey as P256SigningKey;
+use p256::elliptic_curve::Generate;
 use rand_core::OsRng;
 
 fn make_ed25519_component(message: &[u8]) -> ComponentSignature {
@@ -20,7 +21,7 @@ fn make_ed25519_component(message: &[u8]) -> ComponentSignature {
 }
 
 fn make_p256_component(message: &[u8]) -> ComponentSignature {
-    let signing = P256SigningKey::random(&mut OsRng);
+    let signing = P256SigningKey::generate();
     build_p256_component(&signing, message).expect("p256 build")
 }
 

--- a/crates/confium-cli/src/commands/pki.rs
+++ b/crates/confium-cli/src/commands/pki.rs
@@ -72,7 +72,11 @@ fn composite_sign(args: PkiCompositeSignArgs) -> Result<(), String> {
 
     let p256_key_bytes = std::fs::read(&args.p256_key)
         .map_err(|e| format!("read {}: {e}", args.p256_key.display()))?;
-    let p256_key = p256::ecdsa::SigningKey::from_bytes(p256_key_bytes.as_slice().into())
+    let p256_key_bytes: [u8; 32] = p256_key_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| "P-256 key must be exactly 32 bytes".to_string())?;
+    let p256_key = p256::ecdsa::SigningKey::from_bytes(&p256_key_bytes.into())
         .map_err(|e| format!("parse P-256 signing key: {e}"))?;
     let p256_component = confium_composite::build_p256_component(&p256_key, &message)
         .map_err(|e| format!("p256 component: {e}"))?;

--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -350,7 +350,8 @@ mod real_ed25519_tests {
     #[test]
     fn real_p256_round_trip() {
         use p256::ecdsa::{Signature, SigningKey, signature::Signer};
-        let signing = SigningKey::random(&mut OsRng);
+        use p256::elliptic_curve::Generate;
+        let signing = SigningKey::generate();
         let verifying = signing.verifying_key();
         let message = b"composite p256 test message";
         let sig: Signature = signing.sign(message);
@@ -364,7 +365,8 @@ mod real_ed25519_tests {
     #[test]
     fn real_p256_rejects_wrong_message() {
         use p256::ecdsa::{Signature, SigningKey, signature::Signer};
-        let signing = SigningKey::random(&mut OsRng);
+        use p256::elliptic_curve::Generate;
+        let signing = SigningKey::generate();
         let verifying = signing.verifying_key();
         let sig: Signature = signing.sign(b"original");
         let sig_der = sig.to_der();

--- a/crates/confium-coordinator/Cargo.toml
+++ b/crates/confium-coordinator/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "threshold", "coordinator", "confium"]
 crate-type = ["rlib"]
 
 [dependencies]
+getrandom = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/confium-coordinator/src/dkg_coordinator.rs
+++ b/crates/confium-coordinator/src/dkg_coordinator.rs
@@ -3,7 +3,8 @@
 //! Each party contributes randomness to generate a shared keypair
 //! without any single party knowing the full secret.
 
-use p256::elliptic_curve::rand_core::OsRng;
+use getrandom::SysRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
@@ -69,7 +70,9 @@ pub fn generate_contribution(
     party_count: u32,
 ) -> (DkgContribution, Scalar) {
     // Random polynomial: f(0) = secret, f(x) for x in 1..N
-    let coeffs: Vec<Scalar> = (0..threshold).map(|_| Scalar::random(&mut OsRng)).collect();
+    let coeffs: Vec<Scalar> = (0..threshold)
+        .map(|_| Scalar::random(&mut UnwrapErr(SysRng)))
+        .collect();
 
     let secret = coeffs[0];
 
@@ -83,8 +86,8 @@ pub fn generate_contribution(
 
     // VSS commitment: g^{coeffs[0]}
     let commitment = (ProjectivePoint::GENERATOR * secret).to_affine();
-    use p256::elliptic_curve::sec1::ToEncodedPoint;
-    let commitment_hex = hex::encode(commitment.to_encoded_point(true).as_bytes());
+    use p256::elliptic_curve::sec1::ToSec1Point;
+    let commitment_hex = hex::encode(commitment.to_sec1_point(true).as_bytes());
 
     (
         DkgContribution {
@@ -125,12 +128,13 @@ pub fn compute_joint_public_key(session: &DkgSession) -> Result<AffinePoint, Str
     if !session.is_complete() {
         return Err("DKG not complete".into());
     }
-    use p256::elliptic_curve::sec1::FromEncodedPoint;
+    use p256::elliptic_curve::sec1::FromSec1Point;
     let mut sum = ProjectivePoint::IDENTITY;
     for contrib in session.contributions.values() {
         let bytes = hex::decode(&contrib.commitment_hex).map_err(|e| e.to_string())?;
-        let encoded = p256::EncodedPoint::from_bytes(&bytes).map_err(|e| e.to_string())?;
-        let point = Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+        let encoded = p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&bytes)
+            .map_err(|e| e.to_string())?;
+        let point = Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
             .ok_or_else(|| "invalid commitment point".to_string())?;
         sum += ProjectivePoint::from(point);
     }

--- a/crates/confium-crypto-vss/Cargo.toml
+++ b/crates/confium-crypto-vss/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "vss", "paillier", "schnorr", "confium"]
 crate-type = ["rlib"]
 
 [dependencies]
+getrandom = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
 sha2 = { workspace = true }
 serde = { workspace = true }

--- a/crates/confium-crypto-vss/src/nizk.rs
+++ b/crates/confium-crypto-vss/src/nizk.rs
@@ -1,8 +1,9 @@
 //! General-purpose NIZK proof system using Fiat-Shamir transform.
 
+use getrandom::SysRng;
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::rand_core::{OsRng, RngCore};
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::rand_core::{Rng, UnwrapErr};
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
 
@@ -17,7 +18,7 @@ pub struct NizkProof {
 /// Prove knowledge of a discrete log: know x such that Y = x * G.
 pub fn prove_dlog(secret: &Scalar) -> NizkProof {
     let mut nonce_bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut nonce_bytes);
+    UnwrapErr(SysRng).fill_bytes(&mut nonce_bytes);
     let nonce = Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(nonce_bytes)))
         .unwrap_or(Scalar::ZERO);
 
@@ -54,7 +55,7 @@ pub fn prove_dlog_equality(
     g2: &AffinePoint,
 ) -> (NizkProof, NizkProof) {
     let mut nonce_bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut nonce_bytes);
+    UnwrapErr(SysRng).fill_bytes(&mut nonce_bytes);
     let nonce = Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(nonce_bytes)))
         .unwrap_or(Scalar::ZERO);
 
@@ -112,9 +113,9 @@ fn fiat_shamir_challenge(public: &AffinePoint, commitment: &AffinePoint, domain:
     let mut hasher = Sha256::new();
     hasher.update(b"nizk");
     hasher.update(domain);
-    hasher.update(public.to_encoded_point(true).as_bytes());
-    hasher.update(commitment.to_encoded_point(true).as_bytes());
-    let fb = FieldBytes::from(hasher.finalize());
+    hasher.update(public.to_sec1_point(true).as_bytes());
+    hasher.update(commitment.to_sec1_point(true).as_bytes());
+    let fb = FieldBytes::try_from(&hasher.finalize()[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -126,11 +127,11 @@ fn equality_challenge(
 ) -> Scalar {
     let mut hasher = Sha256::new();
     hasher.update(b"nizk-equality");
-    hasher.update(y1.to_encoded_point(true).as_bytes());
-    hasher.update(y2.to_encoded_point(true).as_bytes());
-    hasher.update(c1.to_encoded_point(true).as_bytes());
-    hasher.update(c2.to_encoded_point(true).as_bytes());
-    let fb = FieldBytes::from(hasher.finalize());
+    hasher.update(y1.to_sec1_point(true).as_bytes());
+    hasher.update(y2.to_sec1_point(true).as_bytes());
+    hasher.update(c1.to_sec1_point(true).as_bytes());
+    hasher.update(c2.to_sec1_point(true).as_bytes());
+    let fb = FieldBytes::try_from(&hasher.finalize()[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -141,7 +142,7 @@ mod tests {
 
     #[test]
     fn dlog_proof_verifies() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let proof = prove_dlog(&secret);
         let public = (ProjectivePoint::GENERATOR * secret).to_affine();
         assert!(verify_dlog(&public, &proof));
@@ -149,15 +150,16 @@ mod tests {
 
     #[test]
     fn dlog_wrong_public_rejected() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let proof = prove_dlog(&secret);
-        let wrong = (ProjectivePoint::GENERATOR * Scalar::random(&mut OsRng)).to_affine();
+        let wrong =
+            (ProjectivePoint::GENERATOR * Scalar::random(&mut UnwrapErr(SysRng))).to_affine();
         assert!(!verify_dlog(&wrong, &proof));
     }
 
     #[test]
     fn dlog_tampered_response_rejected() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let mut proof = prove_dlog(&secret);
         let public = (ProjectivePoint::GENERATOR * secret).to_affine();
         proof.response += Scalar::ONE;
@@ -166,7 +168,7 @@ mod tests {
 
     #[test]
     fn dlog_proof_non_deterministic() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let p1 = prove_dlog(&secret);
         let p2 = prove_dlog(&secret);
         assert_ne!(p1.commitment, p2.commitment);
@@ -174,7 +176,7 @@ mod tests {
 
     #[test]
     fn equality_proof_verifies() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let g1 = AffinePoint::GENERATOR;
         let g2 = (ProjectivePoint::GENERATOR * Scalar::from(2u32)).to_affine();
 
@@ -187,12 +189,12 @@ mod tests {
 
     #[test]
     fn equality_wrong_secret_rejected() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let g1 = AffinePoint::GENERATOR;
         let g2 = (ProjectivePoint::GENERATOR * Scalar::from(2u32)).to_affine();
 
         let (p1, p2) = prove_dlog_equality(&secret, &g1, &g2);
-        let wrong = Scalar::random(&mut OsRng);
+        let wrong = Scalar::random(&mut UnwrapErr(SysRng));
         let y1 = (ProjectivePoint::from(g1) * wrong).to_affine();
         let y2 = (ProjectivePoint::from(g2) * secret).to_affine();
 
@@ -201,7 +203,7 @@ mod tests {
 
     #[test]
     fn nizk_proof_serializes() {
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let proof = prove_dlog(&secret);
         // Just verify it has the right structure
         assert!(proof.challenge != Scalar::ZERO || proof.response != Scalar::ZERO);

--- a/crates/confium-crypto-vss/src/pedersen_vss.rs
+++ b/crates/confium-crypto-vss/src/pedersen_vss.rs
@@ -1,7 +1,8 @@
 //! Pedersen VSS — verifiable secret sharing with hiding commitments.
 
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use getrandom::SysRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
@@ -39,7 +40,7 @@ pub struct PedersenParams {
 impl PedersenParams {
     /// Generate h = g^alpha for random alpha (trapdoor discarded).
     pub fn generate() -> Self {
-        let alpha = Scalar::random(&mut OsRng);
+        let alpha = Scalar::random(&mut UnwrapErr(SysRng));
         let h = (ProjectivePoint::GENERATOR * alpha).to_affine();
         Self { h }
     }
@@ -59,11 +60,13 @@ pub fn deal(
             if i == 0 {
                 *secret
             } else {
-                Scalar::random(&mut OsRng)
+                Scalar::random(&mut UnwrapErr(SysRng))
             }
         })
         .collect();
-    let r_coeffs: Vec<Scalar> = (0..threshold).map(|_| Scalar::random(&mut OsRng)).collect();
+    let r_coeffs: Vec<Scalar> = (0..threshold)
+        .map(|_| Scalar::random(&mut UnwrapErr(SysRng)))
+        .collect();
 
     // Commitments: C_i = g^{f_i} * h^{r_i}, D_i = h^{r_i}
     let mut c_points = Vec::with_capacity(threshold as usize);
@@ -157,13 +160,14 @@ fn u32_to_scalar(v: u32) -> Scalar {
 }
 
 fn encode_point(p: &AffinePoint) -> String {
-    hex::encode(p.to_encoded_point(true).as_bytes())
+    hex::encode(p.to_sec1_point(true).as_bytes())
 }
 
 fn decode_point(hex_str: &str) -> Option<AffinePoint> {
     let bytes = hex::decode(hex_str).ok()?;
-    let encoded = p256::EncodedPoint::from_bytes(&bytes).ok()?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+    let encoded =
+        p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&bytes).ok()?;
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
 }
 
 #[cfg(test)]
@@ -173,7 +177,7 @@ mod tests {
     #[test]
     fn deal_and_verify() {
         let params = PedersenParams::generate();
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let (commitment, shares) = deal(&secret, 3, 5, &params);
         for share in &shares {
             assert!(
@@ -187,7 +191,7 @@ mod tests {
     #[test]
     fn tampered_share_rejected() {
         let params = PedersenParams::generate();
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let (commitment, mut shares) = deal(&secret, 2, 3, &params);
         shares[0].value += Scalar::ONE;
         assert!(!verify_share(&shares[0], &commitment, &params));
@@ -196,7 +200,7 @@ mod tests {
     #[test]
     fn joint_public_key_extracted() {
         let params = PedersenParams::generate();
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let (commitment, _) = deal(&secret, 2, 3, &params);
         let pk = joint_public_key(&commitment).unwrap();
         // g^{secret} == pk
@@ -207,8 +211,8 @@ mod tests {
     #[test]
     fn different_secrets_different_commitments() {
         let params = PedersenParams::generate();
-        let s1 = Scalar::random(&mut OsRng);
-        let s2 = Scalar::random(&mut OsRng);
+        let s1 = Scalar::random(&mut UnwrapErr(SysRng));
+        let s2 = Scalar::random(&mut UnwrapErr(SysRng));
         let (c1, _) = deal(&s1, 2, 3, &params);
         let (c2, _) = deal(&s2, 2, 3, &params);
         assert_ne!(c1.c_points_hex[0], c2.c_points_hex[0]);
@@ -217,7 +221,7 @@ mod tests {
     #[test]
     fn threshold_one_works() {
         let params = PedersenParams::generate();
-        let secret = Scalar::random(&mut OsRng);
+        let secret = Scalar::random(&mut UnwrapErr(SysRng));
         let (commitment, shares) = deal(&secret, 1, 3, &params);
         assert_eq!(shares.len(), 3);
         for share in &shares {

--- a/crates/confium-crypto-vss/src/schnorr.rs
+++ b/crates/confium-crypto-vss/src/schnorr.rs
@@ -4,10 +4,11 @@
 //! Uses the Fiat-Shamir heuristic: the challenge is derived from a
 //! hash of the protocol transcript, making the proof non-interactive.
 
+use getrandom::SysRng;
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::elliptic_curve::rand_core::{Rng, UnwrapErr};
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
-use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -38,10 +39,10 @@ pub enum SchnorrError {
 pub fn prove(secret: &Scalar, public: &AffinePoint, message: &[u8]) -> SchnorrProof {
     use p256::elliptic_curve::Field;
     let mut k_bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut k_bytes);
+    UnwrapErr(SysRng).fill_bytes(&mut k_bytes);
     let k_fb = p256::FieldBytes::from(k_bytes);
     let k_ct = Scalar::from_repr(k_fb);
-    let k = Option::<Scalar>::from(k_ct).unwrap_or_else(|| Scalar::random(&mut OsRng));
+    let k = Option::<Scalar>::from(k_ct).unwrap_or_else(|| Scalar::random(&mut UnwrapErr(SysRng)));
 
     let r_point = ProjectivePoint::GENERATOR * k;
     let r_affine = r_point.to_affine();
@@ -49,7 +50,7 @@ pub fn prove(secret: &Scalar, public: &AffinePoint, message: &[u8]) -> SchnorrPr
     let c = fiat_shamir_challenge(public, &r_affine, message);
     let z = k + secret * &c;
 
-    let r_encoded = r_affine.to_encoded_point(true);
+    let r_encoded = r_affine.to_sec1_point(true);
     let z_bytes: [u8; 32] = z.to_repr().into();
 
     SchnorrProof {
@@ -82,8 +83,8 @@ pub fn verify(
 }
 
 fn fiat_shamir_challenge(public: &AffinePoint, r: &AffinePoint, message: &[u8]) -> Scalar {
-    let public_encoded = public.to_encoded_point(true);
-    let r_encoded = r.to_encoded_point(true);
+    let public_encoded = public.to_sec1_point(true);
+    let r_encoded = r.to_sec1_point(true);
 
     let mut hasher = Sha256::new();
     hasher.update(b"confium-schnorr-v1");
@@ -92,14 +93,15 @@ fn fiat_shamir_challenge(public: &AffinePoint, r: &AffinePoint, message: &[u8]) 
     hasher.update(message);
     let hash = hasher.finalize();
 
-    let fb = p256::FieldBytes::from(hash);
+    let fb = p256::FieldBytes::try_from(&hash[..]).expect("digest is 32 bytes");
     let ct = Scalar::from_repr(fb);
     Option::<Scalar>::from(ct).unwrap_or(Scalar::ZERO)
 }
 
 fn decode_point(bytes: &[u8]) -> Result<AffinePoint, SchnorrError> {
-    let encoded = p256::EncodedPoint::from_bytes(bytes).map_err(|_| SchnorrError::InvalidPoint)?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+    let encoded = p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
+        .map_err(|_| SchnorrError::InvalidPoint)?;
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
         .ok_or(SchnorrError::InvalidPoint)
 }
 
@@ -116,10 +118,11 @@ mod tests {
 
     fn random_keypair() -> (Scalar, AffinePoint) {
         let mut buf = [0u8; 32];
-        OsRng.fill_bytes(&mut buf);
+        UnwrapErr(SysRng).fill_bytes(&mut buf);
         let fb = p256::FieldBytes::from(buf);
         let ct = Scalar::from_repr(fb);
-        let secret = Option::<Scalar>::from(ct).unwrap_or_else(|| Scalar::random(&mut OsRng));
+        let secret =
+            Option::<Scalar>::from(ct).unwrap_or_else(|| Scalar::random(&mut UnwrapErr(SysRng)));
         let public = (ProjectivePoint::GENERATOR * secret).to_affine();
         (secret, public)
     }

--- a/crates/confium-crypto-vss/src/threshold_schnorr.rs
+++ b/crates/confium-crypto-vss/src/threshold_schnorr.rs
@@ -1,7 +1,8 @@
 //! Threshold Schnorr (MuSig-style) — 2-round threshold signing.
 
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use getrandom::SysRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
@@ -79,10 +80,10 @@ impl MusigSession {
         let pk_sum = self.aggregate_public_key();
         let mut hasher = Sha256::new();
         hasher.update(b"musig-challenge");
-        hasher.update(r.to_encoded_point(true).as_bytes());
-        hasher.update(pk_sum.to_encoded_point(true).as_bytes());
+        hasher.update(r.to_sec1_point(true).as_bytes());
+        hasher.update(pk_sum.to_sec1_point(true).as_bytes());
         hasher.update(message);
-        let fb = FieldBytes::from(hasher.finalize());
+        let fb = FieldBytes::try_from(&hasher.finalize()[..]).expect("digest is 32 bytes");
         Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
     }
 
@@ -121,7 +122,7 @@ pub fn verify(s: &Scalar, r: &AffinePoint, agg_pk: &AffinePoint, challenge: &Sca
 
 /// Generate a random nonce for a party.
 pub fn generate_nonce(party_idx: u32) -> (Scalar, NonceCommitment) {
-    let k = Scalar::random(&mut OsRng);
+    let k = Scalar::random(&mut UnwrapErr(SysRng));
     let r_point = (ProjectivePoint::GENERATOR * k).to_affine();
     (k, NonceCommitment { party_idx, r_point })
 }
@@ -133,7 +134,7 @@ mod tests {
     fn make_keypairs(n: usize) -> Vec<(Scalar, AffinePoint)> {
         (0..n)
             .map(|_| {
-                let sk = Scalar::random(&mut OsRng);
+                let sk = Scalar::random(&mut UnwrapErr(SysRng));
                 let pk = (ProjectivePoint::GENERATOR * sk).to_affine();
                 (sk, pk)
             })
@@ -240,10 +241,10 @@ mod tests {
         let pairs = make_keypairs(2);
         let pks: Vec<AffinePoint> = pairs.iter().map(|(_, pk)| *pk).collect();
         let session = MusigSession::new(pks.clone(), 2);
-        let r = (ProjectivePoint::GENERATOR * Scalar::random(&mut OsRng)).to_affine();
+        let r = (ProjectivePoint::GENERATOR * Scalar::random(&mut UnwrapErr(SysRng))).to_affine();
         let agg_pk = session.aggregate_public_key();
         let c = session.challenge(b"test");
-        let wrong_s = Scalar::random(&mut OsRng);
+        let wrong_s = Scalar::random(&mut UnwrapErr(SysRng));
         assert!(!verify(&wrong_s, &r, &agg_pk, &c));
     }
 }

--- a/crates/confium-crypto-vss/src/vss.rs
+++ b/crates/confium-crypto-vss/src/vss.rs
@@ -12,7 +12,7 @@
 //! share `f(j)`. They verify: `g^{f(j)} == product(C_i^{j^i})`.
 
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 
 /// Public commitments from a Feldman VSS deal.
@@ -63,7 +63,7 @@ impl VssCommitment {
     pub fn encode(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.commitments.len() * 33);
         for c in &self.commitments {
-            let encoded = c.to_encoded_point(true);
+            let encoded = c.to_sec1_point(true);
             out.extend_from_slice(encoded.as_bytes());
         }
         out
@@ -77,8 +77,9 @@ impl VssCommitment {
         }
         let mut commitments = Vec::with_capacity(bytes.len() / 33);
         for chunk in bytes.chunks_exact(33) {
-            let point = p256::EncodedPoint::from_bytes(chunk).ok()?;
-            let affine = Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&point))?;
+            let point =
+                p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(chunk).ok()?;
+            let affine = Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&point))?;
             commitments.push(affine);
         }
         Some(Self { commitments })
@@ -99,8 +100,8 @@ mod tests {
 
     fn random_scalar() -> Scalar {
         use p256::elliptic_curve::Field;
-        use p256::elliptic_curve::rand_core::OsRng;
-        Scalar::random(&mut OsRng)
+        use p256::elliptic_curve::rand_core::UnwrapErr;
+        Scalar::random(&mut UnwrapErr(getrandom::SysRng))
     }
 
     fn make_commitment_for_polynomial(coeffs: &[Scalar]) -> VssCommitment {

--- a/crates/confium-crypto-zk/Cargo.toml
+++ b/crates/confium-crypto-zk/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "zk", "proof", "confium"]
 crate-type = ["rlib"]
 
 [dependencies]
+getrandom = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
 sha2 = { workspace = true }
 serde = { workspace = true }

--- a/crates/confium-crypto-zk/src/zk_sig_possession.rs
+++ b/crates/confium-crypto-zk/src/zk_sig_possession.rs
@@ -4,11 +4,12 @@
 //! the signature itself. Uses a Schnorr-style proof tied to the
 //! verification equation.
 
+use getrandom::SysRng;
 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::rand_core::RngCore;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::rand_core::Rng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -41,7 +42,7 @@ pub fn prove_possession(
     // The proof demonstrates knowledge of the signature scalars (r, s)
     // by showing a Schnorr-like proof tied to the verification equation.
     let pk_affine = *public_key.as_affine();
-    let pk_bytes = pk_affine.to_encoded_point(true);
+    let pk_bytes = pk_affine.to_sec1_point(true);
     let pk_hex = hex::encode(pk_bytes.as_bytes());
 
     // Hash the message
@@ -57,13 +58,13 @@ pub fn prove_possession(
 
     // Pick random nonce
     let mut nonce_bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut nonce_bytes);
+    UnwrapErr(SysRng).fill_bytes(&mut nonce_bytes);
     let nonce_fb = FieldBytes::from(nonce_bytes);
     let nonce = Option::<Scalar>::from(Scalar::from_repr(nonce_fb)).unwrap_or(Scalar::ZERO);
 
     // Commitment: R = nonce * G
     let commitment = (ProjectivePoint::GENERATOR * nonce).to_affine();
-    let commitment_hex = hex::encode(commitment.to_encoded_point(true).as_bytes());
+    let commitment_hex = hex::encode(commitment.to_sec1_point(true).as_bytes());
 
     // Challenge: c = H(pk || msg || R || r)
     let r_bytes: [u8; 32] = r.to_repr().into();
@@ -71,10 +72,10 @@ pub fn prove_possession(
     challenge_hasher.update(b"sig-possession");
     challenge_hasher.update(pk_bytes.as_bytes());
     challenge_hasher.update(msg_hash);
-    challenge_hasher.update(commitment.to_encoded_point(true).as_bytes());
+    challenge_hasher.update(commitment.to_sec1_point(true).as_bytes());
     challenge_hasher.update(r_bytes);
     let challenge_bytes = challenge_hasher.finalize();
-    let challenge_fb = FieldBytes::from(challenge_bytes);
+    let challenge_fb = FieldBytes::try_from(&challenge_bytes[..]).expect("digest is 32 bytes");
     let challenge = Option::<Scalar>::from(Scalar::from_repr(challenge_fb)).unwrap_or(Scalar::ZERO);
 
     // Response: response = nonce + challenge * s
@@ -131,11 +132,12 @@ pub fn verify_possession(proof: &SignaturePossessionProof, message: &[u8]) -> bo
     // In a real implementation, r would be derived from the proof
     challenge_hasher.update([0u8; 32]);
     let challenge_bytes = challenge_hasher.finalize();
-    let _challenge =
-        match Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(challenge_bytes))) {
-            Some(s) => s,
-            None => return false,
-        };
+    let _challenge = match Option::<Scalar>::from(Scalar::from_repr(
+        FieldBytes::try_from(&challenge_bytes[..]).expect("digest is 32 bytes"),
+    )) {
+        Some(s) => s,
+        None => return false,
+    };
 
     // Verify: response * G == commitment + challenge * pk_point
     let lhs = ProjectivePoint::GENERATOR * response;
@@ -146,20 +148,22 @@ pub fn verify_possession(proof: &SignaturePossessionProof, message: &[u8]) -> bo
 }
 
 fn decode_point(hex_str: &str) -> Option<AffinePoint> {
-    use p256::elliptic_curve::sec1::FromEncodedPoint;
+    use p256::elliptic_curve::sec1::FromSec1Point;
     let bytes = hex::decode(hex_str).ok()?;
-    let encoded = p256::EncodedPoint::from_bytes(&bytes).ok()?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+    let encoded =
+        p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&bytes).ok()?;
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use p256::ecdsa::{SigningKey, signature::Signer};
+    use p256::elliptic_curve::Generate;
 
     #[test]
     fn valid_proof_generates() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let msg = b"test message";
         let sig: Signature = signing.sign(msg);
@@ -170,8 +174,8 @@ mod tests {
 
     #[test]
     fn invalid_signature_rejected() {
-        let signing = SigningKey::random(&mut OsRng);
-        let other = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
+        let other = SigningKey::generate();
         let vk = signing.verifying_key();
         let msg = b"test";
         let sig: Signature = other.sign(msg); // signed with different key
@@ -180,7 +184,7 @@ mod tests {
 
     #[test]
     fn proof_does_not_reveal_signature() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let msg = b"secret message";
         let sig: Signature = signing.sign(msg);
@@ -193,7 +197,7 @@ mod tests {
 
     #[test]
     fn different_messages_different_proofs() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let sig1: Signature = signing.sign(b"msg1");
         let sig2: Signature = signing.sign(b"msg2");
@@ -204,7 +208,7 @@ mod tests {
 
     #[test]
     fn proof_serializes() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let sig: Signature = signing.sign(b"test");
         let proof = prove_possession(vk, b"test", &sig).unwrap();

--- a/crates/confium-privacy/Cargo.toml
+++ b/crates/confium-privacy/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "privacy", "mpc", "psi", "confium"]
 crate-type = ["rlib"]
 
 [dependencies]
+getrandom = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
 sha2 = { workspace = true }
 hmac = { workspace = true }

--- a/crates/confium-privacy/src/adaptor_sig.rs
+++ b/crates/confium-privacy/src/adaptor_sig.rs
@@ -5,9 +5,10 @@
 //! Revealing the completed signature also reveals `y`, enabling
 //! atomic swaps and payment channels.
 
+use getrandom::SysRng;
 use p256::ecdsa::{Signature, SigningKey, VerifyingKey};
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
@@ -29,7 +30,7 @@ pub struct WitnessStatement {
 
 /// Generate a witness statement from a secret witness.
 pub fn create_witness() -> (Scalar, WitnessStatement) {
-    let y = Scalar::random(&mut OsRng);
+    let y = Scalar::random(&mut UnwrapErr(SysRng));
     let y_point = (ProjectivePoint::GENERATOR * y).to_affine();
     (y, WitnessStatement { y_point })
 }
@@ -41,7 +42,7 @@ pub fn pre_sign(
     message: &[u8],
     witness: &WitnessStatement,
 ) -> Result<(AdaptorPreSig, Scalar), String> {
-    let k = Scalar::random(&mut OsRng);
+    let k = Scalar::random(&mut UnwrapErr(SysRng));
     let k_point = (ProjectivePoint::GENERATOR * k).to_affine();
 
     // R' = k*G + Y = (k+y)*G
@@ -142,7 +143,7 @@ pub fn verify_pre_sig(
 }
 
 fn x_coord(point: &AffinePoint) -> Scalar {
-    let encoded = point.to_encoded_point(false);
+    let encoded = point.to_sec1_point(false);
     if let Some(x_bytes) = encoded.x() {
         let mut arr = [0u8; 32];
         arr.copy_from_slice(x_bytes);
@@ -156,7 +157,7 @@ fn x_coord(point: &AffinePoint) -> Scalar {
 fn hash_msg(msg: &[u8]) -> Scalar {
     let mut h = Sha256::new();
     h.update(msg);
-    let fb = FieldBytes::from(h.finalize());
+    let fb = FieldBytes::try_from(&h.finalize()[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -168,10 +169,11 @@ fn invert(s: &Scalar) -> Scalar {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p256::elliptic_curve::Generate;
 
     #[test]
     fn pre_sign_produces_valid_pre_sig() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let (y, witness) = create_witness();
         let (pre_sig, _k) = pre_sign(&signing, b"message", &witness).unwrap();
@@ -181,7 +183,7 @@ mod tests {
 
     #[test]
     fn complete_produces_signature() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let (y, witness) = create_witness();
         let (pre_sig, _k) = pre_sign(&signing, b"payment", &witness).unwrap();
         let full_sig = complete(&pre_sig, &y).unwrap();
@@ -192,7 +194,7 @@ mod tests {
 
     #[test]
     fn different_messages_different_pre_sigs() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let (_, w1) = create_witness();
         let (_, w2) = create_witness();
         let (ps1, _) = pre_sign(&signing, b"msg1", &w1).unwrap();
@@ -202,7 +204,7 @@ mod tests {
 
     #[test]
     fn wrong_witness_rejected() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
         let (_, w1) = create_witness();
         let (_, w2) = create_witness();
@@ -212,7 +214,7 @@ mod tests {
 
     #[test]
     fn witness_extraction() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let (y, witness) = create_witness();
         let (pre_sig, _) = pre_sign(&signing, b"msg", &witness).unwrap();
         let full_sig = complete(&pre_sig, &y).unwrap();

--- a/crates/confium-privacy/src/blind_ecdsa.rs
+++ b/crates/confium-privacy/src/blind_ecdsa.rs
@@ -6,9 +6,10 @@
 //!
 //! Uses the multiplicative blinding technique adapted for ECDSA.
 
+use getrandom::SysRng;
 use p256::Scalar;
 use p256::ecdsa::{Signature, SigningKey, signature::Signer};
-use p256::elliptic_curve::{Field, PrimeField, rand_core::OsRng};
+use p256::elliptic_curve::{Field, PrimeField, rand_core::UnwrapErr};
 use serde::{Deserialize, Serialize};
 
 /// A blind signature request (blinded hash sent to signer).
@@ -34,7 +35,7 @@ pub struct RawSignature {
 
 /// Blind a message hash for the signer.
 pub fn blind(message_hash: &[u8; 32]) -> (BlindedMessage, BlindFactor) {
-    let t = Scalar::random(&mut OsRng);
+    let t = Scalar::random(&mut UnwrapErr(SysRng));
     let e = bytes_to_scalar(message_hash);
     // Blinded hash = e * t (multiplicative blinding)
     let blinded = e * t;
@@ -87,10 +88,11 @@ fn bytes_to_scalar(bytes: &[u8; 32]) -> Scalar {
 mod tests {
     use super::*;
     use p256::ecdsa::signature::Verifier;
+    use p256::elliptic_curve::Generate;
 
     #[test]
     fn blind_sign_produces_valid_sig_on_blinded_hash() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
 
         let msg_hash = [0x42u8; 32];
@@ -136,7 +138,7 @@ mod tests {
 
     #[test]
     fn multiple_messages_each_produce_valid_sigs() {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let vk = signing.verifying_key();
 
         for i in 0u8..5 {

--- a/crates/confium-privacy/src/multi_sig.rs
+++ b/crates/confium-privacy/src/multi_sig.rs
@@ -6,7 +6,7 @@
 
 use p256::ecdsa::{Signature, VerifyingKey};
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::{AffinePoint, Scalar};
 use serde::{Deserialize, Serialize};
 
@@ -47,7 +47,7 @@ pub fn aggregate(
         .iter()
         .map(|vk| {
             let point = *vk.as_affine();
-            hex::encode(point.to_encoded_point(false).as_bytes())
+            hex::encode(point.to_sec1_point(false).as_bytes())
         })
         .collect();
 
@@ -82,11 +82,12 @@ pub fn verify_aggregate(agg: &AggregateSignature, _message: &[u8]) -> bool {
             Ok(b) => b,
             Err(_) => return false,
         };
-        let encoded = match p256::EncodedPoint::from_bytes(&pk_bytes) {
-            Ok(e) => e,
-            Err(_) => return false,
-        };
-        let affine = Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded));
+        let encoded =
+            match p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&pk_bytes) {
+                Ok(e) => e,
+                Err(_) => return false,
+            };
+        let affine = Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded));
         if affine.is_none() {
             return false;
         }
@@ -99,10 +100,10 @@ pub fn verify_aggregate(agg: &AggregateSignature, _message: &[u8]) -> bool {
 mod tests {
     use super::*;
     use p256::ecdsa::{SigningKey, signature::Signer};
-    use p256::elliptic_curve::rand_core::OsRng;
+    use p256::elliptic_curve::Generate;
 
     fn make_sig_pair(msg: &[u8]) -> (Signature, VerifyingKey) {
-        let signing = SigningKey::random(&mut OsRng);
+        let signing = SigningKey::generate();
         let sig: Signature = signing.sign(msg);
         (sig, *signing.verifying_key())
     }

--- a/crates/confium-privacy/src/oblivious_transfer.rs
+++ b/crates/confium-privacy/src/oblivious_transfer.rs
@@ -6,9 +6,10 @@
 //!
 //! Based on the Bellare-Micali protocol using P-256.
 
+use getrandom::SysRng;
 use p256::elliptic_curve::Field;
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
 
@@ -44,14 +45,14 @@ pub struct OtReceiver {
 
 /// Phase 1: Sender initiates with a random point.
 pub fn sender_setup() -> (OtSetup, Scalar) {
-    let c_scalar = Scalar::random(&mut OsRng);
+    let c_scalar = Scalar::random(&mut UnwrapErr(SysRng));
     let c = (ProjectivePoint::GENERATOR * c_scalar).to_affine();
     (OtSetup { c }, c_scalar)
 }
 
 /// Phase 2: Receiver chooses bit b and generates choice message.
 pub fn receiver_choose(b: bool, setup: &OtSetup) -> (OtChoice, OtReceiver) {
-    let k = Scalar::random(&mut OsRng);
+    let k = Scalar::random(&mut UnwrapErr(SysRng));
     let k_g = (ProjectivePoint::GENERATOR * k).to_affine();
 
     // If b == 0: P = k*G
@@ -91,7 +92,7 @@ pub fn receiver_decrypt(enc: &OtEncrypted, receiver: &OtReceiver) -> Vec<u8> {
 fn xor_encrypt(key_point: &AffinePoint, data: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(b"ot-key");
-    hasher.update(key_point.to_encoded_point(true).as_bytes());
+    hasher.update(key_point.to_sec1_point(true).as_bytes());
     let key = hasher.finalize();
     let key = key.as_slice();
 

--- a/crates/confium-privacy/src/proxy_reencryption.rs
+++ b/crates/confium-privacy/src/proxy_reencryption.rs
@@ -10,7 +10,8 @@
 //! 2. Proxy transforms: (c1, c2) → (c1 * rk, c2)  [point multiplication]
 //! 3. Bob decrypts with his secret key
 
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use getrandom::SysRng;
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 
@@ -40,13 +41,13 @@ pub fn generate_rk(alice_sk: &Scalar, _bob_pk: &AffinePoint) -> ReEncryptionKey 
 /// Encrypt a point under public key `pk`.
 pub fn encrypt_point(pk: &AffinePoint, message: &AffinePoint) -> Ciphertext {
     use p256::elliptic_curve::Field;
-    use p256::elliptic_curve::rand_core::OsRng;
-    let r = Scalar::random(&mut OsRng);
+    use p256::elliptic_curve::rand_core::UnwrapErr;
+    let r = Scalar::random(&mut UnwrapErr(SysRng));
     let c1 = (ProjectivePoint::GENERATOR * r).to_affine();
     let c2 = (ProjectivePoint::from(*pk) * r + ProjectivePoint::from(*message)).to_affine();
     Ciphertext {
-        c1_hex: hex::encode(c1.to_encoded_point(true).as_bytes()),
-        c2_hex: hex::encode(c2.to_encoded_point(true).as_bytes()),
+        c1_hex: hex::encode(c1.to_sec1_point(true).as_bytes()),
+        c2_hex: hex::encode(c2.to_sec1_point(true).as_bytes()),
     }
 }
 
@@ -66,25 +67,26 @@ pub fn re_encrypt(rk: &ReEncryptionKey, ct: &Ciphertext) -> Ciphertext {
     // Transform: multiply c1 by rk
     let new_c1 = (ProjectivePoint::from(c1) * rk.rk).to_affine();
     Ciphertext {
-        c1_hex: hex::encode(new_c1.to_encoded_point(true).as_bytes()),
+        c1_hex: hex::encode(new_c1.to_sec1_point(true).as_bytes()),
         c2_hex: ct.c2_hex.clone(),
     }
 }
 
 fn decode_point(hex_str: &str) -> Option<AffinePoint> {
     let bytes = hex::decode(hex_str).ok()?;
-    let encoded = p256::EncodedPoint::from_bytes(&bytes).ok()?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+    let encoded =
+        p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&bytes).ok()?;
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use p256::elliptic_curve::Field;
-    use p256::elliptic_curve::rand_core::OsRng;
+    use p256::elliptic_curve::rand_core::UnwrapErr;
 
     fn random_keypair() -> (Scalar, AffinePoint) {
-        let sk = Scalar::random(&mut OsRng);
+        let sk = Scalar::random(&mut UnwrapErr(SysRng));
         let pk = (ProjectivePoint::GENERATOR * sk).to_affine();
         (sk, pk)
     }

--- a/crates/confium-privacy/src/secure_aggregation.rs
+++ b/crates/confium-privacy/src/secure_aggregation.rs
@@ -5,8 +5,9 @@
 //! value. Uses pairwise masking (each pair shares a mask that cancels
 //! when summed).
 
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::rand_core::RngCore;
+use getrandom::SysRng;
+use p256::elliptic_curve::rand_core::Rng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
 use std::collections::HashMap;
 
 /// A party in the secure aggregation.
@@ -49,7 +50,7 @@ impl SecureAggregation {
     /// When summed, masks cancel.
     pub fn establish_masks(&mut self) {
         let n = self.parties.len();
-        let mut rng = OsRng;
+        let mut rng = UnwrapErr(SysRng);
         for i in 0..n {
             for j in (i + 1)..n {
                 // Use small masks to avoid i64 overflow

--- a/crates/confium-privacy/src/vrf.rs
+++ b/crates/confium-privacy/src/vrf.rs
@@ -5,10 +5,11 @@
 //! the secret key. Used for leader election, lotteries, and
 //! verifiable randomness.
 
+use getrandom::SysRng;
 use p256::elliptic_curve::PrimeField;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::elliptic_curve::rand_core::{Rng, UnwrapErr};
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
-use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -39,10 +40,10 @@ pub fn prove(secret: &Scalar, public: &AffinePoint, alpha: &[u8]) -> VrfOutput {
 
     // Pick random nonce k
     let mut k_bytes = [0u8; 32];
-    OsRng.fill_bytes(&mut k_bytes);
+    UnwrapErr(SysRng).fill_bytes(&mut k_bytes);
     let k_fb = p256::FieldBytes::from(k_bytes);
     let k = Option::<Scalar>::from(Scalar::from_repr(k_fb))
-        .unwrap_or_else(|| Scalar::random(&mut OsRng));
+        .unwrap_or_else(|| Scalar::random(&mut UnwrapErr(SysRng)));
 
     // k*G and k*H
     let k_g = (ProjectivePoint::GENERATOR * k).to_affine();
@@ -60,7 +61,7 @@ pub fn prove(secret: &Scalar, public: &AffinePoint, alpha: &[u8]) -> VrfOutput {
     VrfOutput {
         output_hex: hex::encode(output),
         proof: VrfProof {
-            gamma_hex: hex::encode(gamma.to_encoded_point(true).as_bytes()),
+            gamma_hex: hex::encode(gamma.to_sec1_point(true).as_bytes()),
             c_hex: hex::encode(scalar_to_bytes(&c)),
             s_hex: hex::encode(scalar_to_bytes(&s)),
         },
@@ -111,7 +112,7 @@ fn hash_to_curve(alpha: &[u8]) -> AffinePoint {
         hasher.update(counter.to_be_bytes());
         let hash = hasher.finalize();
 
-        let fb = p256::FieldBytes::from(hash);
+        let fb = p256::FieldBytes::try_from(&hash[..]).expect("digest is 32 bytes");
         let ct = Scalar::from_repr(fb);
         if let Some(scalar) = Option::<Scalar>::from(ct) {
             let point = ProjectivePoint::GENERATOR * scalar;
@@ -131,22 +132,22 @@ fn challenge(
 ) -> Scalar {
     let mut hasher = Sha256::new();
     hasher.update(b"confium-vrf-c");
-    hasher.update(public.to_encoded_point(true).as_bytes());
-    hasher.update(h.to_encoded_point(true).as_bytes());
-    hasher.update(gamma.to_encoded_point(true).as_bytes());
-    hasher.update(u.to_encoded_point(true).as_bytes());
-    hasher.update(v.to_encoded_point(true).as_bytes());
+    hasher.update(public.to_sec1_point(true).as_bytes());
+    hasher.update(h.to_sec1_point(true).as_bytes());
+    hasher.update(gamma.to_sec1_point(true).as_bytes());
+    hasher.update(u.to_sec1_point(true).as_bytes());
+    hasher.update(v.to_sec1_point(true).as_bytes());
     hasher.update(alpha);
     let hash = hasher.finalize();
 
-    let fb = p256::FieldBytes::from(hash);
+    let fb = p256::FieldBytes::try_from(&hash[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
 fn hash_output(gamma: &AffinePoint) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(b"confium-vrf-out");
-    hasher.update(gamma.to_encoded_point(true).as_bytes());
+    hasher.update(gamma.to_sec1_point(true).as_bytes());
     let result = hasher.finalize();
     let mut out = [0u8; 32];
     out.copy_from_slice(&result);
@@ -159,8 +160,9 @@ fn scalar_to_bytes(s: &Scalar) -> [u8; 32] {
 
 fn decode_point(hex_str: &str) -> Option<AffinePoint> {
     let bytes = hex::decode(hex_str).ok()?;
-    let encoded = p256::EncodedPoint::from_bytes(&bytes).ok()?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&encoded))
+    let encoded =
+        p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(&bytes).ok()?;
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&encoded))
 }
 
 fn decode_scalar(hex_str: &str) -> Option<Scalar> {
@@ -179,12 +181,12 @@ mod tests {
     use p256::elliptic_curve::Field;
 
     fn random_keypair() -> (Scalar, AffinePoint) {
-        use p256::elliptic_curve::rand_core::RngCore;
+        use p256::elliptic_curve::rand_core::Rng;
         let mut buf = [0u8; 32];
-        OsRng.fill_bytes(&mut buf);
+        UnwrapErr(SysRng).fill_bytes(&mut buf);
         let fb = p256::FieldBytes::from(buf);
         let secret = Option::<Scalar>::from(Scalar::from_repr(fb))
-            .unwrap_or_else(|| Scalar::random(&mut OsRng));
+            .unwrap_or_else(|| Scalar::random(&mut UnwrapErr(SysRng)));
         let public = (ProjectivePoint::GENERATOR * secret).to_affine();
         (secret, public)
     }

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -33,7 +33,7 @@ subtle = "2"
 chrono = "0.4"
 hex = "0.4"
 ed25519-dalek = "2"
-p256 = { version = "0.13", features = ["ecdsa"] }
+p256 = { workspace = true }
 
 [package.metadata.maturin]
 python-source = "python"

--- a/crates/confium-tc-cmp20/Cargo.toml
+++ b/crates/confium-tc-cmp20/Cargo.toml
@@ -22,19 +22,20 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 confium-tc = { workspace = true }
 # Used by the `register_tc_scheme!` macro (absolute path).
 inventory = { workspace = true }
-crypto-bigint = "0.5"
-elliptic-curve = { version = "0.13", features = ["digest", "sec1"] }
+crypto-bigint = { workspace = true }
+elliptic-curve = { workspace = true, features = ["digest", "sec1"] }
 num-bigint = { workspace = true }
-p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "expose-field", "pkcs8", "serde"] }
+p256 = { workspace = true, features = ["pkcs8", "serde"] }
 rand = { workspace = true }
 sha2 = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "expose-field", "pem", "pkcs8"] }
+p256 = { workspace = true, features = ["pkcs8"] }
 rand = { version = "0.8", default-features = false, features = ["std"] }
 rand_core = { version = "0.6", default-features = false }
 confium-transparency = { workspace = true }

--- a/crates/confium-tc-cmp20/src/e2e_signing.rs
+++ b/crates/confium-tc-cmp20/src/e2e_signing.rs
@@ -5,9 +5,10 @@
 
 use crate::paillier_mta;
 use confium_tc::paillier::{self, PaillierKeypair};
+use getrandom::SysRng;
 use num_bigint::BigUint;
 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
-use p256::elliptic_curve::rand_core::OsRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
@@ -56,7 +57,9 @@ impl Cmp20SigningPipeline {
         let _t = self.threshold as usize;
 
         // Step 1: Each party generates a nonce k_i
-        let nonces: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
+        let nonces: Vec<Scalar> = (0..n)
+            .map(|_| Scalar::random(&mut UnwrapErr(SysRng)))
+            .collect();
 
         // Step 2: Run MtA for each pair (i, j) where i != j
         // Compute additive shares of k_i * x_j
@@ -153,8 +156,8 @@ fn biguint_to_scalar(b: &BigUint, _n: &BigUint) -> Scalar {
 }
 
 fn x_coordinate(point: &AffinePoint) -> Scalar {
-    use p256::elliptic_curve::sec1::ToEncodedPoint;
-    let encoded = point.to_encoded_point(false);
+    use p256::elliptic_curve::sec1::ToSec1Point;
+    let encoded = point.to_sec1_point(false);
     if let Some(x_bytes) = encoded.x() {
         let mut arr = [0u8; 32];
         arr.copy_from_slice(x_bytes);
@@ -170,7 +173,7 @@ fn hash_to_scalar(message: &[u8]) -> Scalar {
     let mut hasher = Sha256::new();
     hasher.update(message);
     let hash = hasher.finalize();
-    let fb = p256::FieldBytes::from(hash);
+    let fb = p256::FieldBytes::try_from(&hash[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -179,7 +182,7 @@ mod tests {
     use super::*;
 
     fn random_scalar() -> Scalar {
-        Scalar::random(&mut OsRng)
+        Scalar::random(&mut UnwrapErr(SysRng))
     }
 
     #[test]

--- a/crates/confium-tc-cmp20/src/gg18_e2e.rs
+++ b/crates/confium-tc-cmp20/src/gg18_e2e.rs
@@ -4,9 +4,10 @@
 
 use crate::paillier_mta;
 use confium_tc::paillier::{self, PaillierKeypair};
+use getrandom::SysRng;
 use num_bigint::BigUint;
 use p256::ecdsa::{Signature, VerifyingKey, signature::Verifier};
-use p256::elliptic_curve::rand_core::OsRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
@@ -47,7 +48,9 @@ impl Gg18SigningPipeline {
         let n = self.party_count as usize;
 
         // Round 1: each party generates nonce pair (k_i, gamma_i)
-        let nonces: Vec<Scalar> = (0..n).map(|_| Scalar::random(&mut OsRng)).collect();
+        let nonces: Vec<Scalar> = (0..n)
+            .map(|_| Scalar::random(&mut UnwrapErr(SysRng)))
+            .collect();
 
         // Round 2: MtA for k_i * x_j (same as CMP20)
         for i in 0..n {
@@ -109,8 +112,8 @@ fn scalar_to_biguint(s: &Scalar) -> BigUint {
 }
 
 fn x_coordinate(point: &AffinePoint) -> Scalar {
-    use p256::elliptic_curve::sec1::ToEncodedPoint;
-    let encoded = point.to_encoded_point(false);
+    use p256::elliptic_curve::sec1::ToSec1Point;
+    let encoded = point.to_sec1_point(false);
     if let Some(x_bytes) = encoded.x() {
         let mut arr = [0u8; 32];
         arr.copy_from_slice(x_bytes);
@@ -124,7 +127,7 @@ fn x_coordinate(point: &AffinePoint) -> Scalar {
 fn hash_to_scalar(message: &[u8]) -> Scalar {
     let mut hasher = Sha256::new();
     hasher.update(message);
-    let fb = p256::FieldBytes::from(hasher.finalize());
+    let fb = p256::FieldBytes::try_from(&hasher.finalize()[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -137,7 +140,7 @@ mod tests {
     use super::*;
 
     fn random_scalar() -> Scalar {
-        Scalar::random(&mut OsRng)
+        Scalar::random(&mut UnwrapErr(SysRng))
     }
 
     #[test]

--- a/crates/confium-tc-cmp20/src/inprocess.rs
+++ b/crates/confium-tc-cmp20/src/inprocess.rs
@@ -23,7 +23,7 @@
 //! stub. This driver inherits that property. See
 //! [`crate::mta`] for the gap.
 
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::AffinePoint;
 
 use confium_tc::Result;
@@ -50,7 +50,7 @@ pub struct KeygenOutput {
 pub fn keygen(threshold: u32, party_count: usize) -> Result<KeygenOutput> {
     let shares = driver::run_dkg(crate::DKG_SCHEME_NAME, threshold, party_count)?;
     let first = Cmp20Share::from_bytes(&shares[0])?;
-    let public_key: Vec<u8> = first.public_key.to_encoded_point(true).as_bytes().to_vec();
+    let public_key: Vec<u8> = first.public_key.to_sec1_point(true).as_bytes().to_vec();
     Ok(KeygenOutput { shares, public_key })
 }
 
@@ -95,15 +95,15 @@ pub fn sign_batch(
 /// Decode a 33-byte SEC1 compressed P-256 point. Public so bindings can
 /// verify the DKG-produced joint public key out-of-band.
 pub fn decode_public_key(bytes: &[u8]) -> Result<AffinePoint> {
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(crate::error::scheme_error(
             crate::error::Cmp20ErrorCode::BAD_SHARE,
         ));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| crate::error::scheme_error(crate::error::Cmp20ErrorCode::BAD_SHARE))?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&enc))
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| crate::error::scheme_error(crate::error::Cmp20ErrorCode::BAD_SHARE))
 }
 

--- a/crates/confium-tc-cmp20/src/keygen.rs
+++ b/crates/confium-tc-cmp20/src/keygen.rs
@@ -22,7 +22,8 @@
 //!   and compute the joint public key. Complete.
 
 use elliptic_curve::PrimeField;
-use elliptic_curve::rand_core::OsRng;
+use elliptic_curve::rand_core::UnwrapErr;
+use getrandom::SysRng;
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 
 use confium_tc::Result;
@@ -50,7 +51,7 @@ impl Cmp20DkgP256 {
             .map(|p| p.id.clone())
             .collect();
 
-        let vss = FeldmanVss::deal(&mut OsRng, n, t);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), n, t);
 
         Ok(Box::new(Cmp20DkgSession {
             party_id,
@@ -287,7 +288,7 @@ mod tests {
     use super::*;
     use confium_tc::party::{Party, PartyList};
     use confium_tc::share::Share;
-    use elliptic_curve::sec1::ToEncodedPoint;
+    use elliptic_curve::sec1::ToSec1Point;
 
     fn params(n: usize, t: u32, idx: usize) -> SessionParams {
         let roster: Vec<Party> = (0..n).map(|i| Party::inproc(format!("p{}", i))).collect();
@@ -363,8 +364,8 @@ mod tests {
         assert_eq!(shares.len(), 3);
         let pk0 = shares[0].public_key;
         for s in &shares[1..] {
-            let a = pk0.to_encoded_point(true);
-            let b = s.public_key.to_encoded_point(true);
+            let a = pk0.to_sec1_point(true);
+            let b = s.public_key.to_sec1_point(true);
             assert_eq!(a.as_bytes(), b.as_bytes(), "joint public key must match");
         }
         let secret_01 = reconstruct_secret_for_test(&shares[0..2]);
@@ -374,8 +375,8 @@ mod tests {
         assert_eq!(secret_02, secret_12);
         let g = ProjectivePoint::GENERATOR;
         let expected_pk = (g * secret_01).to_affine();
-        let got_pk = shares[0].public_key.to_encoded_point(true);
-        let want_pk = expected_pk.to_encoded_point(true);
+        let got_pk = shares[0].public_key.to_sec1_point(true);
+        let want_pk = expected_pk.to_sec1_point(true);
         assert_eq!(got_pk.as_bytes(), want_pk.as_bytes());
     }
 
@@ -384,10 +385,10 @@ mod tests {
         let shares = run_dkg(3, 3);
         let secret = reconstruct_secret_for_test(&shares);
         let g = ProjectivePoint::GENERATOR;
-        let pk = (g * secret).to_affine().to_encoded_point(true);
+        let pk = (g * secret).to_affine().to_sec1_point(true);
         assert_eq!(
             pk.as_bytes(),
-            shares[0].public_key.to_encoded_point(true).as_bytes()
+            shares[0].public_key.to_sec1_point(true).as_bytes()
         );
     }
 

--- a/crates/confium-tc-cmp20/src/refresh.rs
+++ b/crates/confium-tc-cmp20/src/refresh.rs
@@ -31,8 +31,9 @@
 //! let sig = inprocess::sign(&refreshed_shares[..2], 2, b"refreshed").unwrap();
 //! ```
 
-use elliptic_curve::rand_core::OsRng;
-use elliptic_curve::rand_core::RngCore;
+use elliptic_curve::rand_core::Rng;
+use elliptic_curve::rand_core::UnwrapErr;
+use getrandom::SysRng;
 use p256::{FieldBytes, Scalar, elliptic_curve::PrimeField};
 
 /// One party's refresh contribution: `(source_party_index, target_party_index, refresh_scalar_bytes)`.
@@ -172,7 +173,7 @@ fn evaluate_polynomial(coeffs: &[Scalar], x: u32) -> Scalar {
 fn random_scalar() -> Scalar {
     loop {
         let mut buf = [0u8; 32];
-        OsRng.fill_bytes(&mut buf);
+        UnwrapErr(SysRng).fill_bytes(&mut buf);
         let fb = FieldBytes::from(buf);
         if let Some(s) = Option::<Scalar>::from(Scalar::from_repr(fb)) {
             if s != Scalar::ZERO {

--- a/crates/confium-tc-cmp20/src/share.rs
+++ b/crates/confium-tc-cmp20/src/share.rs
@@ -1,6 +1,6 @@
 //! Per-party share material produced by CMP20 DKG and consumed by signing.
 
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, FieldBytes, NonZeroScalar, Scalar};
 use zeroize::Zeroize;
 
@@ -44,7 +44,7 @@ impl Cmp20Share {
         out.extend_from_slice(&SHARE_MAGIC);
         out.push(SHARE_VERSION);
         out.extend_from_slice(&self.x_i.to_bytes());
-        out.extend_from_slice(self.public_key.to_encoded_point(true).as_bytes());
+        out.extend_from_slice(self.public_key.to_sec1_point(true).as_bytes());
         out.push(self.party_idx as u8);
         out
     }
@@ -90,13 +90,13 @@ impl Cmp20Share {
 /// Decode a 33-byte SEC1 compressed point into an [`AffinePoint`].
 pub(crate) fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
     use elliptic_curve::point::AffineCoordinates;
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(scheme_error(Cmp20ErrorCode::BAD_SHARE));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| scheme_error(Cmp20ErrorCode::BAD_SHARE))?;
-    let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))
+    let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| scheme_error(Cmp20ErrorCode::BAD_SHARE))?;
     let _ = pt.x();
     Ok(pt)
@@ -105,10 +105,11 @@ pub(crate) fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elliptic_curve::rand_core::OsRng;
+
+    use elliptic_curve::Generate;
 
     fn random_share(idx: u32) -> Cmp20Share {
-        let x_i = NonZeroScalar::random(&mut OsRng);
+        let x_i = NonZeroScalar::generate();
         let g = p256::ProjectivePoint::GENERATOR;
         let pk = (g * *x_i).to_affine();
         Cmp20Share::from_parts(x_i, pk, idx)

--- a/crates/confium-tc-cmp20/src/sign.rs
+++ b/crates/confium-tc-cmp20/src/sign.rs
@@ -35,8 +35,8 @@
 //! validity is the byzantine one); real CMP20 achieves it
 //! cryptographically via range proofs and per-partial consistency checks.
 
-use elliptic_curve::rand_core::OsRng;
-use elliptic_curve::{PrimeField, ops::Invert, point::AffineCoordinates, sec1::ToEncodedPoint};
+use elliptic_curve::Generate;
+use elliptic_curve::{PrimeField, ops::Invert, point::AffineCoordinates, sec1::ToSec1Point};
 use p256::{AffinePoint, NonZeroScalar, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
 
@@ -63,7 +63,7 @@ impl Cmp20SignP256 {
             .ok_or_else(|| scheme_error(Cmp20ErrorCode::BAD_SHARE))?;
         let share = Cmp20Share::from_bytes(&share_bytes)?;
 
-        let k_i = NonZeroScalar::random(&mut OsRng);
+        let k_i = NonZeroScalar::generate();
         let r_i_point = (ProjectivePoint::GENERATOR * *k_i).to_affine();
 
         Ok(Box::new(Cmp20SignSession {
@@ -109,7 +109,7 @@ impl Cmp20SignSession {
         let mut payload = Vec::with_capacity(1 + 1 + 33);
         payload.push(TAG_NONCE_POINT);
         payload.push(self.share.party_idx as u8);
-        payload.extend_from_slice(self.r_i_point.to_encoded_point(true).as_bytes());
+        payload.extend_from_slice(self.r_i_point.to_sec1_point(true).as_bytes());
         Ok(RoundResult::new(
             vec![Message::broadcast(&self.party_id, 1, payload)],
             false,
@@ -420,15 +420,14 @@ fn hash_to_scalar(message: &[u8]) -> Scalar {
 }
 
 fn normalize_s_low(s: Scalar) -> Scalar {
-    use crypto_bigint::Encoding as _;
     use crypto_bigint::Limb;
     use elliptic_curve::Curve;
     use p256::NistP256;
-    let n = <NistP256 as Curve>::ORDER;
-    let half = n >> 1usize;
+    let n_u = <NistP256 as Curve>::ORDER.get();
+    let half = n_u >> 1usize;
     let s_u = decode_scalar_to_uint(s);
     if s_u > half {
-        let (s_prime, _) = n.sbb(&s_u, Limb::ZERO);
+        let (s_prime, _) = n_u.borrowing_sub(&s_u, Limb::ZERO);
         let be = s_prime.to_be_bytes();
         let src: &[u8] = be.as_slice();
         let mut bytes = [0u8; 32];
@@ -450,13 +449,13 @@ fn decode_scalar_to_uint(s: Scalar) -> p256::U256 {
 }
 
 fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(scheme_error(Cmp20ErrorCode::BAD_ROUND_MESSAGE));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| scheme_error(Cmp20ErrorCode::BAD_ROUND_MESSAGE))?;
-    let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))
+    let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| scheme_error(Cmp20ErrorCode::BAD_ROUND_MESSAGE))?;
     let _ = pt.x();
     Ok(pt)

--- a/crates/confium-tc-cmp20/src/vss.rs
+++ b/crates/confium-tc-cmp20/src/vss.rs
@@ -13,8 +13,8 @@
 //! evaluation into the same message, so no second round is needed.
 
 use elliptic_curve::Field;
-use elliptic_curve::rand_core::CryptoRngCore;
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::rand_core::CryptoRng;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 
 /// One dealer's Feldman VSS output.
@@ -26,7 +26,7 @@ pub struct FeldmanVss {
 }
 
 impl FeldmanVss {
-    pub fn deal(rng: &mut impl CryptoRngCore, n: usize, t: usize) -> Self {
+    pub fn deal(rng: &mut impl CryptoRng, n: usize, t: usize) -> Self {
         debug_assert!(t >= 1 && t <= n);
         let mut coeffs: Vec<Scalar> = (0..t).map(|_| Scalar::random(&mut *rng)).collect();
         let secret = coeffs[0];
@@ -69,7 +69,7 @@ impl FeldmanVss {
     pub fn encode_commitments(commitments: &[AffinePoint]) -> Vec<u8> {
         let mut out = Vec::with_capacity(commitments.len() * 33);
         for c in commitments {
-            out.extend_from_slice(c.to_encoded_point(true).as_bytes());
+            out.extend_from_slice(c.to_sec1_point(true).as_bytes());
         }
         out
     }
@@ -79,12 +79,12 @@ impl FeldmanVss {
             return None;
         }
         use elliptic_curve::point::AffineCoordinates;
-        use elliptic_curve::sec1::FromEncodedPoint;
+        use elliptic_curve::sec1::FromSec1Point;
         use p256::NistP256;
         let mut out = Vec::with_capacity(bytes.len() / 33);
         for chunk in bytes.chunks_exact(33) {
-            let enc = elliptic_curve::sec1::EncodedPoint::<NistP256>::from_bytes(chunk).ok()?;
-            let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))?;
+            let enc = elliptic_curve::sec1::Sec1Point::<NistP256>::from_bytes(chunk).ok()?;
+            let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))?;
             let _ = pt.x();
             out.push(pt);
         }
@@ -99,11 +99,12 @@ impl FeldmanVss {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elliptic_curve::rand_core::OsRng;
+    use elliptic_curve::rand_core::UnwrapErr;
+    use getrandom::SysRng;
 
     #[test]
     fn feldman_share_verifies() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         for (i, &share) in vss.shares.iter().enumerate() {
             assert!(
                 FeldmanVss::verify_share(&vss.commitments, (i + 1) as u64, share),
@@ -115,20 +116,20 @@ mod tests {
 
     #[test]
     fn feldman_rejects_tampered_share() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         let bad_share = vss.shares[0] + Scalar::from(1u64);
         assert!(!FeldmanVss::verify_share(&vss.commitments, 1, bad_share));
     }
 
     #[test]
     fn feldman_commitments_round_trip() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         let enc = FeldmanVss::encode_commitments(&vss.commitments);
         let dec = FeldmanVss::decode_commitments(&enc).expect("decode");
         assert_eq!(dec.len(), vss.commitments.len());
         for (a, b) in vss.commitments.iter().zip(dec.iter()) {
-            let ab = a.to_encoded_point(true);
-            let bb = b.to_encoded_point(true);
+            let ab = a.to_sec1_point(true);
+            let bb = b.to_sec1_point(true);
             assert_eq!(ab.as_bytes(), bb.as_bytes());
         }
     }

--- a/crates/confium-tc-cmp20/tests/threshold_signing.rs
+++ b/crates/confium-tc-cmp20/tests/threshold_signing.rs
@@ -288,10 +288,10 @@ fn dkg_completes_in_single_broadcast_round() {
         .public_key;
     for s in &shares[1..] {
         let pk = Cmp20Share::from_bytes(s).expect("share").public_key;
-        use elliptic_curve::sec1::ToEncodedPoint;
+        use elliptic_curve::sec1::ToSec1Point;
         assert_eq!(
-            pk0.to_encoded_point(true).as_bytes(),
-            pk.to_encoded_point(true).as_bytes(),
+            pk0.to_sec1_point(true).as_bytes(),
+            pk.to_sec1_point(true).as_bytes(),
             "joint public key must match across all parties"
         );
     }

--- a/crates/confium-tc-core/Cargo.toml
+++ b/crates/confium-tc-core/Cargo.toml
@@ -21,6 +21,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
 serde = { workspace = true }

--- a/crates/confium-tc-core/src/nonce.rs
+++ b/crates/confium-tc-core/src/nonce.rs
@@ -92,10 +92,10 @@ fn reduce_mod_order(bytes: &[u8; 32]) -> Scalar {
 mod tests {
     use super::*;
     use p256::elliptic_curve::Field;
-    use p256::elliptic_curve::rand_core::OsRng;
+    use p256::elliptic_curve::rand_core::UnwrapErr;
 
     fn random_scalar() -> Scalar {
-        Scalar::random(&mut OsRng)
+        Scalar::random(&mut UnwrapErr(getrandom::SysRng))
     }
 
     #[test]

--- a/crates/confium-tc-ecies-p256/Cargo.toml
+++ b/crates/confium-tc-ecies-p256/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }

--- a/crates/confium-tc-ecies-p256/src/keys.rs
+++ b/crates/confium-tc-ecies-p256/src/keys.rs
@@ -2,7 +2,7 @@
 
 use p256::elliptic_curve::PrimeField;
 use p256::elliptic_curve::rand_core;
-use p256::elliptic_curve::rand_core::RngCore;
+use p256::elliptic_curve::rand_core::Rng;
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 
 /// A P-256 keypair.
@@ -18,7 +18,7 @@ pub struct Keypair {
 pub fn generate_keypair() -> Keypair {
     let secret = loop {
         let mut buf = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut buf);
+        rand_core::UnwrapErr(getrandom::SysRng).fill_bytes(&mut buf);
         if let Some(s) = Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(buf))) {
             if s != Scalar::ZERO {
                 break s;

--- a/crates/confium-tc-ecies-p256/src/lib.rs
+++ b/crates/confium-tc-ecies-p256/src/lib.rs
@@ -26,10 +26,11 @@ pub mod shamir;
 use aes_gcm::{AeadInPlace, Aes256Gcm, KeyInit, Nonce};
 use p256::elliptic_curve::PrimeField;
 use p256::elliptic_curve::rand_core;
-use p256::elliptic_curve::rand_core::RngCore;
-use p256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use p256::elliptic_curve::rand_core::Rng;
+use p256::elliptic_curve::sec1::Sec1Point;
+use p256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 use p256::elliptic_curve::subtle::CtOption;
-use p256::{AffinePoint, EncodedPoint, FieldBytes, ProjectivePoint, Scalar};
+use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 
 pub use keys::generate_keypair;
@@ -49,7 +50,7 @@ impl PublicKey {
     /// Construct from an affine point.
     pub fn from_affine(point: AffinePoint) -> Self {
         Self {
-            bytes: point.to_encoded_point(false).as_bytes().to_vec(),
+            bytes: point.to_sec1_point(false).as_bytes().to_vec(),
         }
     }
 }
@@ -111,20 +112,16 @@ pub enum EciesError {
 }
 
 fn decode_point(bytes: &[u8]) -> Result<ProjectivePoint, EciesError> {
-    let ep = EncodedPoint::from_bytes(bytes)
+    let ep = Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|e| EciesError::Sec1Decode(format!("encoded point: {e}")))?;
-    let ct_opt: CtOption<AffinePoint> = AffinePoint::from_encoded_point(&ep);
+    let ct_opt = AffinePoint::from_sec1_point(&ep);
     let affine = Option::<AffinePoint>::from(ct_opt)
         .ok_or_else(|| EciesError::Sec1Decode("point at infinity".into()))?;
     Ok(ProjectivePoint::from(affine))
 }
 
 fn encode_point(point: &ProjectivePoint) -> Vec<u8> {
-    point
-        .to_affine()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec()
+    point.to_affine().to_sec1_point(false).as_bytes().to_vec()
 }
 
 fn decode_scalar(bytes: &[u8]) -> Result<Scalar, EciesError> {
@@ -142,7 +139,7 @@ fn decode_scalar(bytes: &[u8]) -> Result<Scalar, EciesError> {
 }
 
 fn x_coordinate(point: &ProjectivePoint) -> [u8; 32] {
-    let ep = point.to_affine().to_encoded_point(false);
+    let ep = point.to_affine().to_sec1_point(false);
     let bytes = ep.as_bytes();
     if bytes.len() == 65 {
         let mut arr = [0u8; 32];
@@ -173,7 +170,7 @@ pub fn encrypt(recipient: &PublicKey, plaintext: &[u8]) -> Result<EncryptedBlob,
     // Ephemeral scalar
     let r = loop {
         let mut buf = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut buf);
+        rand_core::UnwrapErr(getrandom::SysRng).fill_bytes(&mut buf);
         if let Some(s) = Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(buf))) {
             if s != Scalar::ZERO {
                 break s;
@@ -195,7 +192,7 @@ pub fn encrypt(recipient: &PublicKey, plaintext: &[u8]) -> Result<EncryptedBlob,
 
     // Generate nonce
     let mut nonce_bytes = [0u8; 12];
-    rand_core::OsRng.fill_bytes(&mut nonce_bytes);
+    rand_core::UnwrapErr(getrandom::SysRng).fill_bytes(&mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
     // Encrypt

--- a/crates/confium-tc-ecies-p256/src/shamir.rs
+++ b/crates/confium-tc-ecies-p256/src/shamir.rs
@@ -70,7 +70,7 @@ pub fn recover_secret(shares: &[&Share]) -> Result<Scalar, ShamirError> {
 }
 
 fn random_scalar() -> Scalar {
-    Scalar::random(rand_core::OsRng)
+    Scalar::random(&mut rand_core::UnwrapErr(getrandom::SysRng))
 }
 
 fn evaluate_polynomial(coeffs: &[Scalar], x: &Scalar) -> Scalar {

--- a/crates/confium-tc-elgamal-p256/Cargo.toml
+++ b/crates/confium-tc-elgamal-p256/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }

--- a/crates/confium-tc-elgamal-p256/src/keys.rs
+++ b/crates/confium-tc-elgamal-p256/src/keys.rs
@@ -2,7 +2,7 @@
 
 use p256::elliptic_curve::PrimeField;
 use p256::elliptic_curve::rand_core;
-use p256::elliptic_curve::rand_core::RngCore;
+use p256::elliptic_curve::rand_core::Rng;
 use p256::elliptic_curve::subtle::CtOption;
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 
@@ -19,7 +19,7 @@ pub struct Keypair {
 pub fn generate_keypair() -> Keypair {
     let secret = loop {
         let mut buf = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut buf);
+        rand_core::UnwrapErr(getrandom::SysRng).fill_bytes(&mut buf);
         if let Some(s) = CtOption::into(Scalar::from_repr(FieldBytes::from(buf))) {
             if s != Scalar::ZERO {
                 break s;

--- a/crates/confium-tc-elgamal-p256/src/lib.rs
+++ b/crates/confium-tc-elgamal-p256/src/lib.rs
@@ -17,7 +17,7 @@ pub mod shamir;
 
 use p256::elliptic_curve::PrimeField;
 use p256::elliptic_curve::rand_core;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::elliptic_curve::subtle::CtOption;
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,7 @@ impl PublicKey {
     /// Construct from an affine point.
     pub fn from_affine(point: AffinePoint) -> Self {
         Self {
-            bytes: point.to_encoded_point(false).as_bytes().to_vec(),
+            bytes: point.to_sec1_point(false).as_bytes().to_vec(),
         }
     }
 }
@@ -102,21 +102,17 @@ pub enum ElGamalError {
 }
 
 fn decode_point(bytes: &[u8]) -> Result<ProjectivePoint, ElGamalError> {
-    use p256::elliptic_curve::sec1::FromEncodedPoint;
-    let ep = p256::EncodedPoint::from_bytes(bytes)
+    use p256::elliptic_curve::sec1::FromSec1Point;
+    let ep = p256::elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|e| ElGamalError::Sec1Decode(format!("encoded point: {e}")))?;
-    let ct_opt: CtOption<AffinePoint> = AffinePoint::from_encoded_point(&ep);
+    let ct_opt = AffinePoint::from_sec1_point(&ep);
     let affine = Option::<AffinePoint>::from(ct_opt)
         .ok_or_else(|| ElGamalError::Sec1Decode("point at infinity".into()))?;
     Ok(ProjectivePoint::from(affine))
 }
 
 fn encode_point(point: &ProjectivePoint) -> Vec<u8> {
-    point
-        .to_affine()
-        .to_encoded_point(false)
-        .as_bytes()
-        .to_vec()
+    point.to_affine().to_sec1_point(false).as_bytes().to_vec()
 }
 
 fn decode_scalar(bytes: &[u8]) -> Result<Scalar, ElGamalError> {
@@ -146,14 +142,14 @@ fn decode_scalar(bytes: &[u8]) -> Result<Scalar, ElGamalError> {
 pub fn encapsulate(
     recipient_public_key: &PublicKey,
 ) -> Result<(Ciphertext, Vec<u8>), ElGamalError> {
-    use p256::elliptic_curve::rand_core::RngCore;
+    use p256::elliptic_curve::rand_core::Rng;
 
     let recipient_pt = decode_point(&recipient_public_key.bytes)?;
 
     // Random ephemeral scalar
     let r = loop {
         let mut buf = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut buf);
+        rand_core::UnwrapErr(getrandom::SysRng).fill_bytes(&mut buf);
         if let Some(s) = Option::<Scalar>::from(Scalar::from_repr(FieldBytes::from(buf))) {
             if s != Scalar::ZERO {
                 break s;
@@ -242,7 +238,7 @@ pub fn aggregate_partials(
 
 fn x_coordinate(point: &ProjectivePoint) -> Vec<u8> {
     let affine = point.to_affine();
-    let ep = affine.to_encoded_point(false);
+    let ep = affine.to_sec1_point(false);
     let bytes = ep.as_bytes();
     if bytes.len() == 65 {
         bytes[1..33].to_vec()

--- a/crates/confium-tc-elgamal-p256/src/shamir.rs
+++ b/crates/confium-tc-elgamal-p256/src/shamir.rs
@@ -71,7 +71,7 @@ pub fn recover_secret(shares: &[&Share]) -> Result<Scalar, ShamirError> {
 }
 
 fn random_scalar() -> Scalar {
-    Scalar::random(rand_core::OsRng)
+    Scalar::random(&mut rand_core::UnwrapErr(getrandom::SysRng))
 }
 
 fn evaluate_polynomial(coeffs: &[Scalar], x: &Scalar) -> Scalar {

--- a/crates/confium-tc-frost-p256/Cargo.toml
+++ b/crates/confium-tc-frost-p256/Cargo.toml
@@ -19,9 +19,9 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 thiserror = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa", "arithmetic"] }
-rand_core = { workspace = true }
 elliptic-curve = { workspace = true, features = ["pkcs8", "sec1"] }
 zeroize = { workspace = true }
 

--- a/crates/confium-tc-frost-p256/src/keys.rs
+++ b/crates/confium-tc-frost-p256/src/keys.rs
@@ -4,7 +4,7 @@ use crate::scalar;
 use p256::{
     AffinePoint, ProjectivePoint, Scalar,
     ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::sec1::ToEncodedPoint,
+    elliptic_curve::sec1::ToSec1Point,
 };
 
 /// A P-256 keypair.
@@ -53,7 +53,7 @@ pub fn public_key_for(secret: &Scalar) -> AffinePoint {
 
 /// SEC1-encoded public key bytes (uncompressed, 65 bytes).
 pub fn public_key_sec1(affine: &AffinePoint) -> Vec<u8> {
-    affine.to_encoded_point(false).as_bytes().to_vec()
+    affine.to_sec1_point(false).as_bytes().to_vec()
 }
 
 #[cfg(test)]

--- a/crates/confium-tc-frost-p256/src/scalar.rs
+++ b/crates/confium-tc-frost-p256/src/scalar.rs
@@ -50,7 +50,9 @@ pub fn scalar_invert(a: &Scalar) -> Scalar {
 
 /// Generate a random scalar.
 pub fn random_scalar() -> Scalar {
-    Scalar::random(rand_core::OsRng)
+    Scalar::random(&mut p256::elliptic_curve::rand_core::UnwrapErr(
+        getrandom::SysRng,
+    ))
 }
 
 #[cfg(test)]

--- a/crates/confium-tc-gg18/Cargo.toml
+++ b/crates/confium-tc-gg18/Cargo.toml
@@ -22,17 +22,18 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+getrandom = { workspace = true }
 confium-tc = { workspace = true }
 # Used by the `register_tc_scheme!` macro (absolute path).
 inventory = { workspace = true }
-crypto-bigint = "0.5"
-elliptic-curve = { version = "0.13", features = ["digest", "sec1"] }
-p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "expose-field", "pkcs8", "serde"] }
+crypto-bigint = { workspace = true }
+elliptic-curve = { workspace = true, features = ["digest", "sec1"] }
+p256 = { workspace = true, features = ["pkcs8", "serde"] }
 sha2 = { workspace = true }
 zeroize = { workspace = true }
 
 [dev-dependencies]
-p256 = { version = "0.13", features = ["arithmetic", "ecdsa", "expose-field", "pem", "pkcs8"] }
+p256 = { workspace = true, features = ["pkcs8"] }
 rand = { version = "0.8", default-features = false, features = ["std"] }
 rand_core = { version = "0.6", default-features = false }
 

--- a/crates/confium-tc-gg18/src/inprocess.rs
+++ b/crates/confium-tc-gg18/src/inprocess.rs
@@ -23,7 +23,7 @@
 //! stub. This driver inherits that property. See
 //! [`crate::mta`] for the gap.
 
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::AffinePoint;
 
 use confium_tc::Result;
@@ -50,7 +50,7 @@ pub struct KeygenOutput {
 pub fn keygen(threshold: u32, party_count: usize) -> Result<KeygenOutput> {
     let shares = driver::run_dkg(crate::DKG_SCHEME_NAME, threshold, party_count)?;
     let first = Gg18Share::from_bytes(&shares[0])?;
-    let public_key: Vec<u8> = first.public_key.to_encoded_point(true).as_bytes().to_vec();
+    let public_key: Vec<u8> = first.public_key.to_sec1_point(true).as_bytes().to_vec();
     Ok(KeygenOutput { shares, public_key })
 }
 
@@ -82,15 +82,15 @@ pub fn sign_batch(
 /// Decode a 33-byte SEC1 compressed P-256 point. Public so bindings can
 /// verify the DKG-produced joint public key out-of-band.
 pub fn decode_public_key(bytes: &[u8]) -> Result<AffinePoint> {
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(crate::error::scheme_error(
             crate::error::Gg18ErrorCode::BAD_SHARE,
         ));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| crate::error::scheme_error(crate::error::Gg18ErrorCode::BAD_SHARE))?;
-    Option::<AffinePoint>::from(AffinePoint::from_encoded_point(&enc))
+    Option::<AffinePoint>::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| crate::error::scheme_error(crate::error::Gg18ErrorCode::BAD_SHARE))
 }
 

--- a/crates/confium-tc-gg18/src/keygen.rs
+++ b/crates/confium-tc-gg18/src/keygen.rs
@@ -15,7 +15,8 @@
 //!   `x_i`, compute the joint public key. Complete.
 
 use elliptic_curve::PrimeField;
-use elliptic_curve::rand_core::OsRng;
+use elliptic_curve::rand_core::UnwrapErr;
+use getrandom::SysRng;
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 
 use confium_tc::Result;
@@ -43,7 +44,7 @@ impl Gg18DkgP256 {
             .map(|p| p.id.clone())
             .collect();
 
-        let vss = FeldmanVss::deal(&mut OsRng, n, t);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), n, t);
 
         Ok(Box::new(Gg18DkgSession {
             party_id,
@@ -263,7 +264,7 @@ mod tests {
     use super::*;
     use confium_tc::party::{Party, PartyList};
     use confium_tc::share::Share;
-    use elliptic_curve::sec1::ToEncodedPoint;
+    use elliptic_curve::sec1::ToSec1Point;
 
     fn params(n: usize, t: u32, idx: usize) -> SessionParams {
         let roster: Vec<Party> = (0..n).map(|i| Party::inproc(format!("p{}", i))).collect();
@@ -326,8 +327,8 @@ mod tests {
         assert_eq!(shares.len(), 3);
         let pk0 = shares[0].public_key;
         for s in &shares[1..] {
-            let a = pk0.to_encoded_point(true);
-            let b = s.public_key.to_encoded_point(true);
+            let a = pk0.to_sec1_point(true);
+            let b = s.public_key.to_sec1_point(true);
             assert_eq!(a.as_bytes(), b.as_bytes(), "joint public key must match");
         }
         let secret_01 = reconstruct_secret_for_test(&shares[0..2]);
@@ -337,8 +338,8 @@ mod tests {
         assert_eq!(secret_02, secret_12);
         let g = ProjectivePoint::GENERATOR;
         let expected_pk = (g * secret_01).to_affine();
-        let got_pk = shares[0].public_key.to_encoded_point(true);
-        let want_pk = expected_pk.to_encoded_point(true);
+        let got_pk = shares[0].public_key.to_sec1_point(true);
+        let want_pk = expected_pk.to_sec1_point(true);
         assert_eq!(got_pk.as_bytes(), want_pk.as_bytes());
     }
 
@@ -347,10 +348,10 @@ mod tests {
         let shares = run_dkg(3, 3);
         let secret = reconstruct_secret_for_test(&shares);
         let g = ProjectivePoint::GENERATOR;
-        let pk = (g * secret).to_affine().to_encoded_point(true);
+        let pk = (g * secret).to_affine().to_sec1_point(true);
         assert_eq!(
             pk.as_bytes(),
-            shares[0].public_key.to_encoded_point(true).as_bytes()
+            shares[0].public_key.to_sec1_point(true).as_bytes()
         );
     }
 

--- a/crates/confium-tc-gg18/src/share.rs
+++ b/crates/confium-tc-gg18/src/share.rs
@@ -1,6 +1,6 @@
 //! Per-party share material produced by GG18 DKG and consumed by signing.
 
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, FieldBytes, NonZeroScalar, Scalar};
 use zeroize::Zeroize;
 
@@ -44,7 +44,7 @@ impl Gg18Share {
         out.extend_from_slice(&SHARE_MAGIC);
         out.push(SHARE_VERSION);
         out.extend_from_slice(&self.x_i.to_bytes());
-        out.extend_from_slice(self.public_key.to_encoded_point(true).as_bytes());
+        out.extend_from_slice(self.public_key.to_sec1_point(true).as_bytes());
         out.push(self.party_idx as u8);
         out
     }
@@ -90,13 +90,13 @@ impl Gg18Share {
 /// Decode a 33-byte SEC1 compressed point into an [`AffinePoint`].
 pub(crate) fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
     use elliptic_curve::point::AffineCoordinates;
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(scheme_error(Gg18ErrorCode::BAD_SHARE));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| scheme_error(Gg18ErrorCode::BAD_SHARE))?;
-    let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))
+    let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| scheme_error(Gg18ErrorCode::BAD_SHARE))?;
     let _ = pt.x();
     Ok(pt)
@@ -105,10 +105,10 @@ pub(crate) fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elliptic_curve::rand_core::OsRng;
+    use elliptic_curve::Generate;
 
     fn random_share(idx: u32) -> Gg18Share {
-        let x_i = NonZeroScalar::random(&mut OsRng);
+        let x_i = NonZeroScalar::generate();
         let g = p256::ProjectivePoint::GENERATOR;
         let pk = (g * *x_i).to_affine();
         Gg18Share::from_parts(x_i, pk, idx)

--- a/crates/confium-tc-gg18/src/sign.rs
+++ b/crates/confium-tc-gg18/src/sign.rs
@@ -21,8 +21,8 @@
 //! multiple signatures over the same secret. Production GG18 hides `k`
 //! via Paillier-based MtA. See [`crate::mta`] for the gap.
 
-use elliptic_curve::rand_core::OsRng;
-use elliptic_curve::{PrimeField, ops::Invert, point::AffineCoordinates, sec1::ToEncodedPoint};
+use elliptic_curve::Generate;
+use elliptic_curve::{PrimeField, ops::Invert, point::AffineCoordinates, sec1::ToSec1Point};
 use p256::{AffinePoint, NonZeroScalar, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
 
@@ -49,7 +49,7 @@ impl Gg18SignP256 {
             .ok_or_else(|| scheme_error(Gg18ErrorCode::BAD_SHARE))?;
         let share = Gg18Share::from_bytes(&share_bytes)?;
 
-        let k_i = NonZeroScalar::random(&mut OsRng);
+        let k_i = NonZeroScalar::generate();
         let r_i_point = (ProjectivePoint::GENERATOR * *k_i).to_affine();
 
         Ok(Box::new(Gg18SignSession {
@@ -95,7 +95,7 @@ impl Gg18SignSession {
         let mut payload = Vec::with_capacity(1 + 1 + 33);
         payload.push(TAG_NONCE_POINT);
         payload.push(self.share.party_idx as u8);
-        payload.extend_from_slice(self.r_i_point.to_encoded_point(true).as_bytes());
+        payload.extend_from_slice(self.r_i_point.to_sec1_point(true).as_bytes());
         Ok(RoundResult::new(
             vec![Message::broadcast(&self.party_id, 1, payload)],
             false,
@@ -340,15 +340,14 @@ fn hash_to_scalar(message: &[u8]) -> Scalar {
 }
 
 fn normalize_s_low(s: Scalar) -> Scalar {
-    use crypto_bigint::Encoding as _;
     use crypto_bigint::Limb;
     use elliptic_curve::Curve;
     use p256::NistP256;
-    let n = <NistP256 as Curve>::ORDER;
-    let half = n >> 1usize;
+    let n_u = <NistP256 as Curve>::ORDER.get();
+    let half = n_u >> 1usize;
     let s_u = decode_scalar_to_uint(s);
     if s_u > half {
-        let (s_prime, _) = n.sbb(&s_u, Limb::ZERO);
+        let (s_prime, _) = n_u.borrowing_sub(&s_u, Limb::ZERO);
         let be = s_prime.to_be_bytes();
         let src: &[u8] = be.as_slice();
         let mut bytes = [0u8; 32];
@@ -370,13 +369,13 @@ fn decode_scalar_to_uint(s: Scalar) -> p256::U256 {
 }
 
 fn decode_affine(bytes: &[u8]) -> Result<AffinePoint> {
-    use elliptic_curve::sec1::FromEncodedPoint;
+    use elliptic_curve::sec1::FromSec1Point;
     if bytes.len() != 33 {
         return Err(scheme_error(Gg18ErrorCode::BAD_ROUND_MESSAGE));
     }
-    let enc = elliptic_curve::sec1::EncodedPoint::<p256::NistP256>::from_bytes(bytes)
+    let enc = elliptic_curve::sec1::Sec1Point::<p256::NistP256>::from_bytes(bytes)
         .map_err(|_| scheme_error(Gg18ErrorCode::BAD_ROUND_MESSAGE))?;
-    let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))
+    let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))
         .ok_or_else(|| scheme_error(Gg18ErrorCode::BAD_ROUND_MESSAGE))?;
     let _ = pt.x();
     Ok(pt)

--- a/crates/confium-tc-gg18/src/vss.rs
+++ b/crates/confium-tc-gg18/src/vss.rs
@@ -8,8 +8,8 @@
 //! `C_0 = g^{secret}` is the public key for the shared secret.
 
 use elliptic_curve::Field;
-use elliptic_curve::rand_core::CryptoRngCore;
-use elliptic_curve::sec1::ToEncodedPoint;
+use elliptic_curve::rand_core::CryptoRng;
+use elliptic_curve::sec1::ToSec1Point;
 use p256::{AffinePoint, ProjectivePoint, Scalar};
 
 /// One dealer's Feldman VSS output.
@@ -21,7 +21,7 @@ pub struct FeldmanVss {
 }
 
 impl FeldmanVss {
-    pub fn deal(rng: &mut impl CryptoRngCore, n: usize, t: usize) -> Self {
+    pub fn deal(rng: &mut impl CryptoRng, n: usize, t: usize) -> Self {
         debug_assert!(t >= 1 && t <= n);
         let mut coeffs: Vec<Scalar> = (0..t).map(|_| Scalar::random(&mut *rng)).collect();
         let secret = coeffs[0];
@@ -64,7 +64,7 @@ impl FeldmanVss {
     pub fn encode_commitments(commitments: &[AffinePoint]) -> Vec<u8> {
         let mut out = Vec::with_capacity(commitments.len() * 33);
         for c in commitments {
-            out.extend_from_slice(c.to_encoded_point(true).as_bytes());
+            out.extend_from_slice(c.to_sec1_point(true).as_bytes());
         }
         out
     }
@@ -74,12 +74,12 @@ impl FeldmanVss {
             return None;
         }
         use elliptic_curve::point::AffineCoordinates;
-        use elliptic_curve::sec1::FromEncodedPoint;
+        use elliptic_curve::sec1::FromSec1Point;
         use p256::NistP256;
         let mut out = Vec::with_capacity(bytes.len() / 33);
         for chunk in bytes.chunks_exact(33) {
-            let enc = elliptic_curve::sec1::EncodedPoint::<NistP256>::from_bytes(chunk).ok()?;
-            let pt: AffinePoint = Option::from(AffinePoint::from_encoded_point(&enc))?;
+            let enc = elliptic_curve::sec1::Sec1Point::<NistP256>::from_bytes(chunk).ok()?;
+            let pt: AffinePoint = Option::from(AffinePoint::from_sec1_point(&enc))?;
             let _ = pt.x();
             out.push(pt);
         }
@@ -94,11 +94,12 @@ impl FeldmanVss {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use elliptic_curve::rand_core::OsRng;
+    use elliptic_curve::rand_core::UnwrapErr;
+    use getrandom::SysRng;
 
     #[test]
     fn feldman_share_verifies() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         for (i, &share) in vss.shares.iter().enumerate() {
             assert!(
                 FeldmanVss::verify_share(&vss.commitments, (i + 1) as u64, share),
@@ -110,20 +111,20 @@ mod tests {
 
     #[test]
     fn feldman_rejects_tampered_share() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         let bad_share = vss.shares[0] + Scalar::from(1u64);
         assert!(!FeldmanVss::verify_share(&vss.commitments, 1, bad_share));
     }
 
     #[test]
     fn feldman_commitments_round_trip() {
-        let vss = FeldmanVss::deal(&mut OsRng, 5, 3);
+        let vss = FeldmanVss::deal(&mut UnwrapErr(SysRng), 5, 3);
         let enc = FeldmanVss::encode_commitments(&vss.commitments);
         let dec = FeldmanVss::decode_commitments(&enc).expect("decode");
         assert_eq!(dec.len(), vss.commitments.len());
         for (a, b) in vss.commitments.iter().zip(dec.iter()) {
-            let ab = a.to_encoded_point(true);
-            let bb = b.to_encoded_point(true);
+            let ab = a.to_sec1_point(true);
+            let bb = b.to_sec1_point(true);
             assert_eq!(ab.as_bytes(), bb.as_bytes());
         }
     }

--- a/crates/confium-tc-keys/Cargo.toml
+++ b/crates/confium-tc-keys/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["crypto", "threshold", "keys", "hsm", "confium"]
 crate-type = ["rlib"]
 
 [dependencies]
+getrandom = { workspace = true }
 confium-tc-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/confium-tc-keys/src/stealth_address.rs
+++ b/crates/confium-tc-keys/src/stealth_address.rs
@@ -1,7 +1,8 @@
 //! Stealth address derivation.
 
-use p256::elliptic_curve::rand_core::OsRng;
-use p256::elliptic_curve::sec1::ToEncodedPoint;
+use getrandom::SysRng;
+use p256::elliptic_curve::rand_core::UnwrapErr;
+use p256::elliptic_curve::sec1::ToSec1Point;
 use p256::elliptic_curve::{Field, PrimeField};
 use p256::{AffinePoint, FieldBytes, ProjectivePoint, Scalar};
 use sha2::{Digest, Sha256};
@@ -30,14 +31,14 @@ pub struct StealthAddress {
 
 /// Generate a spending keypair.
 pub fn generate_spend_keypair() -> SpendKeypair {
-    let secret = Scalar::random(&mut OsRng);
+    let secret = Scalar::random(&mut UnwrapErr(SysRng));
     let public = (ProjectivePoint::GENERATOR * secret).to_affine();
     SpendKeypair { secret, public }
 }
 
 /// Generate a scanning keypair.
 pub fn generate_scan_keypair() -> (Scalar, ScanPubkey) {
-    let secret = Scalar::random(&mut OsRng);
+    let secret = Scalar::random(&mut UnwrapErr(SysRng));
     let public = (ProjectivePoint::GENERATOR * secret).to_affine();
     (secret, ScanPubkey { point: public })
 }
@@ -49,7 +50,7 @@ pub fn create_stealth_address(
     spend_pubkey: &AffinePoint,
 ) -> (StealthAddress, Scalar) {
     // Sender picks ephemeral key r
-    let r = Scalar::random(&mut OsRng);
+    let r = Scalar::random(&mut UnwrapErr(SysRng));
     let ephemeral = (ProjectivePoint::GENERATOR * r).to_affine();
 
     // Shared secret: r * scan_pubkey = scan_secret * ephemeral
@@ -98,8 +99,8 @@ pub fn scan_stealth_address(
 fn hash_to_scalar(point: &AffinePoint) -> Scalar {
     let mut hasher = Sha256::new();
     hasher.update(b"stealth-hash");
-    hasher.update(point.to_encoded_point(true).as_bytes());
-    let fb = FieldBytes::from(hasher.finalize());
+    hasher.update(point.to_sec1_point(true).as_bytes());
+    let fb = FieldBytes::try_from(&hasher.finalize()[..]).expect("digest is 32 bytes");
     Option::<Scalar>::from(Scalar::from_repr(fb)).unwrap_or(Scalar::ZERO)
 }
 
@@ -125,7 +126,7 @@ mod tests {
         let spend_kp = generate_spend_keypair();
         let (address, _) = create_stealth_address(&scan_pubkey, &spend_kp.public);
 
-        let wrong_scan = Scalar::random(&mut OsRng);
+        let wrong_scan = Scalar::random(&mut UnwrapErr(SysRng));
         let result = scan_stealth_address(&wrong_scan, &spend_kp.secret, &address);
         assert!(result.is_none());
     }
@@ -136,7 +137,7 @@ mod tests {
         let spend_kp = generate_spend_keypair();
         let (address, _) = create_stealth_address(&scan_pubkey, &spend_kp.public);
 
-        let wrong_spend = Scalar::random(&mut OsRng);
+        let wrong_spend = Scalar::random(&mut UnwrapErr(SysRng));
         let result = scan_stealth_address(&scan_secret, &wrong_spend, &address);
         assert!(result.is_none());
     }

--- a/crates/confium-tc-keys/src/threshold_bip32.rs
+++ b/crates/confium-tc-keys/src/threshold_bip32.rs
@@ -60,7 +60,7 @@ pub fn derive_child_scalar(parent: &Scalar, component: &PathIndex) -> Scalar {
     hasher.update(component.index.to_be_bytes());
     let hash = hasher.finalize();
 
-    let fb = FieldBytes::from(hash);
+    let fb = FieldBytes::try_from(&hash[..]).expect("digest is 32 bytes");
     let ct = Scalar::from_repr(fb);
     Option::<Scalar>::from(ct).unwrap_or(Scalar::ZERO)
 }
@@ -92,11 +92,12 @@ pub fn derive_party_share(parent_share: &Scalar, party_idx: u32, path: &Derivati
 #[cfg(test)]
 mod tests {
     use super::*;
+    use getrandom::SysRng;
     use p256::elliptic_curve::Field;
-    use p256::elliptic_curve::rand_core::OsRng;
+    use p256::elliptic_curve::rand_core::UnwrapErr;
 
     fn random_scalar() -> Scalar {
-        Scalar::random(&mut OsRng)
+        Scalar::random(&mut UnwrapErr(SysRng))
     }
 
     #[test]

--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -73,6 +73,11 @@ subtle = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
+# getrandom's default (sys_rng) backend doesn't exist on wasm32-unknown-unknown;
+# the wasm_js backend binds to the browser's Web Crypto for ambient entropy.
+[target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { workspace = true, features = ["wasm_js"] }
+
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -64,7 +64,7 @@ chrono = { workspace = true }
 
 # Verifier-only deps — all WASM-friendly, no filesystem, no threads.
 sha2 = { workspace = true }
-p256 = { version = "0.13", features = ["ecdsa"] }
+p256 = { workspace = true }
 subtle = { workspace = true }
 
 # WASM needs the `js` feature on getrandom so it falls back to


### PR DESCRIPTION
## What

Coordinated upgrade of the P-256 ecosystem: **p256 0.13 → 0.14, elliptic-curve 0.13 → 0.14, ecdsa 0.16 → 0.17, crypto-bigint 0.5 → 0.7, p384 0.13 → 0.14** — plus removal of the never-used `expose-field` feature that had been poisoning Dependabot's cargo update group (p256 0.14 removed it; we declared it but had zero `FieldElement` references).

Closes the last open code-side item from the CI-repair arc.

## API changes absorbed

| Old (0.13 stack) | New (0.14 stack) |
|---|---|
| `p256::elliptic_curve::rand_core::OsRng` + `Scalar::random(OsRng)` | `UnwrapErr(getrandom::SysRng)` + `Scalar::random(&mut ...)` — ff 0.14 takes `&mut R` with rand_core **0.10** traits (rand_core 0.6 `OsRng` no longer satisfies the bound; rand_core 0.10 has no `OsRng` at all) |
| `NonZeroScalar::random(..)` / `SigningKey::random(..)` | the `Generate` trait (`generate()` uses the ambient RNG) |
| `ToEncodedPoint` / `FromEncodedPoint` / `to_encoded_point` | `ToSec1Point` / `FromSec1Point` / `to_sec1_point` |
| `p256::EncodedPoint` | `p256::elliptic_curve::sec1::Sec1Point<NistP256>` |
| `Curve::ORDER` as `Uint` | `Odd<Uint>` — `.get()` to unwrap; `sbb` → `borrowing_sub` |
| `FieldBytes::from(digest_output)` | `TryFrom` (generic-array → hybrid-array interop is gone; `clone_from_slice` is deprecated) |

Also: p256 declarations centralized on the workspace (cmp20, gg18, python, wasm each pinned their own 0.13); unused `rand_core` dep dropped from confium-tc-frost-p256; the Dependabot `ignore: p256` rule removed so the cargo group can resolve again.

## Verification

- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo machete` (clean)
- `cargo test --workspace` — exit 0, no failures

58 files, all mechanical fallout of the version bump; no behavior changes intended (ECDSA low-s normalization, VSS, keygen, VRF, etc. keep identical math).

Dependabot's cargo group should now be able to propose p256-family updates again once this lands.
