### PR TITLE
ci(release): publish via crates.io trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ name: Release
 permissions:
   pull-requests: write
   contents: write
+  # Trusted publishing: lets release-plz exchange the GitHub OIDC token
+  # for a short-lived crates.io token. Every publishable crate has a
+  # trusted-publisher config for confium/confium + release.yml on
+  # crates.io, so no CARGO_REGISTRY_TOKEN is needed (and an env token
+  # would take precedence over OIDC, so none is set).
 
 on:
   push:
@@ -32,4 +37,3 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5.131
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## What

Switches the Release workflow from the broken long-lived registry token to **crates.io trusted publishing** (OIDC identity federation):

- adds `id-token: write` to the release-plz job
- removes `CARGO_REGISTRY_TOKEN` — an env token takes precedence over OIDC, and the secret belongs to a non-owner account (the source of the 403 `you don't seem to be an owner` that has been failing every Release run)

Trusted-publisher configs for `confium/confium` + `release.yml` were registered on crates.io for all **51 publishable crates that already exist there** (done via the `/api/v1/trusted_publishing/github_configs` API). Verified working: e.g. confium-macros now lists the config.

## Remaining manual step

8 crates are not on crates.io yet, so a trusted-publisher config cannot exist for them until their first publish:

confium-keyless, confium-log-monitor, confium-log-server, confium-node, confium-oidc, confium-operator, confium-threshold, confium-verify

They need a one-time `cargo publish` from an owner account; after that the same API call can register their configs. Until then release-plz will fail only for those 8 (the other 51 publish via OIDC).

## References

- crates.io trusted publishing docs
- release-plz GitHub quickstart (documents `id-token: write`)
