### PR TITLE
ci(release): actually grant id-token: write

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ name: Release
 permissions:
   pull-requests: write
   contents: write
+  id-token: write
   # Trusted publishing: lets release-plz exchange the GitHub OIDC token
   # for a short-lived crates.io token. Every publishable crate has a
   # trusted-publisher config for confium/confium + release.yml on


### PR DESCRIPTION
The previous trusted-publishing PR added the explanatory comment but dropped the actual permission line, so GitHub never injected the OIDC env vars (release-plz WARNed: ACTIONS_ID_TOKEN_REQUEST_URL not set, then fell back to no-token and failed). One-line fix.