### PR TITLE
fix(verify-server): drop publish = false — confium-verify depends on it

### DIFF
--- a/crates/confium-verify-server/Cargo.toml
+++ b/crates/confium-verify-server/Cargo.toml
@@ -10,7 +10,6 @@ repository.workspace = true
 categories = ["cryptography", "authentication"]
 keywords = ["crypto", "verify", "http", "confium"]
 description = "HTTP service for verifying threshold signatures and transparency proofs"
-publish = false
 
 [[bin]]
 name = "confium-verify-server"


### PR DESCRIPTION
confium-verify declares confium-verify-server as an optional versioned dependency, so cargo publish cannot resolve confium-verify while that crate is marked publish = false and absent from the registry. The sibling HTTP service confium-log-server is published; this flag was an oversight. One-line change.