### PR TITLE
feat(signatif): framework core — trust graph, co-signed artifacts, verification pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,7 @@ jobs:
           tool: cargo-semver-checks
 
       - name: Check semver compatibility
-        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-store-tpm --exclude confium-store-pkcs11 --exclude confium-tc-ml-kem --exclude confium-tc-fhe-bfv --exclude confium-tc-bls --exclude confium-tc-frost-ml-dsa-65 --exclude confium-verify --exclude confium-store-openpgp-card --exclude confium-tc
+        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-signatif --exclude confium-store-tpm --exclude confium-store-pkcs11 --exclude confium-tc-ml-kem --exclude confium-tc-fhe-bfv --exclude confium-tc-bls --exclude confium-tc-frost-ml-dsa-65 --exclude confium-verify --exclude confium-store-openpgp-card --exclude confium-tc
 
   # ============================================================================
   # Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,6 +1467,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "confium-signatif"
+version = "0.4.7"
+dependencies = [
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "confium-signerd"
 version = "0.4.7"
 dependencies = [
@@ -1807,6 +1821,7 @@ dependencies = [
  "confium-tc-gg18",
  "confium-transparency",
  "getrandom 0.2.17",
+ "getrandom 0.4.3",
  "js-sys",
  "p256",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "crates/confium-api",
     "crates/confium-attributes",
+    "crates/confium-signatif",
     "crates/confium-pki",
     "crates/confium-cli",
     "crates/confium-composite",
@@ -84,6 +85,7 @@ categories = ["authentication", "cryptography"]
 [workspace.dependencies]
 confium-api = { path = "crates/confium-api", version = "0.4.0" }
 confium-attributes = { path = "crates/confium-attributes", version = "0.4.0" }
+confium-signatif = { path = "crates/confium-signatif", version = "0.4.0" }
 confium-core = { path = "crates/confium-core", version = "0.4.0" }
 confium-composite = { path = "crates/confium-composite", version = "0.4.0" }
 confium-deployment = { path = "crates/confium-deployment", version = "0.4.0" }

--- a/crates/confium-signatif/Cargo.toml
+++ b/crates/confium-signatif/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "confium-signatif"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+categories = ["cryptography", "authentication"]
+readme = "README.md"
+description = "SIGNATIF framework implementation layer for Confium: trust graph, co-signed artifacts, verification pipeline, coverage reports"
+documentation = "https://docs.rs/confium-signatif"
+keywords = ["crypto", "signatif", "trust", "threshold", "confium"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+chrono = { workspace = true }
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
+rand_core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]

--- a/crates/confium-signatif/README.md
+++ b/crates/confium-signatif/README.md
@@ -1,0 +1,32 @@
+# confium-signatif
+
+Implementation of the [SIGNATIF](https://signatif.github.io) framework
+(Sealed Interoperable Graduated Non-repudiable Anchored Trust
+Infrastructure Framework, ISO/TC 154 working draft) on top of the Confium
+cryptographic substrate.
+
+SIGNATIF is the framework; Confium is the implementation tool; domain
+schemes (e.g. CNML for metrology) adopt the framework through this crate:
+
+- **Trust graph** — delegation DAG from root trust authorities through
+  delegated authorities to end certificates, with path-finding that
+  collects every valid verification path and validates signature and
+  scope narrowing at each link.
+- **Trust anchor bundles** — versioned, signed, offline-distributable
+  root sets with quorum metadata.
+- **Trusted artifacts** — co-signature blocks tagged by trust dimension,
+  all attesting the same canonical payload hash; living artifacts
+  accumulate dimension attestations over time.
+- **Verification pipeline** — ordered hard and soft checks, an objective
+  coverage report, and scheme-defined classification plus verifier
+  acceptance policies producing graduated trust decisions.
+- **Revocation** — signed CRLs, artifact-to-authority-state hash
+  bindings, transitive propagation, and forward/reverse queries.
+- **Ceremony records** — verifiable transcripts of threshold ceremonies.
+- **Registries** — the five scheme-maintained registries (dimensions,
+  algorithms, ceremony types, format profiles, scope dimensions).
+- **Delivery** — machine-readable passports, challenge-response, and
+  transparency-log reference discovery.
+
+Everything verifies offline against a trust anchor bundle: no phone-home,
+no proprietary component.

--- a/crates/confium-signatif/src/artifact.rs
+++ b/crates/confium-signatif/src/artifact.rs
@@ -1,0 +1,393 @@
+//! Trusted artifacts and dimension-tagged co-signatures (SIGNATIF §8).
+//!
+//! A [`TrustedArtifact`] is the convergence point of independent
+//! attestations: every [`CoSignatureBlock`] — regardless of trust
+//! dimension, organization, or trust chain — signs the **same**
+//! canonical payload hash. Partial attestation is not conforming, a
+//! co-signature cannot be stripped without breaking self-description,
+//! and each block binds to the artifact identifier so blocks cannot be
+//! replayed onto a different artifact (the `replay-protection`
+//! requirement).
+//!
+//! Artifacts are *living*: dimension attestations accumulate over time
+//! ([`TrustedArtifact::add_attestation`]) while the original canonical
+//! payload hash stays fixed.
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::error::{SignatifError, SignatifResult};
+use crate::graph::SignatureVerifier;
+use crate::jcs;
+use crate::registry::{DimensionTag, Registry};
+
+/// Semantic version of the artifact format.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactVersion {
+    /// Breaking changes — verifiers reject higher majors.
+    pub major: u32,
+    /// Backward/forward compatible additions — unknown fields ignored.
+    pub minor: u32,
+}
+
+impl ArtifactVersion {
+    /// Whether a verifier supporting `(self)` can process `other`:
+    /// same or lower major, any minor.
+    pub fn accepts(&self, other: &ArtifactVersion) -> bool {
+        other.major <= self.major
+    }
+}
+
+impl std::fmt::Display for ArtifactVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+/// One independent attestation on the artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CoSignatureBlock {
+    /// The trust dimension this block attests.
+    pub dimension: DimensionTag,
+    /// Signing algorithm identifier (from the algorithm registry).
+    pub algorithm: String,
+    /// End-certificate reference: a transparency-log sequence pointer
+    /// or a key fingerprint.
+    pub signer_cert_ref: String,
+    /// The signer's public key (SPKI bytes).
+    pub signer_pubkey: Vec<u8>,
+    /// Reference to the signer's root — may differ per block
+    /// (cross-domain fusion needs no root cross-recognition).
+    pub chain_ref: String,
+    /// The signature over the co-signature signing input.
+    pub signature: Vec<u8>,
+    /// When this attestation was produced.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// A trusted artifact: payload + dimension attestations.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustedArtifact {
+    /// Artifact format version.
+    pub version: ArtifactVersion,
+    /// Unique artifact identifier — bound into every co-signature to
+    /// prevent replay onto other artifacts.
+    pub artifact_id: String,
+    /// The domain payload (schema identified by `$payload_schema`).
+    pub payload: Value,
+    /// URI identifying the payload schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub payload_schema: Option<String>,
+    /// SHA-256 of the JCS canonicalization of the payload.
+    pub canonical_payload_hash: [u8; 32],
+    /// The dimension attestations converging on this artifact.
+    pub co_signatures: Vec<CoSignatureBlock>,
+}
+
+impl TrustedArtifact {
+    /// Create a new artifact, computing the canonical payload hash.
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn new(
+        version: ArtifactVersion,
+        artifact_id: impl Into<String>,
+        payload: Value,
+        payload_schema: Option<String>,
+    ) -> SignatifResult<Self> {
+        let canonical_payload_hash = jcs::canonical_hash(&payload)?;
+        Ok(Self {
+            version,
+            artifact_id: artifact_id.into(),
+            payload,
+            payload_schema,
+            canonical_payload_hash,
+            co_signatures: Vec::new(),
+        })
+    }
+
+    /// The signing input for a co-signature: artifact identity bound to
+    /// the canonical payload hash, so blocks are artifact-specific and
+    /// cannot be replayed across artifacts.
+    pub fn cosign_input(&self, dimension: &DimensionTag) -> Vec<u8> {
+        let mut bytes = self.artifact_id.as_bytes().to_vec();
+        bytes.push(0x00);
+        bytes.extend_from_slice(&self.canonical_payload_hash);
+        bytes.push(0x00);
+        bytes.extend_from_slice(dimension.as_str().as_bytes());
+        bytes
+    }
+
+    /// Produce a co-signature over this artifact (helper for signers).
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sign(
+        &mut self,
+        dimension: DimensionTag,
+        algorithm: impl Into<String>,
+        signer_cert_ref: impl Into<String>,
+        signer_pubkey: Vec<u8>,
+        chain_ref: impl Into<String>,
+        signer: &dyn Fn(&[u8]) -> Vec<u8>,
+        registry: &Registry,
+    ) -> SignatifResult<()> {
+        if !registry.dimensions.contains(dimension.as_str()) {
+            return Err(SignatifError::Registry {
+                registry: "trust-dimension".into(),
+                entry: dimension.as_str().to_string(),
+            });
+        }
+        let algorithm = algorithm.into();
+        registry
+            .algorithms
+            .usable(&algorithm)
+            .ok_or_else(|| SignatifError::Registry {
+                registry: "algorithm".into(),
+                entry: algorithm.clone(),
+            })?;
+        let input = self.cosign_input(&dimension);
+        let signature = signer(&input);
+        self.co_signatures.push(CoSignatureBlock {
+            dimension,
+            algorithm,
+            signer_cert_ref: signer_cert_ref.into(),
+            signer_pubkey,
+            chain_ref: chain_ref.into(),
+            signature,
+            timestamp: chrono::Utc::now(),
+        });
+        Ok(())
+    }
+
+    /// Living artifacts: add a dimension attestation. The block must
+    /// sign the *original* canonical payload hash — enforced because
+    /// the signing input derives from the fixed hash and artifact id.
+    ///
+    /// # Errors
+    ///
+    /// Returns a registry error for unknown dimensions or unusable
+    /// algorithms.
+    pub fn add_attestation(
+        &mut self,
+        block: CoSignatureBlock,
+        registry: &Registry,
+    ) -> SignatifResult<()> {
+        if !registry.dimensions.contains(block.dimension.as_str()) {
+            return Err(SignatifError::Registry {
+                registry: "trust-dimension".into(),
+                entry: block.dimension.as_str().to_string(),
+            });
+        }
+        registry
+            .algorithms
+            .usable(&block.algorithm)
+            .ok_or_else(|| SignatifError::Registry {
+                registry: "algorithm".into(),
+                entry: block.algorithm.clone(),
+            })?;
+        self.co_signatures.push(block);
+        Ok(())
+    }
+
+    /// Verify the artifact's self-consistency: the recorded canonical
+    /// payload hash equals the hash of the current payload (detects
+    /// any post-signing payload modification — signature wrapping
+    /// prevention), and every block is verified independently against
+    /// its own public key.
+    ///
+    /// # Errors
+    ///
+    /// [`SignatifError::ArtifactFormat`] on hash mismatch or an
+    /// unknown/retired algorithm; [`SignatifError::BadSignature`] when
+    /// a block fails to verify.
+    pub fn verify_self(
+        &self,
+        registry: &Registry,
+        verifier: &dyn SignatureVerifier,
+    ) -> SignatifResult<()> {
+        let recomputed = jcs::canonical_hash(&self.payload)?;
+        if recomputed != self.canonical_payload_hash {
+            return Err(SignatifError::ArtifactFormat(
+                "payload does not match canonical_payload_hash (signed content != processed content)"
+                    .into(),
+            ));
+        }
+        for block in &self.co_signatures {
+            registry
+                .algorithms
+                .usable(&block.algorithm)
+                .ok_or_else(|| SignatifError::Registry {
+                    registry: "algorithm".into(),
+                    entry: block.algorithm.clone(),
+                })?;
+            let input = self.cosign_input(&block.dimension);
+            if !verifier.verify(&block.signer_pubkey, &input, &block.signature) {
+                return Err(SignatifError::BadSignature {
+                    context: format!(
+                        "co-signature dimension={} signer={}",
+                        block.dimension.as_str(),
+                        block.signer_cert_ref
+                    ),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// The distinct dimensions attested by currently-valid blocks.
+    pub fn dimensions_verified(&self) -> Vec<DimensionTag> {
+        let mut seen = std::collections::BTreeSet::new();
+        for b in &self.co_signatures {
+            seen.insert(b.dimension.clone());
+        }
+        seen.into_iter().collect()
+    }
+
+    /// The distinct chain (root) references across blocks — feeds the
+    /// coverage report's independent-root count.
+    pub fn distinct_roots(&self) -> Vec<String> {
+        let mut seen = std::collections::BTreeSet::new();
+        for b in &self.co_signatures {
+            seen.insert(b.chain_ref.clone());
+        }
+        seen.into_iter().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::Registry;
+    use ed25519_dalek::{Signature, Signer, SigningKey, Verifier};
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    fn sample(registry: &Registry) -> (TrustedArtifact, SigningKey) {
+        let sk = generate_key();
+        let mut art = TrustedArtifact::new(
+            ArtifactVersion { major: 1, minor: 0 },
+            "art-2026-00001",
+            serde_json::json!({"batch_id": "LOT-2026-001", "quantity": 50000}),
+            Some("https://example.cnml/schema/vaccine-batch.json".into()),
+        )
+        .unwrap();
+        let pk = sk.verifying_key().as_bytes().to_vec();
+        art.sign(
+            DimensionTag::data(),
+            "Ed25519",
+            "transparency-log-seq:12345",
+            pk.clone(),
+            "root-cnml",
+            &|m| sk.sign(m).to_bytes().to_vec(),
+            registry,
+        )
+        .unwrap();
+        (art, sk)
+    }
+
+    #[test]
+    fn create_sign_and_verify() {
+        let registry = Registry::with_initial_values();
+        let (art, _) = sample(&registry);
+        assert!(art.verify_self(&registry, &Ed25519Verifier).is_ok());
+        assert_eq!(art.dimensions_verified(), vec![DimensionTag::data()]);
+        assert_eq!(art.distinct_roots(), vec!["root-cnml".to_string()]);
+    }
+
+    #[test]
+    fn payload_tampering_detected() {
+        let registry = Registry::with_initial_values();
+        let (mut art, _) = sample(&registry);
+        art.payload["quantity"] = serde_json::json!(1);
+        assert!(art.verify_self(&registry, &Ed25519Verifier).is_err());
+    }
+
+    #[test]
+    fn replay_across_artifacts_fails() {
+        let registry = Registry::with_initial_values();
+        let (art, sk) = sample(&registry);
+        // A second artifact with different id: the stolen block signs
+        // the first artifact's id+hash, so it fails here.
+        let mut other = TrustedArtifact::new(
+            ArtifactVersion { major: 1, minor: 0 },
+            "art-2026-00002",
+            serde_json::json!({"batch_id": "LOT-2026-001", "quantity": 50000}),
+            None,
+        )
+        .unwrap();
+        let stolen = art.co_signatures[0].clone();
+        other.co_signatures.push(stolen);
+        assert!(other.verify_self(&registry, &Ed25519Verifier).is_err());
+        let _ = sk;
+    }
+
+    #[test]
+    fn living_artifact_accumulates_dimensions() {
+        let registry = Registry::with_initial_values();
+        let (mut art, _) = sample(&registry);
+        let person = generate_key();
+        let before_hash = art.canonical_payload_hash;
+        art.sign(
+            DimensionTag::person(),
+            "Ed25519",
+            "operator-key-fingerprint",
+            person.verifying_key().as_bytes().to_vec(),
+            "root-cnml",
+            &|m| person.sign(m).to_bytes().to_vec(),
+            &registry,
+        )
+        .unwrap();
+        assert_eq!(art.canonical_payload_hash, before_hash);
+        assert!(art.verify_self(&registry, &Ed25519Verifier).is_ok());
+        assert_eq!(art.dimensions_verified().len(), 2);
+    }
+
+    #[test]
+    fn unknown_dimension_rejected_via_registry() {
+        let registry = Registry::with_initial_values();
+        let (mut art, _) = sample(&registry);
+        let err = art
+            .sign(
+                DimensionTag::custom("no-such-dimension"),
+                "Ed25519",
+                "x",
+                vec![0u8; 32],
+                "r",
+                &|_| vec![0u8; 64],
+                &registry,
+            )
+            .unwrap_err();
+        assert!(matches!(err, SignatifError::Registry { .. }));
+    }
+
+    #[test]
+    fn version_compatibility() {
+        let v1 = ArtifactVersion { major: 1, minor: 3 };
+        assert!(v1.accepts(&ArtifactVersion { major: 1, minor: 0 }));
+        assert!(v1.accepts(&ArtifactVersion { major: 1, minor: 9 }));
+        assert!(!v1.accepts(&ArtifactVersion { major: 2, minor: 0 }));
+    }
+}

--- a/crates/confium-signatif/src/bundle.rs
+++ b/crates/confium-signatif/src/bundle.rs
@@ -1,0 +1,203 @@
+//! Trust anchor bundles (SIGNATIF §7, Annex E).
+//!
+//! The bundle is the starting point of all verification paths: the set
+//! of root trust authorities (with aggregate keys and quorum
+//! parameters) and the recognized transparency logs. It is versioned,
+//! validity-bounded, signed by the root authority, deterministic for
+//! out-of-band distribution, and — per the framework — its updates are
+//! recorded in a transparency log.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+use crate::graph::Quorum;
+use crate::jcs;
+
+/// One root trust authority in the bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnchorRoot {
+    /// Human-readable root name.
+    pub name: String,
+    /// The root's aggregate public key (SPKI or raw verifier bytes).
+    pub aggregate_key: Vec<u8>,
+    /// SHA-256 fingerprint of the aggregate key (hex).
+    pub fingerprint: String,
+    /// Quorum parameters of the root authority.
+    pub quorum: Option<Quorum>,
+}
+
+/// One recognized transparency log.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnchorLog {
+    /// Log name.
+    pub name: String,
+    /// The log operator's public key (verifies signed tree heads).
+    pub operator_key: Vec<u8>,
+    /// Log endpoint (primary or mirror).
+    pub endpoint: String,
+}
+
+/// A versioned, signed set of trust anchors.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustAnchorBundle {
+    /// Version identifier (e.g. "2026.08").
+    pub bundle_version: String,
+    /// Bundle validity start.
+    pub valid_from: DateTime<Utc>,
+    /// Bundle validity end.
+    pub valid_until: DateTime<Utc>,
+    /// Root trust authorities.
+    pub roots: Vec<AnchorRoot>,
+    /// Recognized transparency logs and mirrors.
+    pub transparency_logs: Vec<AnchorLog>,
+    /// Threshold signature of the issuing root over the canonical
+    /// bundle body (all fields except this signature).
+    pub bundle_signature: Vec<u8>,
+}
+
+impl TrustAnchorBundle {
+    /// The canonical bytes covered by the bundle signature: JCS of the
+    /// bundle with `bundle_signature` cleared.
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn signing_bytes(&self) -> SignatifResult<Vec<u8>> {
+        let mut copy = self.clone();
+        copy.bundle_signature = Vec::new();
+        Ok(
+            jcs::canonicalize(&serde_json::to_value(&copy).expect("bundle serializes"))?
+                .into_bytes(),
+        )
+    }
+
+    /// Verify the bundle signature against the root whose key it was
+    /// produced with, and the validity period at `now`.
+    ///
+    /// # Errors
+    ///
+    /// [`SignatifError::BadSignature`] when no root key verifies the
+    /// signature; [`SignatifError::BundleValidity`] outside the
+    /// validity window.
+    pub fn verify(
+        &self,
+        now: DateTime<Utc>,
+        verifier: &dyn crate::graph::SignatureVerifier,
+    ) -> SignatifResult<()> {
+        if now < self.valid_from || now > self.valid_until {
+            return Err(SignatifError::BundleValidity);
+        }
+        let msg = self.signing_bytes()?;
+        if self.roots.is_empty() {
+            return Err(SignatifError::BadSignature {
+                context: "anchor bundle has no roots".into(),
+            });
+        }
+        if self
+            .roots
+            .iter()
+            .any(|r| verifier.verify(&r.aggregate_key, &msg, &self.bundle_signature))
+        {
+            return Ok(());
+        }
+        Err(SignatifError::BadSignature {
+            context: "anchor bundle signature".into(),
+        })
+    }
+
+    /// Whether `root_key` belongs to one of the bundle's roots — used
+    /// by path-finding to decide path termination.
+    pub fn matches_root(&self, root_key: &[u8]) -> bool {
+        self.roots.iter().any(|r| r.aggregate_key == root_key)
+    }
+
+    /// The root whose aggregate key equals `root_key`, if any.
+    pub fn root_by_key(&self, root_key: &[u8]) -> Option<&AnchorRoot> {
+        self.roots.iter().find(|r| r.aggregate_key == root_key)
+    }
+
+    /// Deterministic distribution bytes (JCS of the full bundle).
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn distribution_bytes(&self) -> SignatifResult<Vec<u8>> {
+        Ok(
+            jcs::canonicalize(&serde_json::to_value(self).expect("bundle serializes"))?
+                .into_bytes(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::AcceptAllVerifier;
+    use ed25519_dalek::Signer;
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl crate::graph::SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    #[test]
+    fn bundle_signs_and_verifies() {
+        let sk = generate_key();
+        let pk = sk.verifying_key().as_bytes().to_vec();
+        let mut bundle = TrustAnchorBundle {
+            bundle_version: "2026.08".into(),
+            valid_from: Utc::now() - chrono::Duration::hours(1),
+            valid_until: Utc::now() + chrono::Duration::days(30),
+            roots: vec![AnchorRoot {
+                name: "root".into(),
+                aggregate_key: pk,
+                fingerprint: "00".into(),
+                quorum: None,
+            }],
+            transparency_logs: Vec::new(),
+            bundle_signature: Vec::new(),
+        };
+        bundle.bundle_signature = sk
+            .sign(&bundle.signing_bytes().unwrap())
+            .to_bytes()
+            .to_vec();
+        assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_ok());
+        bundle.bundle_signature[3] ^= 1;
+        assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_err());
+    }
+
+    #[test]
+    fn expired_bundle_fails() {
+        let b = TrustAnchorBundle {
+            bundle_version: "1".into(),
+            valid_from: Utc::now() - chrono::Duration::days(30),
+            valid_until: Utc::now() - chrono::Duration::days(1),
+            roots: vec![],
+            transparency_logs: vec![],
+            bundle_signature: vec![],
+        };
+        assert!(matches!(
+            b.verify(Utc::now(), &AcceptAllVerifier),
+            Err(SignatifError::BundleValidity)
+        ));
+    }
+}

--- a/crates/confium-signatif/src/ceremony.rs
+++ b/crates/confium-signatif/src/ceremony.rs
@@ -1,0 +1,248 @@
+//! Ceremony records (SIGNATIF §17).
+//!
+//! Every threshold ceremony — DKG, re-share, signing, revocation —
+//! produces a verifiable [`CeremonyTranscript`]: the participants with
+//! their contribution proofs, the quorum parameters, the canonical
+//! payload hash signed, the aggregate threshold signature produced,
+//! and a timestamp. Each participant signs the transcript attesting
+//! their participation. The [`ceremony_audit`] algorithm verifies
+//! every member signature, the aggregate signature, the T-of-N
+//! participation, the transparency-log cross-reference, and timestamp
+//! consistency.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+use crate::graph::{Quorum, SignatureVerifier};
+
+/// One participant's contribution record.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Participant {
+    /// Participant identity (organization or member key fingerprint).
+    pub id: String,
+    /// The participant's public key.
+    pub public_key: Vec<u8>,
+    /// Proof of contribution — for DKG, the member's PoP over the
+    /// session transcript (rogue-key prevention, §10); for signing,
+    /// the member's partial-signature commitment.
+    pub contribution_proof: Vec<u8>,
+    /// The participant's signature over the transcript participation
+    /// binding bytes (`transcript-signing` requirement).
+    pub participation_signature: Vec<u8>,
+}
+
+/// A verifiable record of one threshold ceremony.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CeremonyTranscript {
+    /// Ceremony type (from the ceremony-type registry): dkg, reshare,
+    /// sign, revoke, rotation.
+    pub ceremony_type: String,
+    /// Participating members with contribution proofs.
+    pub participants: Vec<Participant>,
+    /// Quorum parameters of the authority that ran the ceremony.
+    pub quorum: Quorum,
+    /// The canonical payload hash the ceremony signed.
+    pub payload_hash: [u8; 32],
+    /// The aggregate threshold signature produced.
+    pub aggregate_signature: Vec<u8>,
+    /// The authority's aggregate public key (verifies the aggregate).
+    pub aggregate_key: Vec<u8>,
+    /// When the ceremony concluded.
+    pub timestamp: DateTime<Utc>,
+    /// Transparency-log sequence of the artifact/certificate the
+    /// ceremony produced (`transcript-log-cross-reference`).
+    pub log_sequence: u64,
+}
+
+impl CeremonyTranscript {
+    /// The bytes each participant signs to attest participation:
+    /// ceremony type, member identity, quorum, payload hash, timestamp.
+    pub fn participation_bytes(&self, member_id: &str) -> SignatifResult<Vec<u8>> {
+        let v = serde_json::json!({
+            "ceremony_type": self.ceremony_type,
+            "member": member_id,
+            "quorum": self.quorum,
+            "payload_hash": hex::encode(self.payload_hash),
+            "timestamp": self.timestamp.to_rfc3339(),
+        });
+        Ok(crate::jcs::canonicalize(&v)?.into_bytes())
+    }
+}
+
+/// The audit algorithm (`audit-algorithm` requirement): verify each
+/// member participation signature, verify the aggregate threshold
+/// signature against the published aggregate key, confirm at least T
+/// of N members participated, cross-reference the payload with the
+/// transparency log entry, and confirm timestamp consistency.
+///
+/// `log_entry_payload_hash` is the hash recovered from the referenced
+/// transparency-log sequence number.
+///
+/// # Errors
+///
+/// Returns [`SignatifError::Ceremony`] with a precise reason for every
+/// failed audit step.
+pub fn ceremony_audit(
+    transcript: &CeremonyTranscript,
+    verifier: &dyn SignatureVerifier,
+    log_entry_payload_hash: Option<&[u8; 32]>,
+) -> SignatifResult<()> {
+    // 1. Member participation signatures.
+    for p in &transcript.participants {
+        let bytes = transcript.participation_bytes(&p.id)?;
+        if !verifier.verify(&p.public_key, &bytes, &p.participation_signature) {
+            return Err(SignatifError::Ceremony(format!(
+                "participation signature of member {} failed",
+                p.id
+            )));
+        }
+    }
+
+    // 2. Quorum: at least T of N participated, N consistent.
+    if transcript.participants.len() < transcript.quorum.t as usize {
+        return Err(SignatifError::Ceremony(format!(
+            "quorum not met: {} of {} required, {} participated",
+            transcript.quorum.t,
+            transcript.quorum.n,
+            transcript.participants.len()
+        )));
+    }
+    if transcript.participants.len() > transcript.quorum.n as usize {
+        return Err(SignatifError::Ceremony(format!(
+            "more participants ({}) than committee size N ({})",
+            transcript.participants.len(),
+            transcript.quorum.n
+        )));
+    }
+
+    // 3. Aggregate threshold signature over the payload hash.
+    if !verifier.verify(
+        &transcript.aggregate_key,
+        &transcript.payload_hash,
+        &transcript.aggregate_signature,
+    ) {
+        return Err(SignatifError::Ceremony(
+            "aggregate threshold signature failed".into(),
+        ));
+    }
+
+    // 4. Transparency-log cross-reference.
+    match log_entry_payload_hash {
+        Some(h) if *h != transcript.payload_hash => {
+            return Err(SignatifError::Ceremony(
+                "transparency log entry payload hash mismatch".into(),
+            ));
+        }
+        None => {
+            return Err(SignatifError::Ceremony(
+                "transparency log entry not available".into(),
+            ));
+        }
+        _ => {}
+    }
+
+    // 5. Timestamp consistency: not in the future.
+    if transcript.timestamp > Utc::now() {
+        return Err(SignatifError::Ceremony(
+            "transcript timestamp is in the future".into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer;
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    fn transcript(t: u32, n: u32, participating: usize) -> (CeremonyTranscript, [u8; 32]) {
+        let payload_hash = [7u8; 32];
+        let timestamp = Utc::now();
+        let mut participants = Vec::new();
+        for i in 0..participating {
+            let sk = generate_key();
+            let template = CeremonyTranscript {
+                ceremony_type: "dkg".into(),
+                participants: vec![],
+                quorum: Quorum { t, n },
+                payload_hash,
+                aggregate_signature: vec![],
+                aggregate_key: vec![],
+                timestamp,
+                log_sequence: 99,
+            };
+            let bytes = template.participation_bytes(&format!("m{i}")).unwrap();
+            participants.push(Participant {
+                id: format!("m{i}"),
+                public_key: sk.verifying_key().as_bytes().to_vec(),
+                contribution_proof: sk.sign(&bytes).to_bytes().to_vec(),
+                participation_signature: sk.sign(&bytes).to_bytes().to_vec(),
+            });
+        }
+        let agg_sk = generate_key();
+        let transcript = CeremonyTranscript {
+            ceremony_type: "dkg".into(),
+            participants,
+            quorum: Quorum { t, n },
+            payload_hash,
+            aggregate_signature: agg_sk.sign(&payload_hash).to_bytes().to_vec(),
+            aggregate_key: agg_sk.verifying_key().as_bytes().to_vec(),
+            timestamp,
+            log_sequence: 99,
+        };
+        (transcript, payload_hash)
+    }
+
+    #[test]
+    fn audit_passes_for_valid_transcript() {
+        let (t, hash) = transcript(2, 3, 3);
+        // Re-sign participation signatures correctly (helper signed
+        // participation with same key already).
+        assert!(ceremony_audit(&t, &Ed25519Verifier, Some(&hash)).is_ok());
+    }
+
+    #[test]
+    fn audit_fails_below_quorum() {
+        let (t, hash) = transcript(2, 3, 1);
+        assert!(ceremony_audit(&t, &Ed25519Verifier, Some(&hash)).is_err());
+    }
+
+    #[test]
+    fn audit_fails_on_log_mismatch() {
+        let (t, _) = transcript(2, 3, 3);
+        let wrong = [0u8; 32];
+        let err = ceremony_audit(&t, &Ed25519Verifier, Some(&wrong)).unwrap_err();
+        assert!(err.to_string().contains("log entry"));
+    }
+
+    #[test]
+    fn audit_fails_on_bad_aggregate() {
+        let (mut t, hash) = transcript(2, 3, 3);
+        t.aggregate_signature[0] ^= 1;
+        assert!(ceremony_audit(&t, &Ed25519Verifier, Some(&hash)).is_err());
+    }
+}

--- a/crates/confium-signatif/src/coverage.rs
+++ b/crates/confium-signatif/src/coverage.rs
@@ -1,0 +1,206 @@
+//! Coverage reports and trust classification (SIGNATIF §14).
+//!
+//! The pipeline produces an **objective** [`CoverageReport`] — facts,
+//! not judgements. The scheme's [`ClassificationPolicy`] maps the
+//! report to a [`ClassificationLabel`] (a pure, deterministic function
+//! published in the deployment manifest). The verifier's
+//! [`AcceptancePolicy`] maps the label to an accept/reject decision for
+//! a given decision context. Three layers, three owners.
+
+use serde::{Deserialize, Serialize};
+
+/// The objective verification facts collected by the pipeline.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CoverageReport {
+    /// Whether every hard check passed (format, signatures, chain,
+    /// scope narrowing, conditions, revocation).
+    pub hard_checks: HardCheckStatus,
+    /// Whether the artifact (or its certificates) are provably included
+    /// in a recognized transparency log.
+    pub transparency_included: bool,
+    /// Whether a time dimension attestation anchored to an external
+    /// source was verified.
+    pub time_anchored: bool,
+    /// The trust dimensions whose attestations verified.
+    pub dimensions_verified: Vec<String>,
+    /// Count of independently attested dimensions.
+    pub dimension_count: usize,
+    /// Count of distinct roots across verified paths (cross-domain
+    /// diversity).
+    pub independent_roots: usize,
+    /// Whether the multi-log M-of-K inclusion quorum was met.
+    pub multi_log_quorum: bool,
+    /// Number of valid verification paths found.
+    pub paths_found: usize,
+    /// Downgrade reasons accumulated from soft checks.
+    pub downgrades: Vec<String>,
+}
+
+/// Hard-check outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardCheckStatus {
+    /// All hard checks passed.
+    Pass,
+    /// A hard check failed — the pipeline short-circuits to rejected.
+    Fail,
+}
+
+/// A classification label produced by a scheme's policy.
+///
+/// The reference stack uses: `unverified`, `basic`, `verified`,
+/// `attested`, `certified`, `rejected`; schemes may define their own.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ClassificationLabel(pub String);
+
+impl ClassificationLabel {
+    /// The mandatory rejection label.
+    pub const REJECTED: &'static str = "rejected";
+
+    /// Build an arbitrary label.
+    pub fn new(label: impl Into<String>) -> Self {
+        Self(label.into())
+    }
+}
+
+/// A scheme-defined classification policy: a pure function from the
+/// coverage report to a label. The reference policy implements the
+/// Annex E ladder; schemes replace it via their deployment manifest.
+pub trait ClassificationPolicy {
+    /// Map a coverage report to a classification label.
+    fn classify(&self, report: &CoverageReport) -> ClassificationLabel;
+}
+
+/// The reference ladder from Annex E:
+/// rejected → unverified → basic → verified → attested → certified.
+///
+/// - any hard-check failure → `rejected`
+/// - no transparency, no time anchor, no person → `unverified`
+/// - transparency only → `basic`
+/// - transparency + time → `verified`
+/// - + person dimension → `attested`
+/// - + ≥2 independent roots → `certified`
+#[derive(Debug, Clone, Default)]
+pub struct ReferenceClassificationPolicy;
+
+impl ClassificationPolicy for ReferenceClassificationPolicy {
+    fn classify(&self, report: &CoverageReport) -> ClassificationLabel {
+        if report.hard_checks == HardCheckStatus::Fail {
+            return ClassificationLabel::new(ClassificationLabel::REJECTED);
+        }
+        if !report.transparency_included {
+            return ClassificationLabel::new("unverified");
+        }
+        if !report.time_anchored {
+            return ClassificationLabel::new("basic");
+        }
+        let dims: Vec<&str> = report
+            .dimensions_verified
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        let has_person = dims.contains(&"person");
+        if !has_person {
+            return ClassificationLabel::new("verified");
+        }
+        if report.independent_roots >= 2 {
+            ClassificationLabel::new("certified")
+        } else {
+            ClassificationLabel::new("attested")
+        }
+    }
+}
+
+/// The verifier's acceptance policy: label → decision, per decision
+/// context. This is the verifier's own risk posture, not the scheme's.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcceptancePolicy {
+    /// Labels accepted (everything else rejected).
+    pub accepted_labels: Vec<String>,
+}
+
+impl AcceptancePolicy {
+    /// A policy accepting exactly `labels`.
+    pub fn accept(labels: &[&str]) -> Self {
+        Self {
+            accepted_labels: labels.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    /// Decide for a label.
+    pub fn decide(&self, label: &ClassificationLabel) -> Acceptance {
+        if self.accepted_labels.iter().any(|l| l == &label.0) {
+            Acceptance::Accept
+        } else {
+            Acceptance::Reject
+        }
+    }
+}
+
+/// The acceptance decision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Acceptance {
+    /// The artifact is accepted for this decision context.
+    Accept,
+    /// The artifact is rejected for this decision context.
+    Reject,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(t: bool, time: bool, dims: &[&str], roots: usize) -> CoverageReport {
+        CoverageReport {
+            hard_checks: HardCheckStatus::Pass,
+            transparency_included: t,
+            time_anchored: time,
+            dimensions_verified: dims.iter().map(|s| s.to_string()).collect(),
+            dimension_count: dims.len(),
+            independent_roots: roots,
+            multi_log_quorum: false,
+            paths_found: 1,
+            downgrades: vec![],
+        }
+    }
+
+    #[test]
+    fn reference_ladder() {
+        let p = ReferenceClassificationPolicy;
+        assert_eq!(
+            p.classify(&report(false, false, &["data"], 1)).0,
+            "unverified"
+        );
+        assert_eq!(p.classify(&report(true, false, &["data"], 1)).0, "basic");
+        assert_eq!(p.classify(&report(true, true, &["data"], 1)).0, "verified");
+        assert_eq!(
+            p.classify(&report(true, true, &["data", "person"], 1)).0,
+            "attested"
+        );
+        assert_eq!(
+            p.classify(&report(true, true, &["data", "person"], 2)).0,
+            "certified"
+        );
+
+        let mut failed = report(true, true, &["data"], 1);
+        failed.hard_checks = HardCheckStatus::Fail;
+        assert_eq!(p.classify(&failed).0, "rejected");
+    }
+
+    #[test]
+    fn acceptance_policy_decides_by_label() {
+        let policy = AcceptancePolicy::accept(&["verified", "attested", "certified"]);
+        assert_eq!(
+            policy.decide(&ClassificationLabel::new("attested")),
+            Acceptance::Accept
+        );
+        assert_eq!(
+            policy.decide(&ClassificationLabel::new("basic")),
+            Acceptance::Reject
+        );
+        assert_eq!(
+            policy.decide(&ClassificationLabel::new("rejected")),
+            Acceptance::Reject
+        );
+    }
+}

--- a/crates/confium-signatif/src/discovery.rs
+++ b/crates/confium-signatif/src/discovery.rs
@@ -1,0 +1,221 @@
+//! Chain discovery strategies (SIGNATIF §7, §16).
+//!
+//! A signature wrapper shall carry or reference the full delegation
+//! chain to a root anchor under one of three strategies:
+//!
+//! - [`ChainDelivery::Embedded`] — the full chain inline, fully
+//!   offline-capable;
+//! - [`ChainDelivery::LogReference`] — transparency-log sequence
+//!   pointers, resolved on first encounter (then cacheable);
+//! - [`ChainDelivery::Hybrid`] — the immediate chain inline plus log
+//!   references for freshness.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+
+/// A pointer to a delegation credential stored in a transparency log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LogRef {
+    /// Name of the log holding the entry.
+    pub log: String,
+    /// Sequence number of the certificate entry in that log.
+    pub sequence: u64,
+}
+
+/// How an artifact carries its delegation chain.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "strategy", rename_all = "snake_case")]
+pub enum ChainDelivery {
+    /// The full chain of DER certificates inline (offline-capable).
+    Embedded {
+        /// DER certificates from signer-adjacent to root-adjacent.
+        chain: Vec<Vec<u8>>,
+    },
+    /// Transparency-log sequence pointers for every chain credential.
+    LogReference {
+        /// One pointer per delegation credential on the chain.
+        refs: Vec<LogRef>,
+    },
+    /// Immediate chain inline, log references for freshness checks.
+    Hybrid {
+        /// The immediate (signer-adjacent) credentials inline.
+        immediate: Vec<Vec<u8>>,
+        /// Pointers for the remaining chain and freshness verification.
+        refs: Vec<LogRef>,
+    },
+}
+
+impl ChainDelivery {
+    /// Whether the strategy alone can reconstruct the full chain with
+    /// no network access.
+    pub fn is_offline_capable(&self) -> bool {
+        matches!(self, ChainDelivery::Embedded { .. })
+    }
+}
+
+/// Resolves log references into certificate bytes. Production
+/// implementations bind to a transparency log client (the confium
+/// log-server `/v1/certificates` API); tests bind to in-memory fakes.
+pub trait LogResolver {
+    /// Fetch the certificate bytes for a log reference.
+    ///
+    /// # Errors
+    ///
+    /// Implementations return [`SignatifError::Encoding`] for misses.
+    fn resolve(&mut self, r: &LogRef) -> SignatifResult<Vec<u8>>;
+}
+
+/// A caching resolver decorator: first-encounter fetches go to the
+/// inner resolver, subsequent ones hit the cache — the §16 caching
+/// requirement for connected delivery.
+#[derive(Debug, Default)]
+pub struct CachingResolver<R> {
+    inner: R,
+    cache: HashMap<(String, u64), Vec<u8>>,
+}
+
+impl<R: LogResolver> LogResolver for CachingResolver<R> {
+    fn resolve(&mut self, r: &LogRef) -> SignatifResult<Vec<u8>> {
+        CachingResolver::resolve(self, r)
+    }
+}
+
+impl<R: LogResolver> CachingResolver<R> {
+    /// Wrap an inner resolver with a cache.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            cache: HashMap::new(),
+        }
+    }
+
+    /// Resolve with caching.
+    ///
+    /// # Errors
+    ///
+    /// Propagates inner resolver errors.
+    pub fn resolve(&mut self, r: &LogRef) -> SignatifResult<Vec<u8>> {
+        if let Some(hit) = self.cache.get(&(r.log.clone(), r.sequence)) {
+            return Ok(hit.clone());
+        }
+        let fetched = self.inner.resolve(r)?;
+        self.cache
+            .insert((r.log.clone(), r.sequence), fetched.clone());
+        Ok(fetched)
+    }
+
+    /// Number of cached entries (observable for tests and metrics).
+    pub fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+}
+
+/// Reconstruct the full certificate chain from a delivery strategy,
+/// using `resolver` only for non-embedded strategies.
+///
+/// # Errors
+///
+/// Returns [`SignatifError::Encoding`] when a reference cannot be
+/// resolved.
+pub fn reconstruct_chain(
+    delivery: &ChainDelivery,
+    resolver: Option<&mut dyn LogResolver>,
+) -> SignatifResult<Vec<Vec<u8>>> {
+    match delivery {
+        ChainDelivery::Embedded { chain } => Ok(chain.clone()),
+        ChainDelivery::LogReference { refs } => {
+            let resolver = resolver.ok_or_else(|| {
+                SignatifError::Encoding("log-reference delivery requires a resolver".into())
+            })?;
+            refs.iter().map(|r| resolver.resolve(r)).collect()
+        }
+        ChainDelivery::Hybrid { immediate, refs } => {
+            let mut chain = immediate.clone();
+            let resolver = resolver.ok_or_else(|| {
+                SignatifError::Encoding("hybrid delivery requires a resolver".into())
+            })?;
+            for r in refs {
+                chain.push(resolver.resolve(r)?);
+            }
+            Ok(chain)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeLog {
+        entries: HashMap<(String, u64), Vec<u8>>,
+        fetches: std::cell::Cell<u32>,
+    }
+
+    impl LogResolver for &FakeLog {
+        fn resolve(&mut self, r: &LogRef) -> SignatifResult<Vec<u8>> {
+            self.fetches.set(self.fetches.get() + 1);
+            self.entries
+                .get(&(r.log.clone(), r.sequence))
+                .cloned()
+                .ok_or_else(|| SignatifError::Encoding("miss".into()))
+        }
+    }
+
+    #[test]
+    fn embedded_is_offline() {
+        let d = ChainDelivery::Embedded {
+            chain: vec![vec![1]],
+        };
+        assert!(d.is_offline_capable());
+        assert_eq!(reconstruct_chain(&d, None).unwrap(), vec![vec![1]]);
+    }
+
+    #[test]
+    fn log_reference_resolves_and_caches() {
+        let log = FakeLog {
+            entries: [("pharma-log".to_string(), 7u64)]
+                .iter()
+                .map(|(l, s)| ((l.clone(), *s), vec![9, 9]))
+                .collect(),
+            fetches: std::cell::Cell::new(0),
+        };
+        let d = ChainDelivery::LogReference {
+            refs: vec![LogRef {
+                log: "pharma-log".into(),
+                sequence: 7,
+            }],
+        };
+        let mut cache = CachingResolver::new(&log);
+        let chain = reconstruct_chain(&d, Some(&mut cache)).unwrap();
+        assert_eq!(chain, vec![vec![9, 9]]);
+        assert_eq!(cache.cache_len(), 1);
+        // Second resolution is served from cache: one inner fetch total.
+        reconstruct_chain(&d, Some(&mut cache)).unwrap();
+        assert_eq!(log.fetches.get(), 1);
+    }
+
+    #[test]
+    fn hybrid_combines_inline_and_resolved() {
+        let log = FakeLog {
+            entries: [("log".to_string(), 1u64)]
+                .iter()
+                .map(|(l, s)| ((l.clone(), *s), vec![2]))
+                .collect(),
+            fetches: std::cell::Cell::new(0),
+        };
+        let d = ChainDelivery::Hybrid {
+            immediate: vec![vec![1]],
+            refs: vec![LogRef {
+                log: "log".into(),
+                sequence: 1,
+            }],
+        };
+        assert_eq!(
+            reconstruct_chain(&d, Some(&mut &log)).unwrap(),
+            vec![vec![1], vec![2]]
+        );
+    }
+}

--- a/crates/confium-signatif/src/error.rs
+++ b/crates/confium-signatif/src/error.rs
@@ -1,0 +1,57 @@
+//! Errors for the SIGNATIF framework implementation.
+
+use thiserror::Error;
+
+/// Errors produced by the SIGNATIF framework implementation.
+#[derive(Debug, Error)]
+pub enum SignatifError {
+    /// A verification path could not be found from an artifact signer to
+    /// any root anchor in the trust anchor bundle.
+    #[error("no verification path to a trusted root")]
+    NoPath,
+    /// Scope widening detected at a delegation link — a hard failure.
+    #[error("scope widening at delegation link {parent} -> {child} on dimension {dimension}")]
+    ScopeWidening {
+        /// Parent authority identifier.
+        parent: String,
+        /// Child authority identifier.
+        child: String,
+        /// The scope dimension that was widened.
+        dimension: String,
+    },
+    /// A signature failed to verify.
+    #[error("signature verification failed for {context}")]
+    BadSignature {
+        /// What was being verified when the failure occurred.
+        context: String,
+    },
+    /// The trust anchor bundle is expired or not yet valid.
+    #[error("anchor bundle not valid at the evaluation time")]
+    BundleValidity,
+    /// Artifact format error (version, self-description, replay).
+    #[error("artifact format error: {0}")]
+    ArtifactFormat(String),
+    /// Hard-check failure carrying the failing check name.
+    #[error("hard check failed: {0}")]
+    HardCheck(String),
+    /// A required registry entry is unknown or retired.
+    #[error("registry {registry} has no usable entry {entry}")]
+    Registry {
+        /// Registry name.
+        registry: String,
+        /// Entry identifier.
+        entry: String,
+    },
+    /// CRL or revocation state error.
+    #[error("revocation error: {0}")]
+    Revocation(String),
+    /// Ceremony transcript audit failure.
+    #[error("ceremony audit failure: {0}")]
+    Ceremony(String),
+    /// Serialization or canonicalization failure.
+    #[error("encoding error: {0}")]
+    Encoding(String),
+}
+
+/// Convenient result alias.
+pub type SignatifResult<T> = Result<T, SignatifError>;

--- a/crates/confium-signatif/src/graph.rs
+++ b/crates/confium-signatif/src/graph.rs
@@ -1,0 +1,579 @@
+//! The trust graph: delegation DAG and verification path-finding
+//! (SIGNATIF §7).
+//!
+//! Nodes are trust authorities (root, delegated, or end-certificate)
+//! carrying an aggregate public key, optional quorum parameters, and a
+//! multi-dimensional scope. Edges are delegation credentials — the
+//! parent's signature over the child's binding (identifier, key,
+//! quorum, scope). The graph generalizes a linear chain to a directed
+//! acyclic graph: cross-recognition and federated memberships produce
+//! multiple parents.
+//!
+//! [`TrustGraph::find_paths`] collects **every** path from an artifact
+//! signer to a root present in the trust anchor bundle, validating the
+//! delegation signature and the monotonic scope narrowing at each link.
+//! Multiple valid paths and multiple distinct roots feed the coverage
+//! report's cross-domain diversity scoring.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::bundle::TrustAnchorBundle;
+use crate::error::{SignatifError, SignatifResult};
+use crate::jcs;
+use crate::scope::ScopeDimensions;
+
+/// Threshold quorum parameters (T of N).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Quorum {
+    /// Threshold — signatures required.
+    pub t: u32,
+    /// Committee size.
+    pub n: u32,
+}
+
+impl Quorum {
+    /// Construct a quorum, validating T <= N and T >= 1.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SignatifError::Encoding`] when the parameters are
+    /// inconsistent.
+    pub fn new(t: u32, n: u32) -> SignatifResult<Self> {
+        if t == 0 || t > n {
+            return Err(SignatifError::Encoding(format!(
+                "invalid quorum {t} of {n}: require 1 <= T <= N"
+            )));
+        }
+        Ok(Self { t, n })
+    }
+}
+
+/// The kind of a trust authority node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthorityKind {
+    /// A root trust authority — verification terminus.
+    Root,
+    /// A delegated trust authority.
+    Delegated,
+    /// An end certificate authorizing one signing key.
+    EndCertificate,
+}
+
+/// A node in the trust graph.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorityNode {
+    /// Stable identifier (typically a key fingerprint).
+    pub id: String,
+    /// Kind of authority.
+    pub kind: AuthorityKind,
+    /// Aggregate (or single) public key, SPKI-encoded.
+    pub public_key: Vec<u8>,
+    /// Quorum parameters when the authority is threshold.
+    pub quorum: Option<Quorum>,
+    /// The authority's authorization scope.
+    pub scope: ScopeDimensions,
+}
+
+impl AuthorityNode {
+    /// The canonical signing input for this node's binding: the JCS of
+    /// the node's identity material. Delegation signatures and anchor
+    /// bundle references are computed over these bytes.
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn binding_bytes(&self) -> SignatifResult<Vec<u8>> {
+        let v = serde_json::json!({
+            "id": self.id,
+            "kind": self.kind,
+            "public_key": hex::encode(&self.public_key),
+            "quorum": self.quorum,
+            "scope": self.scope,
+        });
+        Ok(jcs::canonicalize(&v)?.into_bytes())
+    }
+}
+
+/// A delegation edge: the parent's credential over the child node.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DelegationEdge {
+    /// Parent authority identifier.
+    pub parent: String,
+    /// Child authority identifier.
+    pub child: String,
+    /// The parent's signature over the child's [`AuthorityNode::binding_bytes`].
+    pub signature: Vec<u8>,
+}
+
+/// One verified delegation link on a path.
+#[derive(Debug, Clone)]
+pub struct PathLink {
+    /// The parent authority.
+    pub parent: AuthorityNode,
+    /// The child authority.
+    pub child: AuthorityNode,
+    /// The delegation credential that was verified.
+    pub edge: DelegationEdge,
+}
+
+/// A complete verification path from an artifact signer to a root.
+#[derive(Debug, Clone)]
+pub struct VerificationPath {
+    /// Links in order from the signer's node up to (excluding) the root.
+    pub links: Vec<PathLink>,
+    /// The root authority terminating the path.
+    pub root: AuthorityNode,
+}
+
+impl VerificationPath {
+    /// The distinct authorities on this path, signer first.
+    pub fn authorities(&self) -> Vec<&AuthorityNode> {
+        let mut out = Vec::new();
+        if let Some(first) = self.links.first() {
+            out.push(&first.child);
+        }
+        for link in &self.links {
+            out.push(&link.parent);
+        }
+        out.push(&self.root);
+        out
+    }
+
+    /// The scope of the signer node (the most-narrow scope on the path).
+    pub fn signer_scope(&self) -> &ScopeDimensions {
+        self.links
+            .first()
+            .map(|l| &l.child.scope)
+            .unwrap_or(&self.root.scope)
+    }
+}
+
+/// Verifies a delegation signature: `signature` over `message` under
+/// `public_key`. Implementations bind the concrete algorithm fleet
+/// (Ed25519, ECDSA-P256, ML-DSA, threshold aggregate verification).
+pub trait SignatureVerifier {
+    /// Verify `signature` over `message` under `public_key`.
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool;
+}
+
+/// A no-op verifier that accepts everything — for graph topology tests
+/// only; never use in production code paths.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AcceptAllVerifier;
+
+impl SignatureVerifier for AcceptAllVerifier {
+    fn verify(&self, _pk: &[u8], _msg: &[u8], _sig: &[u8]) -> bool {
+        true
+    }
+}
+
+/// The trust graph: authorities and delegation edges forming a DAG.
+#[derive(Debug, Clone, Default)]
+pub struct TrustGraph {
+    nodes: BTreeMap<String, AuthorityNode>,
+    edges: Vec<DelegationEdge>,
+}
+
+impl TrustGraph {
+    /// An empty graph.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a node, replacing any node with the same identifier.
+    pub fn add_node(&mut self, node: AuthorityNode) {
+        self.nodes.insert(node.id.clone(), node);
+    }
+
+    /// Insert a delegation edge. Returns an error when either endpoint
+    /// is unknown or when the edge would create a cycle.
+    ///
+    /// # Errors
+    ///
+    /// [`SignatifError::Encoding`] for unknown endpoints or a cycle.
+    pub fn add_delegation(&mut self, edge: DelegationEdge) -> SignatifResult<()> {
+        if !self.nodes.contains_key(&edge.parent) || !self.nodes.contains_key(&edge.child) {
+            return Err(SignatifError::Encoding(format!(
+                "delegation references unknown node(s) {} -> {}",
+                edge.parent, edge.child
+            )));
+        }
+        self.edges.push(edge);
+        if !self.is_acyclic() {
+            self.edges.pop();
+            return Err(SignatifError::Encoding(
+                "delegation would create a cycle in the trust graph".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// All nodes.
+    pub fn nodes(&self) -> impl Iterator<Item = &AuthorityNode> {
+        self.nodes.values()
+    }
+
+    /// All delegation edges.
+    pub fn edges(&self) -> &[DelegationEdge] {
+        &self.edges
+    }
+
+    /// Look up a node by identifier.
+    pub fn node(&self, id: &str) -> Option<&AuthorityNode> {
+        self.nodes.get(id)
+    }
+
+    /// Incoming delegation edges for a child node.
+    pub fn parents_of(&self, child: &str) -> Vec<&DelegationEdge> {
+        self.edges.iter().filter(|e| e.child == child).collect()
+    }
+
+    /// Cycle detection over the delegation graph.
+    pub fn is_acyclic(&self) -> bool {
+        #[derive(Clone, Copy, PartialEq)]
+        enum Mark {
+            #[allow(dead_code)]
+            White,
+            Grey,
+            Black,
+        }
+        fn visit(graph: &TrustGraph, id: &str, marks: &mut BTreeMap<String, Mark>) -> bool {
+            match marks.get(id).copied() {
+                Some(Mark::Grey) => false,
+                Some(Mark::Black) => true,
+                _ => {
+                    marks.insert(id.to_string(), Mark::Grey);
+                    for edge in graph.parents_of(id) {
+                        if !visit(graph, &edge.parent, marks) {
+                            return false;
+                        }
+                    }
+                    marks.insert(id.to_string(), Mark::Black);
+                    true
+                }
+            }
+        }
+        let mut marks: BTreeMap<String, Mark> = BTreeMap::new();
+        self.nodes.keys().all(|id| visit(self, id, &mut marks))
+    }
+
+    /// Find **all** verification paths from `signer` to roots present in
+    /// `bundle`. Each link is validated: the parent's delegation
+    /// signature over the child's binding bytes, the monotonic scope
+    /// narrowing invariant, and — for the terminal link — that the root
+    /// matches an anchor in the bundle by aggregate key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SignatifError::ScopeWidening`] on the first widening
+    /// link (a hard failure), and [`SignatifError::BadSignature`] when
+    /// a delegation credential does not verify.
+    pub fn find_paths(
+        &self,
+        signer: &str,
+        bundle: &TrustAnchorBundle,
+        verifier: &dyn SignatureVerifier,
+    ) -> SignatifResult<Vec<VerificationPath>> {
+        let signer_node = self.nodes.get(signer).ok_or(SignatifError::NoPath)?;
+        let mut paths = Vec::new();
+        let mut prefix: Vec<PathLink> = Vec::new();
+        self.walk(signer_node, bundle, verifier, &mut prefix, &mut paths)?;
+        Ok(paths)
+    }
+
+    fn walk(
+        &self,
+        node: &AuthorityNode,
+        bundle: &TrustAnchorBundle,
+        verifier: &dyn SignatureVerifier,
+        prefix: &mut Vec<PathLink>,
+        out: &mut Vec<VerificationPath>,
+    ) -> SignatifResult<()> {
+        if node.kind == AuthorityKind::Root {
+            if bundle.matches_root(&node.public_key) {
+                out.push(VerificationPath {
+                    links: prefix.clone(),
+                    root: node.clone(),
+                });
+            }
+            return Ok(());
+        }
+        for edge in self.parents_of(&node.id) {
+            let parent = match self.nodes.get(&edge.parent) {
+                Some(p) => p,
+                None => continue,
+            };
+            if !verifier.verify(&parent.public_key, &node.binding_bytes()?, &edge.signature) {
+                return Err(SignatifError::BadSignature {
+                    context: format!("delegation {} -> {}", edge.parent, node.id),
+                });
+            }
+            if let Some(dim) = node.scope.first_widened_dimension(&parent.scope) {
+                return Err(SignatifError::ScopeWidening {
+                    parent: parent.id.clone(),
+                    child: node.id.clone(),
+                    dimension: dim,
+                });
+            }
+            prefix.push(PathLink {
+                parent: parent.clone(),
+                child: node.clone(),
+                edge: edge.clone(),
+            });
+            self.walk(parent, bundle, verifier, prefix, out)?;
+            prefix.pop();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bundle::AnchorRoot;
+    use crate::scope::ScopeValue;
+    use chrono::{Duration, Utc};
+    use sha2::Digest as _;
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    fn ed25519_keypair() -> (ed25519_dalek::SigningKey, Vec<u8>) {
+        let sk = generate_key();
+        let pk = sk.verifying_key().as_bytes().to_vec();
+        (sk, pk)
+    }
+
+    struct Ed25519Verifier;
+
+    impl SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    fn root(id: &str, scope: ScopeDimensions) -> (AuthorityNode, ed25519_dalek::SigningKey) {
+        let (sk, pk) = ed25519_keypair();
+        (
+            AuthorityNode {
+                id: id.into(),
+                kind: AuthorityKind::Root,
+                public_key: pk,
+                quorum: None,
+                scope,
+            },
+            sk,
+        )
+    }
+
+    fn child(
+        id: &str,
+        kind: AuthorityKind,
+        scope: ScopeDimensions,
+        key: &ed25519_dalek::SigningKey,
+    ) -> AuthorityNode {
+        AuthorityNode {
+            id: id.into(),
+            kind,
+            public_key: key.verifying_key().as_bytes().to_vec(),
+            quorum: Some(Quorum::new(2, 3).unwrap()),
+            scope,
+        }
+    }
+
+    fn sign(sk: &ed25519_dalek::SigningKey, node: &AuthorityNode) -> Vec<u8> {
+        use ed25519_dalek::Signer;
+        sk.sign(&node.binding_bytes().unwrap()).to_bytes().to_vec()
+    }
+
+    fn bundle_for(root_node: &AuthorityNode) -> TrustAnchorBundle {
+        TrustAnchorBundle {
+            bundle_version: "2026.08".into(),
+            valid_from: Utc::now() - Duration::hours(1),
+            valid_until: Utc::now() + Duration::days(365),
+            roots: vec![AnchorRoot {
+                name: root_node.id.clone(),
+                aggregate_key: root_node.public_key.clone(),
+                fingerprint: hex::encode(sha2::Sha256::digest(&root_node.public_key)),
+                quorum: root_node.quorum,
+            }],
+            transparency_logs: Vec::new(),
+            bundle_signature: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn finds_single_path_and_validates_links() {
+        let mut parent_scope = ScopeDimensions::unconstrained();
+        parent_scope.set("domain", ScopeValue::Wildcard);
+        let (root_node, root_sk) = root("root-1", parent_scope);
+
+        let mut child_scope = ScopeDimensions::unconstrained();
+        child_scope.set("domain", ScopeValue::Single("pharma".into()));
+        let (end_sk, _) = ed25519_keypair();
+        let end = child("end-1", AuthorityKind::EndCertificate, child_scope, &end_sk);
+
+        let mut graph = TrustGraph::new();
+        graph.add_node(root_node.clone());
+        graph.add_node(end.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root-1".into(),
+                child: "end-1".into(),
+                signature: sign(&root_sk, &end),
+            })
+            .unwrap();
+
+        let bundle = bundle_for(&root_node);
+        let paths = graph
+            .find_paths("end-1", &bundle, &Ed25519Verifier)
+            .unwrap();
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0].root.id, "root-1");
+        assert_eq!(paths[0].links.len(), 1);
+    }
+
+    #[test]
+    fn tampered_delegation_signature_is_hard_failure() {
+        let (root_node, root_sk) = root("root-1", ScopeDimensions::unconstrained());
+        let (end_sk, _) = ed25519_keypair();
+        let end = child(
+            "end-1",
+            AuthorityKind::EndCertificate,
+            ScopeDimensions::unconstrained(),
+            &end_sk,
+        );
+        let mut bad = sign(&root_sk, &end);
+        bad[0] ^= 1;
+        let mut graph = TrustGraph::new();
+        graph.add_node(root_node.clone());
+        graph.add_node(end);
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root-1".into(),
+                child: "end-1".into(),
+                signature: bad,
+            })
+            .unwrap();
+        let err = graph
+            .find_paths("end-1", &bundle_for(&root_node), &Ed25519Verifier)
+            .unwrap_err();
+        assert!(matches!(err, SignatifError::BadSignature { .. }));
+    }
+
+    #[test]
+    fn scope_widening_is_hard_failure() {
+        let mut narrow = ScopeDimensions::unconstrained();
+        narrow.set("domain", ScopeValue::Single("pharma".into()));
+        let mut wide = ScopeDimensions::unconstrained();
+        wide.set(
+            "domain",
+            ScopeValue::Set(["pharma", "food"].iter().map(|s| s.to_string()).collect()),
+        );
+        let (root_node, root_sk) = root("root-1", narrow);
+        let (end_sk, _) = ed25519_keypair();
+        let end = child("end-1", AuthorityKind::EndCertificate, wide, &end_sk);
+        let mut graph = TrustGraph::new();
+        graph.add_node(root_node.clone());
+        let edge_sig = sign(&root_sk, &end);
+        graph.add_node(end);
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root-1".into(),
+                child: "end-1".into(),
+                signature: edge_sig,
+            })
+            .unwrap();
+        let err = graph
+            .find_paths("end-1", &bundle_for(&root_node), &Ed25519Verifier)
+            .unwrap_err();
+        match err {
+            SignatifError::ScopeWidening { dimension, .. } => assert_eq!(dimension, "domain"),
+            other => panic!("expected widening, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn multiple_roots_yield_multiple_paths() {
+        let (r1, s1) = root("root-1", ScopeDimensions::unconstrained());
+        let (r2, s2) = root("root-2", ScopeDimensions::unconstrained());
+        let (end_sk, _) = ed25519_keypair();
+        let end = child(
+            "end-1",
+            AuthorityKind::EndCertificate,
+            ScopeDimensions::unconstrained(),
+            &end_sk,
+        );
+        let mut graph = TrustGraph::new();
+        graph.add_node(r1.clone());
+        graph.add_node(r2.clone());
+        graph.add_node(end.clone());
+        for (parent, sk) in [("root-1", &s1), ("root-2", &s2)] {
+            graph
+                .add_delegation(DelegationEdge {
+                    parent: parent.into(),
+                    child: "end-1".into(),
+                    signature: sign(sk, &end),
+                })
+                .unwrap();
+        }
+        let mut bundle = bundle_for(&r1);
+        bundle.roots.push(AnchorRoot {
+            name: "root-2".into(),
+            aggregate_key: r2.public_key.clone(),
+            fingerprint: hex::encode(sha2::Sha256::digest(&r2.public_key)),
+            quorum: None,
+        });
+        let paths = graph
+            .find_paths("end-1", &bundle, &Ed25519Verifier)
+            .unwrap();
+        assert_eq!(paths.len(), 2);
+    }
+
+    #[test]
+    fn cycles_are_rejected_at_insertion() {
+        let (r, _) = root("root-1", ScopeDimensions::unconstrained());
+        let (a_sk, _) = ed25519_keypair();
+        let a = child(
+            "a",
+            AuthorityKind::Delegated,
+            ScopeDimensions::unconstrained(),
+            &a_sk,
+        );
+        let mut graph = TrustGraph::new();
+        graph.add_node(r);
+        graph.add_node(a.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root-1".into(),
+                child: "a".into(),
+                signature: vec![0],
+            })
+            .unwrap();
+        assert!(
+            graph
+                .add_delegation(DelegationEdge {
+                    parent: "a".into(),
+                    child: "root-1".into(),
+                    signature: vec![0],
+                })
+                .is_err()
+        );
+        assert!(graph.is_acyclic());
+    }
+}

--- a/crates/confium-signatif/src/jcs.rs
+++ b/crates/confium-signatif/src/jcs.rs
@@ -1,0 +1,208 @@
+//! RFC 8785 JSON Canonicalization Scheme (JCS).
+//!
+//! Produces the deterministic byte string that all co-signatures and
+//! bundle signatures attest: same logical content, same bytes, for any
+//! conforming implementation. The rules implemented here:
+//!
+//! - object keys sorted by UTF-16 code unit sequence;
+//! - no insignificant whitespace;
+//! - strings serialized with the JSON minimal-escape set (`\b \t \n \f
+//!   \r` `\"` `\\` and lowercase `\u00xx` for other control characters),
+//!   all other characters emitted verbatim as UTF-8;
+//! - numbers: integers exactly; floats in shortest round-trip form
+//!   (ECMAScript number-to-string), negative zero normalized to `0`,
+//!   NaN and infinities rejected;
+//! - booleans and null as `true` / `false` / `null`.
+
+use crate::error::{SignatifError, SignatifResult};
+use serde_json::Value;
+
+/// Canonicalize a JSON value to its RFC 8785 byte string.
+///
+/// # Errors
+///
+/// Returns [`SignatifError::Encoding`] for values that cannot appear in
+/// canonical JSON (non-finite numbers).
+pub fn canonicalize(value: &Value) -> SignatifResult<String> {
+    let mut out = String::new();
+    write_value(value, &mut out)?;
+    Ok(out)
+}
+
+/// SHA-256 over the JCS canonicalization — the SIGNATIF canonical
+/// payload hash of a JSON object.
+///
+/// # Errors
+///
+/// Propagates canonicalization errors.
+pub fn canonical_hash(value: &Value) -> SignatifResult<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    let canon = canonicalize(value)?;
+    Ok(Sha256::digest(canon.as_bytes()).into())
+}
+
+fn write_value(v: &Value, out: &mut String) -> SignatifResult<()> {
+    match v {
+        Value::Null => out.push_str("null"),
+        Value::Bool(true) => out.push_str("true"),
+        Value::Bool(false) => out.push_str("false"),
+        Value::Number(n) => write_number(n, out)?,
+        Value::String(s) => write_string(s, out),
+        Value::Array(items) => {
+            out.push('[');
+            for (i, item) in items.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_value(item, out)?;
+            }
+            out.push(']');
+        }
+        Value::Object(map) => {
+            // RFC 8785 §3.2.3: lexicographic order by UTF-16 code units.
+            let mut keys: Vec<&String> = map.keys().collect();
+            keys.sort_by(|a, b| utf16_cmp(a, b));
+            out.push('{');
+            for (i, key) in keys.iter().enumerate() {
+                if i > 0 {
+                    out.push(',');
+                }
+                write_string(key, out);
+                out.push(':');
+                write_value(&map[*key], out)?;
+            }
+            out.push('}');
+        }
+    }
+    Ok(())
+}
+
+fn utf16_cmp(a: &str, b: &str) -> std::cmp::Ordering {
+    let mut ai = a.encode_utf16();
+    let mut bi = b.encode_utf16();
+    loop {
+        match (ai.next(), bi.next()) {
+            (None, None) => return std::cmp::Ordering::Equal,
+            (None, Some(_)) => return std::cmp::Ordering::Less,
+            (Some(_), None) => return std::cmp::Ordering::Greater,
+            (Some(x), Some(y)) => match x.cmp(&y) {
+                std::cmp::Ordering::Equal => continue,
+                other => return other,
+            },
+        }
+    }
+}
+
+fn write_number(n: &serde_json::Number, out: &mut String) -> SignatifResult<()> {
+    if let Some(i) = n.as_i64() {
+        out.push_str(&i.to_string());
+        return Ok(());
+    }
+    if let Some(u) = n.as_u64() {
+        out.push_str(&u.to_string());
+        return Ok(());
+    }
+    let f = n
+        .as_f64()
+        .ok_or_else(|| SignatifError::Encoding("number is not finite".into()))?;
+    if !f.is_finite() {
+        return Err(SignatifError::Encoding(
+            "NaN and Infinity are not allowed".into(),
+        ));
+    }
+    if f == 0.0 {
+        // RFC 8785 §3.2.2.3: negative zero becomes 0.
+        out.push('0');
+        return Ok(());
+    }
+    // serde_json serializes f64 with shortest round-trip (ryu), matching
+    // the ECMAScript number serialization JCS specifies.
+    out.push_str(&serde_json::to_string(&Value::from(f)).expect("finite f64 serializes"));
+    Ok(())
+}
+
+fn write_string(s: &str, out: &mut String) {
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{09}' => out.push_str("\\t"),
+            '\u{0a}' => out.push_str("\\n"),
+            '\u{0c}' => out.push_str("\\f"),
+            '\u{0d}' => out.push_str("\\r"),
+            c if (c as u32) < 0x20 => {
+                out.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn control_chars_escaped_lowercase_hex() {
+        assert_eq!(
+            canonicalize(&json!("\u{0007}\u{001f}")).unwrap(),
+            "\"\\u0007\\u001f\""
+        );
+    }
+
+    #[test]
+    fn verbatim_characters_pass_through() {
+        // RFC 8785: U+20AC etc. are not escaped.
+        assert_eq!(canonicalize(&json!("€ßé")).unwrap(), "\"€ßé\"");
+    }
+
+    #[test]
+    fn sorts_keys_by_utf16() {
+        let v = json!({"b": 1, "a": 2});
+        assert_eq!(canonicalize(&v).unwrap(), r#"{"a":2,"b":1}"#);
+    }
+
+    #[test]
+    fn utf16_ordering_beats_codepoint_ordering() {
+        // U+FF21 (FULLWIDTH A) sorts before U+10000 in UTF-16, and after
+        // in UTF-32. Constructing such keys checks the comparator.
+        // U+10000 is the surrogate pair D800 DE00 in UTF-16, which
+        // sorts before U+FF21 — but after it in codepoint order.
+        let v = json!({"\u{10000}": 1, "\u{FF21}": 2});
+        let c = canonicalize(&v).unwrap();
+        let surrogate_pos = c.find('\u{10000}').expect("surrogate char present");
+        let fullwidth_pos = c.find('\u{FF21}').expect("fullwidth char present");
+        assert!(surrogate_pos < fullwidth_pos, "got {c}");
+    }
+
+    #[test]
+    fn deterministic_nested_structures() {
+        let a = json!({"z": [1, 2.5, true, null], "a": {"y": "x"}});
+        let b = json!({"a": {"y": "x"}, "z": [1, 2.5, true, null]});
+        assert_eq!(canonicalize(&a).unwrap(), canonicalize(&b).unwrap());
+    }
+
+    #[test]
+    fn negative_zero_normalizes() {
+        let v: Value = serde_json::from_str("-0.0").unwrap();
+        assert_eq!(canonicalize(&v).unwrap(), "0");
+    }
+
+    #[test]
+    fn floats_shortest_round_trip() {
+        assert_eq!(canonicalize(&json!(2.5)).unwrap(), "2.5");
+        assert_eq!(canonicalize(&json!(1e30)).unwrap(), "1e+30");
+    }
+
+    #[test]
+    fn canonical_hash_is_sha256_of_canonical_bytes() {
+        use sha2::{Digest, Sha256};
+        let h = canonical_hash(&json!({"a":1})).unwrap();
+        let expect: [u8; 32] = Sha256::digest(b"{\"a\":1}").into();
+        assert_eq!(h, expect);
+    }
+}

--- a/crates/confium-signatif/src/lib.rs
+++ b/crates/confium-signatif/src/lib.rs
@@ -1,0 +1,46 @@
+//! # confium-signatif
+//!
+//! Implementation of the SIGNATIF framework — Sealed Interoperable
+//! Graduated Non-repudiable Anchored Trust Infrastructure Framework
+//! (ISO/TC 154 working draft) — on top of the Confium cryptographic
+//! substrate.
+//!
+//! SIGNATIF is the framework, Confium is the implementation tool, and a
+//! domain scheme (for example CNML for metrology) adopts the framework
+//! through this crate:
+//!
+//! - [`graph`]: the trust graph (delegation DAG) and path-finding that
+//!   collects every valid verification path.
+//! - [`bundle`]: versioned, signed trust anchor bundles.
+//! - [`scope`]: the multi-dimensional scope lattice with monotonic
+//!   narrowing.
+//! - [`artifact`]: trusted artifacts with dimension-tagged co-signature
+//!   blocks over one canonical payload hash.
+//! - [`pipeline`]: the ordered hard/soft check verification pipeline,
+//!   [`coverage`] reports, classification and acceptance policies.
+//! - [`revocation`]: signed CRLs, hash bindings, transitive propagation.
+//! - [`ceremony`]: verifiable ceremony transcripts and their audit.
+//! - [`registry`]: the five scheme-maintained registries.
+//!
+//! All verification is offline-capable against a trust anchor bundle.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod artifact;
+pub mod bundle;
+pub mod ceremony;
+pub mod coverage;
+pub mod discovery;
+pub mod error;
+pub mod graph;
+pub mod jcs;
+pub mod multilog;
+pub mod passport;
+pub mod pipeline;
+pub mod registry;
+pub mod revocation;
+pub mod scope;
+pub mod time;
+
+pub use error::{SignatifError, SignatifResult};

--- a/crates/confium-signatif/src/multilog.rs
+++ b/crates/confium-signatif/src/multilog.rs
@@ -1,0 +1,228 @@
+//! Multi-log attestation and gossip quorum (SIGNATIF §13).
+//!
+//! - [`MultiLogPolicy`] `{m, k}`: a federated authority's artifacts
+//!   must carry inclusion proofs from at least M of K independent
+//!   logs — no single log operator controls the record.
+//! - [`GossipQuorum`]: the signed tree head a verifier relies on must
+//!   be witnessed by at least N independent witnesses.
+//! - [`MultiLogAttestation`]: the verification side — which logs
+//!   produced valid inclusion proofs.
+
+use serde::{Deserialize, Serialize};
+
+/// M-of-K multi-log policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MultiLogPolicy {
+    /// Required number of valid inclusion proofs.
+    pub m: usize,
+    /// Recognized independent logs.
+    pub k: usize,
+}
+
+impl MultiLogPolicy {
+    /// Validate M <= K and M >= 1.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error for inconsistent parameters.
+    pub fn validate(&self) -> crate::error::SignatifResult<()> {
+        if self.m == 0 || self.m > self.k {
+            return Err(crate::error::SignatifError::Encoding(format!(
+                "invalid multi-log policy {} of {}",
+                self.m, self.k
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// One log's inclusion-verification result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogInclusion {
+    /// Log name.
+    pub log: String,
+    /// Whether a valid inclusion proof was verified for the artifact.
+    pub included: bool,
+}
+
+/// The set of inclusion results evaluated against a policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MultiLogAttestation {
+    /// Per-log results.
+    pub inclusions: Vec<LogInclusion>,
+}
+
+impl MultiLogAttestation {
+    /// Evaluate the M-of-K quorum.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the policy parameters are inconsistent.
+    pub fn satisfies(&self, policy: &MultiLogPolicy) -> crate::error::SignatifResult<bool> {
+        policy.validate()?;
+        let included = self.inclusions.iter().filter(|i| i.included).count();
+        Ok(included >= policy.m)
+    }
+}
+
+/// One witness's signature over a signed tree head.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WitnessCosignature {
+    /// Witness identity.
+    pub witness: String,
+    /// The witnessed tree head bytes (root hash + size + timestamp).
+    pub tree_head_bytes: Vec<u8>,
+    /// The witness's signature over the tree head bytes.
+    pub signature: Vec<u8>,
+    /// The witness's public key.
+    pub public_key: Vec<u8>,
+}
+
+/// Gossip quorum verification: at least `min_sources` distinct,
+/// independently-signed observations of the *same* tree head.
+#[derive(Debug, Clone, Copy)]
+pub struct GossipQuorum {
+    /// Minimum independent witnesses required.
+    pub min_sources: usize,
+}
+
+impl GossipQuorum {
+    /// Check the quorum.
+    ///
+    /// # Errors
+    ///
+    /// Propagates signature-verification errors as hard failures.
+    pub fn check(
+        &self,
+        cosignatures: &[WitnessCosignature],
+        verifier: &dyn crate::graph::SignatureVerifier,
+    ) -> crate::error::SignatifResult<bool> {
+        use std::collections::BTreeMap;
+        // Group by tree head bytes; a quorum must agree on one head.
+        let mut by_head: BTreeMap<Vec<u8>, Vec<&WitnessCosignature>> = BTreeMap::new();
+        for c in cosignatures {
+            by_head
+                .entry(c.tree_head_bytes.clone())
+                .or_default()
+                .push(c);
+        }
+        for (_, witnesses) in by_head {
+            let mut distinct = std::collections::BTreeSet::new();
+            let mut all_valid = true;
+            for w in &witnesses {
+                if !verifier.verify(&w.public_key, &w.tree_head_bytes, &w.signature) {
+                    all_valid = false;
+                    break;
+                }
+                distinct.insert(w.witness.clone());
+            }
+            if all_valid && distinct.len() >= self.min_sources {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl crate::graph::SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    #[test]
+    fn multilog_quorum() {
+        let policy = MultiLogPolicy { m: 2, k: 3 };
+        let att = MultiLogAttestation {
+            inclusions: vec![
+                LogInclusion {
+                    log: "a".into(),
+                    included: true,
+                },
+                LogInclusion {
+                    log: "b".into(),
+                    included: true,
+                },
+                LogInclusion {
+                    log: "c".into(),
+                    included: false,
+                },
+            ],
+        };
+        assert!(att.satisfies(&policy).unwrap());
+        let weak = MultiLogAttestation {
+            inclusions: vec![
+                LogInclusion {
+                    log: "a".into(),
+                    included: true,
+                },
+                LogInclusion {
+                    log: "b".into(),
+                    included: false,
+                },
+                LogInclusion {
+                    log: "c".into(),
+                    included: false,
+                },
+            ],
+        };
+        assert!(!weak.satisfies(&policy).unwrap());
+        assert!(policy.with_m_zero().validate().is_err());
+    }
+
+    impl MultiLogPolicy {
+        fn with_m_zero(&self) -> MultiLogPolicy {
+            MultiLogPolicy { m: 0, k: self.k }
+        }
+    }
+
+    #[test]
+    fn gossip_quorum_needs_agreement() {
+        let head = b"tree-head-v1".to_vec();
+        let witnesses: Vec<SigningKey> = (0..3).map(|_| generate_key()).collect();
+        let cosigns: Vec<WitnessCosignature> = witnesses
+            .iter()
+            .enumerate()
+            .map(|(i, sk)| WitnessCosignature {
+                witness: format!("w{i}"),
+                tree_head_bytes: head.clone(),
+                signature: sk.sign(&head).to_bytes().to_vec(),
+                public_key: sk.verifying_key().as_bytes().to_vec(),
+            })
+            .collect();
+        let q = GossipQuorum { min_sources: 3 };
+        assert!(q.check(&cosigns, &Ed25519Verifier).unwrap());
+
+        // Split view: two heads, no single head has the quorum.
+        let mut split = cosigns.clone();
+        split[2].tree_head_bytes = b"other-head".to_vec();
+        assert!(!q.check(&split, &Ed25519Verifier).unwrap());
+
+        // Forged signature invalidates that head's group.
+        let mut forged = cosigns.clone();
+        forged[1].signature[0] ^= 1;
+        assert!(!q.check(&forged, &Ed25519Verifier).unwrap());
+    }
+}

--- a/crates/confium-signatif/src/passport.rs
+++ b/crates/confium-signatif/src/passport.rs
@@ -1,0 +1,163 @@
+//! Delivery formats: passports and challenge-response (SIGNATIF §16).
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+use crate::jcs;
+
+/// A machine-readable passport: a compact, deterministic summary of a
+/// certificate or artifact, verifiable against the same anchor bundle
+/// and transparency log as the underlying object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Passport {
+    /// Passport format version.
+    pub version: u32,
+    /// The certificate or artifact identifier.
+    pub object_id: String,
+    /// Key fingerprint of the identified object.
+    pub key_fingerprint: String,
+    /// Human- and machine-readable scope summary.
+    pub scope_summary: String,
+    /// Passport validity period start.
+    pub valid_from: DateTime<Utc>,
+    /// Passport validity period end.
+    pub valid_until: DateTime<Utc>,
+}
+
+impl Passport {
+    /// Deterministic distribution bytes (JCS) — the barcode payload
+    /// base for 2D delivery.
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn distribution_bytes(&self) -> SignatifResult<Vec<u8>> {
+        let v = serde_json::to_value(self).expect("passport serializes");
+        Ok(jcs::canonicalize(&v)?.into_bytes())
+    }
+
+    /// Whether the passport is valid at `now`.
+    pub fn is_valid_at(&self, now: DateTime<Utc>) -> bool {
+        now >= self.valid_from && now <= self.valid_until
+    }
+
+    /// Parse a passport from its deterministic bytes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error on malformed input.
+    pub fn from_distribution_bytes(bytes: &[u8]) -> SignatifResult<Self> {
+        serde_json::from_slice(bytes)
+            .map_err(|e| SignatifError::Encoding(format!("passport decode: {e}")))
+    }
+}
+
+/// A challenge issued to a device signer: a fresh 256-bit nonce and a
+/// validity window. Authenticity is established by the ability to
+/// produce a timely, nonce-bound response — a static copy of a prior
+/// artifact cannot satisfy the challenge.
+#[derive(Debug, Clone)]
+pub struct Challenge {
+    /// The nonce (>= 128 bits of entropy; we use 256).
+    pub nonce: [u8; 32],
+    /// When the challenge was issued.
+    pub issued_at: DateTime<Utc>,
+    /// Freshness window.
+    pub window: chrono::Duration,
+}
+
+impl Challenge {
+    /// Generate a challenge with an OS-random nonce.
+    ///
+    /// # Errors
+    ///
+    /// Returns a revocation-category error if the OS RNG fails.
+    pub fn generate(window: chrono::Duration) -> SignatifResult<Self> {
+        use rand_core::RngCore;
+        let mut nonce = [0u8; 32];
+        rand_core::OsRng
+            .try_fill_bytes(&mut nonce)
+            .map_err(|e| SignatifError::Revocation(format!("os rng: {e}")))?;
+        Ok(Self {
+            nonce,
+            issued_at: Utc::now(),
+            window,
+        })
+    }
+
+    /// The canonical payload the response artifact must carry: the
+    /// nonce bound into a deterministic JSON object.
+    pub fn expected_payload(&self) -> serde_json::Value {
+        serde_json::json!({
+            "challenge_nonce": hex::encode(self.nonce),
+            "challenged_at": self.issued_at.to_rfc3339(),
+        })
+    }
+
+    /// Verify a response artifact's payload: the nonce must match and
+    /// the response must be inside the freshness window.
+    ///
+    /// # Errors
+    ///
+    /// Returns an artifact-format error on nonce mismatch or expiry.
+    pub fn verify_response(
+        &self,
+        response_payload: &serde_json::Value,
+        now: DateTime<Utc>,
+    ) -> SignatifResult<()> {
+        let got = response_payload
+            .get("challenge_nonce")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                SignatifError::ArtifactFormat("response lacks challenge_nonce".into())
+            })?;
+        if got != hex::encode(self.nonce) {
+            return Err(SignatifError::ArtifactFormat(
+                "challenge nonce mismatch — replayed response".into(),
+            ));
+        }
+        if now > self.issued_at + self.window {
+            return Err(SignatifError::ArtifactFormat(
+                "response outside freshness window".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passport_round_trips_deterministically() {
+        let p = Passport {
+            version: 1,
+            object_id: "end-cert-7".into(),
+            key_fingerprint: "ab00".into(),
+            scope_summary: "domain:pharma/*".into(),
+            valid_from: Utc::now(),
+            valid_until: Utc::now() + chrono::Duration::days(365),
+        };
+        let bytes = p.distribution_bytes().unwrap();
+        let back = Passport::from_distribution_bytes(&bytes).unwrap();
+        assert_eq!(back.object_id, p.object_id);
+        assert_eq!(back.distribution_bytes().unwrap(), bytes);
+        assert!(back.is_valid_at(Utc::now()));
+    }
+
+    #[test]
+    fn challenge_response_binds_nonce_and_freshness() {
+        let c = Challenge::generate(chrono::Duration::seconds(30)).unwrap();
+        let payload = c.expected_payload();
+        assert!(c.verify_response(&payload, Utc::now()).is_ok());
+
+        let mut wrong = payload.clone();
+        wrong["challenge_nonce"] = serde_json::json!("00");
+        assert!(c.verify_response(&wrong, Utc::now()).is_err());
+
+        let late = Utc::now() + chrono::Duration::minutes(5);
+        assert!(c.verify_response(&payload, late).is_err());
+    }
+}

--- a/crates/confium-signatif/src/pipeline.rs
+++ b/crates/confium-signatif/src/pipeline.rs
@@ -1,0 +1,514 @@
+//! The verification pipeline (SIGNATIF §14).
+//!
+//! An ordered sequence of checks classified as **hard** or **soft**.
+//! Any hard failure short-circuits to the scheme's rejected label;
+//! soft results accumulate into the [`CoverageReport`]. Inputs are the
+//! artifact, the trust anchor bundle, the trust graph, the registries,
+//! a revocation view, and the classification/acceptance policies —
+//! everything an offline verifier holds or caches.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::TrustedArtifact;
+use crate::bundle::TrustAnchorBundle;
+use crate::coverage::{
+    Acceptance, AcceptancePolicy, ClassificationLabel, ClassificationPolicy, CoverageReport,
+    HardCheckStatus, ReferenceClassificationPolicy,
+};
+use crate::error::{SignatifError, SignatifResult};
+use crate::graph::{SignatureVerifier, TrustGraph};
+use crate::registry::Registry;
+use crate::revocation::{DEFAULT_GRACE_PERIOD, RevocationView};
+use crate::scope::ScopeDimensions;
+
+/// Soft-check inputs the pipeline cannot derive on its own.
+#[derive(Debug, Clone, Default)]
+pub struct TransparencyInputs {
+    /// Whether inclusion proofs were verified for the artifact against
+    /// a recognized log (from the bundle's log set).
+    pub artifact_included: bool,
+    /// Whether the M-of-K multi-log quorum was met.
+    pub multi_log_quorum: bool,
+    /// Whether a time-anchor attestation was verified (see [`crate::time`]).
+    pub time_anchored: bool,
+    /// Downgrade reasons the caller's soft checks produced (e.g.
+    /// "transparency_missing", "time_anchor_absent").
+    pub downgrades: Vec<String>,
+}
+
+/// The freshness window applied to time attestations (§14
+/// `time-freshness-window`): attestations inside the window are fresh;
+/// inside `grace` but outside the window they downgrade; older reject.
+#[derive(Debug, Clone, Copy)]
+pub struct FreshnessWindow {
+    /// Maximum age of a time attestation.
+    pub window: chrono::Duration,
+    /// Secondary grace period at downgraded classification.
+    pub grace: chrono::Duration,
+}
+
+impl Default for FreshnessWindow {
+    fn default() -> Self {
+        Self {
+            window: chrono::Duration::seconds(30 * 60),
+            grace: chrono::Duration::hours(24),
+        }
+    }
+}
+
+/// The outcome of a pipeline run.
+#[derive(Debug, Clone)]
+pub struct VerificationOutcome {
+    /// The objective coverage report.
+    pub report: CoverageReport,
+    /// The scheme's classification of the report.
+    pub label: ClassificationLabel,
+    /// The verifier's acceptance decision.
+    pub acceptance: Acceptance,
+}
+
+/// The ordered verification pipeline.
+pub struct Pipeline<'a> {
+    /// Anchor bundle (offline trust starting point).
+    pub bundle: &'a TrustAnchorBundle,
+    /// The trust graph (delegation DAG).
+    pub graph: &'a TrustGraph,
+    /// Scheme registries.
+    pub registry: &'a Registry,
+    /// Signature verifier fleet.
+    pub verifier: &'a dyn SignatureVerifier,
+    /// Revocation state view (CRLs and hash bindings).
+    pub revocation: &'a dyn RevocationView,
+    /// Soft-check inputs from transparency and time verification.
+    pub transparency: TransparencyInputs,
+    /// Time-freshness window.
+    pub freshness: FreshnessWindow,
+    /// Classification policy (scheme-defined).
+    pub classification: &'a dyn ClassificationPolicy,
+    /// Acceptance policy (verifier-defined).
+    pub acceptance: &'a AcceptancePolicy,
+}
+
+impl<'a> Pipeline<'a> {
+    /// A pipeline with the reference classification policy.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        bundle: &'a TrustAnchorBundle,
+        graph: &'a TrustGraph,
+        registry: &'a Registry,
+        verifier: &'a dyn SignatureVerifier,
+        revocation: &'a dyn RevocationView,
+        transparency: TransparencyInputs,
+        acceptance: &'a AcceptancePolicy,
+    ) -> Self {
+        Self {
+            bundle,
+            graph,
+            registry,
+            verifier,
+            revocation,
+            transparency,
+            freshness: FreshnessWindow::default(),
+            classification: &ReferenceClassificationPolicy,
+            acceptance,
+        }
+    }
+
+    /// Override the classification policy.
+    pub fn with_classification(mut self, policy: &'a dyn ClassificationPolicy) -> Self {
+        self.classification = policy;
+        self
+    }
+
+    /// Override the freshness window.
+    pub fn with_freshness(mut self, window: FreshnessWindow) -> Self {
+        self.freshness = window;
+        self
+    }
+
+    /// Run the pipeline. Hard checks in order: bundle validity, format
+    /// validity + registry status, co-signature verification, chain
+    /// path-finding (scope narrowing per link), revocation status.
+    /// Soft checks accumulate: transparency, time anchor, multi-log
+    /// quorum, dimension coverage, root diversity.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first hard failure encountered; the error is the
+    /// machine-readable reason, the caller short-circuits to the
+    /// rejected label.
+    pub fn run(
+        &self,
+        artifact: &TrustedArtifact,
+        now: DateTime<Utc>,
+    ) -> SignatifResult<VerificationOutcome> {
+        // Hard 1: anchor bundle validity.
+        self.bundle
+            .verify(now, self.verifier)
+            .map_err(|e| SignatifError::HardCheck(format!("bundle_validity: {e}")))?;
+
+        // Hard 2: format validity, version compatibility, registry
+        // status, self-description (canonical hash binding), and every
+        // co-signature independently.
+        let supported = crate::artifact::ArtifactVersion { major: 1, minor: 0 };
+        if !supported.accepts(&artifact.version) {
+            return Err(SignatifError::HardCheck(format!(
+                "format_version: artifact {} exceeds supported {}",
+                artifact.version, supported
+            )));
+        }
+        artifact
+            .verify_self(self.registry, self.verifier)
+            .map_err(|e| SignatifError::HardCheck(format!("signature_validity: {e}")))?;
+
+        // Hard 3: chain integrity — at least one path from a signer to
+        // an anchor for each distinct chain_ref, scope narrowing
+        // enforced per link by the graph walk.
+        let mut paths_found = 0usize;
+        let mut roots: Vec<String> = Vec::new();
+        for block in &artifact.co_signatures {
+            let node = self.graph.node(&block.signer_cert_ref).ok_or_else(|| {
+                SignatifError::HardCheck(format!(
+                    "chain_integrity: unknown signer {}",
+                    block.signer_cert_ref
+                ))
+            })?;
+            let paths = self
+                .graph
+                .find_paths(&node.id, self.bundle, self.verifier)
+                .map_err(|e| SignatifError::HardCheck(format!("chain_integrity: {e}")))?;
+            if paths.is_empty() {
+                return Err(SignatifError::HardCheck(format!(
+                    "chain_integrity: no path from {} to an anchor",
+                    node.id
+                )));
+            }
+            paths_found += paths.len();
+            for p in &paths {
+                if !roots.contains(&p.root.id) {
+                    roots.push(p.root.id.clone());
+                }
+            }
+        }
+
+        // Hard 4: revocation of every authority on every valid path.
+        for block in &artifact.co_signatures {
+            let status = self
+                .revocation
+                .authority_status(&block.signer_cert_ref, now);
+            match status {
+                crate::revocation::RevocationStatus::Revoked => {
+                    return Err(SignatifError::HardCheck(format!(
+                        "revocation: signer {} is revoked",
+                        block.signer_cert_ref
+                    )));
+                }
+                crate::revocation::RevocationStatus::GraceDowngrade => {
+                    // soft: recorded as downgrade below
+                }
+                crate::revocation::RevocationStatus::Good => {}
+            }
+        }
+
+        // Soft checks: accumulate into the coverage report.
+        let mut downgrades = self.transparency.downgrades.clone();
+        if !self.transparency.artifact_included {
+            downgrades.push("transparency_missing".into());
+        }
+        if !self.transparency.time_anchored {
+            downgrades.push("time_anchor_absent".into());
+        }
+        if self.revocation.max_crl_age(now) > DEFAULT_GRACE_PERIOD {
+            downgrades.push("crl_stale".into());
+        }
+        // Freshness: newest time-dimension attestation inside window?
+        if let Some(newest) = artifact
+            .co_signatures
+            .iter()
+            .filter(|b| b.dimension.as_str() == crate::registry::DimensionTag::TIME)
+            .map(|b| b.timestamp)
+            .max()
+        {
+            let age = now.signed_duration_since(newest);
+            if age > self.freshness.window + self.freshness.grace {
+                return Err(SignatifError::HardCheck(
+                    "time_freshness: time attestation outside window and grace".into(),
+                ));
+            }
+            if age > self.freshness.window {
+                downgrades.push("time_attestation_stale".into());
+            }
+        }
+
+        let report = CoverageReport {
+            hard_checks: HardCheckStatus::Pass,
+            transparency_included: self.transparency.artifact_included,
+            time_anchored: self.transparency.time_anchored,
+            dimensions_verified: artifact
+                .dimensions_verified()
+                .iter()
+                .map(|d| d.as_str().to_string())
+                .collect(),
+            dimension_count: artifact.dimensions_verified().len(),
+            independent_roots: roots.len(),
+            multi_log_quorum: self.transparency.multi_log_quorum,
+            paths_found,
+            downgrades,
+        };
+        let label = self.classification.classify(&report);
+        let acceptance = self.acceptance.decide(&label);
+        Ok(VerificationOutcome {
+            report,
+            label,
+            acceptance,
+        })
+    }
+}
+
+/// The scope of the signer on the (first) verified path — policy input
+/// for downstream decisions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignerScopeSummary {
+    /// Signer node identifier.
+    pub signer: String,
+    /// The signer's scope.
+    pub scope: ScopeDimensions,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::ArtifactVersion;
+    use crate::bundle::AnchorRoot;
+    use crate::graph::{AuthorityKind, AuthorityNode, DelegationEdge, Quorum as GraphQuorum};
+    use crate::registry::DimensionTag;
+    use crate::registry::Registry;
+    use crate::revocation::NoRevocations;
+    use ed25519_dalek::{Signer, SigningKey};
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    struct Fixture {
+        graph: TrustGraph,
+        bundle: TrustAnchorBundle,
+        registry: Registry,
+        artifact: TrustedArtifact,
+        end_sk: SigningKey,
+    }
+
+    fn build() -> Fixture {
+        let registry = Registry::with_initial_values();
+        let root_sk = generate_key();
+        let root = AuthorityNode {
+            id: "root".into(),
+            kind: AuthorityKind::Root,
+            public_key: root_sk.verifying_key().as_bytes().to_vec(),
+            quorum: Some(GraphQuorum::new(2, 3).unwrap()),
+            scope: crate::scope::ScopeDimensions::unconstrained(),
+        };
+        let end_sk = generate_key();
+        let end = AuthorityNode {
+            id: "end".into(),
+            kind: AuthorityKind::EndCertificate,
+            public_key: end_sk.verifying_key().as_bytes().to_vec(),
+            quorum: None,
+            scope: crate::scope::ScopeDimensions::unconstrained(),
+        };
+        let mut graph = TrustGraph::new();
+        graph.add_node(root.clone());
+        graph.add_node(end.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root".into(),
+                child: "end".into(),
+                signature: root_sk
+                    .sign(&end.binding_bytes().unwrap())
+                    .to_bytes()
+                    .to_vec(),
+            })
+            .unwrap();
+
+        let bundle = TrustAnchorBundle {
+            bundle_version: "2026.08".into(),
+            valid_from: Utc::now() - chrono::Duration::hours(1),
+            valid_until: Utc::now() + chrono::Duration::days(30),
+            roots: vec![AnchorRoot {
+                name: "root".into(),
+                aggregate_key: root.public_key.clone(),
+                fingerprint: "00".into(),
+                quorum: root.quorum,
+            }],
+            transparency_logs: vec![],
+            bundle_signature: vec![],
+        };
+        // Bundle signature unused by pipeline? It verifies signatures —
+        // sign the bundle with the root key so hard check 1 passes.
+        let mut bundle = bundle;
+        let mut signed = bundle.clone();
+        signed.bundle_signature = Vec::new();
+        let msg = crate::jcs::canonicalize(&serde_json::to_value(&signed).unwrap()).unwrap();
+        bundle.bundle_signature = root_sk.sign(msg.as_bytes()).to_bytes().to_vec();
+
+        let mut artifact = TrustedArtifact::new(
+            ArtifactVersion { major: 1, minor: 0 },
+            "art-1",
+            serde_json::json!({"v": 1}),
+            None,
+        )
+        .unwrap();
+        artifact
+            .sign(
+                DimensionTag::data(),
+                "Ed25519",
+                "end",
+                end_sk.verifying_key().as_bytes().to_vec(),
+                "root",
+                &|m| end_sk.sign(m).to_bytes().to_vec(),
+                &registry,
+            )
+            .unwrap();
+
+        Fixture {
+            graph,
+            bundle,
+            registry,
+            artifact,
+            end_sk,
+        }
+    }
+
+    #[test]
+    fn full_pipeline_rejects_without_transparency_then_ladders_up() {
+        let f = build();
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        let accept_all =
+            AcceptancePolicy::accept(&["unverified", "basic", "verified", "attested", "certified"]);
+
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &f.registry,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs::default(),
+            &accept_all,
+        );
+        let out = pipe.run(&f.artifact, Utc::now()).unwrap();
+        assert_eq!(out.label.0, "unverified");
+        assert_eq!(out.acceptance, Acceptance::Accept);
+
+        let with_transparency = pipe_with(&f, true, false, &accept_all);
+        let out = with_transparency.run(&f.artifact, Utc::now()).unwrap();
+        assert_eq!(out.label.0, "basic");
+
+        let with_time = pipe_with(&f, true, true, &accept_all);
+        let out = with_time.run(&f.artifact, Utc::now()).unwrap();
+        assert_eq!(out.label.0, "verified");
+    }
+
+    fn pipe_with<'p>(
+        f: &'p Fixture,
+        transparency: bool,
+        time: bool,
+        acceptance: &'p AcceptancePolicy,
+    ) -> Pipeline<'p> {
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &f.registry,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs {
+                artifact_included: transparency,
+                time_anchored: time,
+                multi_log_quorum: false,
+                downgrades: vec![],
+            },
+            acceptance,
+        )
+    }
+
+    #[test]
+    fn tampered_artifact_short_circuits_to_hard_failure() {
+        let f = build();
+        let mut broken = f.artifact.clone();
+        broken.payload["v"] = serde_json::json!(2);
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        let accept_all = AcceptancePolicy::accept(&["verified"]);
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &f.registry,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs::default(),
+            &accept_all,
+        );
+        let err = pipe.run(&broken, Utc::now()).unwrap_err();
+        assert!(err.to_string().contains("signature_validity"));
+    }
+
+    #[test]
+    fn stale_time_attestation_beyond_grace_is_hard_failure() {
+        let f = build();
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        let accept_all = AcceptancePolicy::accept(&["verified"]);
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &f.registry,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs {
+                artifact_included: true,
+                time_anchored: true,
+                multi_log_quorum: false,
+                downgrades: vec![],
+            },
+            &accept_all,
+        )
+        .with_freshness(FreshnessWindow {
+            window: chrono::Duration::seconds(60),
+            grace: chrono::Duration::seconds(60),
+        });
+        // A properly signed TIME block whose timestamp is beyond
+        // window + grace: hard failure.
+        let mut old = f.artifact.clone();
+        let input = old.cosign_input(&DimensionTag::time());
+        use ed25519_dalek::Signer as _;
+        old.co_signatures.push(crate::artifact::CoSignatureBlock {
+            dimension: DimensionTag::time(),
+            algorithm: "Ed25519".into(),
+            signer_cert_ref: "end".into(),
+            signer_pubkey: f.end_sk.verifying_key().as_bytes().to_vec(),
+            chain_ref: "root".into(),
+            signature: f.end_sk.sign(&input).to_bytes().to_vec(),
+            timestamp: Utc::now() - chrono::Duration::hours(2),
+        });
+        let err = pipe.run(&old, Utc::now()).unwrap_err();
+        assert!(err.to_string().contains("time_freshness"), "got {err}");
+    }
+}

--- a/crates/confium-signatif/src/registry.rs
+++ b/crates/confium-signatif/src/registry.rs
@@ -1,0 +1,401 @@
+//! The five scheme-maintained registries (SIGNATIF Annex C).
+//!
+//! A scheme adopting the framework owns registries for the extensible
+//! value spaces: trust dimensions, algorithms, ceremony types, format
+//! profiles, and scope dimensions. Each entry carries a lifecycle
+//! status consumed by the verification pipeline (`deprecated`
+//! downgrades, `retired` rejects). Registries are deterministic,
+//! serializable documents so a scheme can publish them.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+
+/// Lifecycle status of a registry entry (algorithm agility §20).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    /// Recognized and usable.
+    Active,
+    /// Announced for removal: artifacts using it are downgraded.
+    Deprecated,
+    /// Removed: artifacts using it are rejected.
+    Retired,
+}
+
+/// A registry entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Entry {
+    /// Entry identifier (e.g. `Ed25519`, `data`, `/conf/format-cose`).
+    pub name: String,
+    /// Human-readable description.
+    pub description: String,
+    /// Lifecycle status.
+    pub status: Status,
+    /// Reference to the specification or standard.
+    pub reference: String,
+}
+
+/// The trust dimension tags used in co-signature blocks.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct DimensionTag(String);
+
+impl DimensionTag {
+    /// The `data` dimension — the primary content attestation.
+    pub const DATA: &'static str = "data";
+    /// The `person` dimension — a human witnessed or authorized.
+    pub const PERSON: &'static str = "person";
+    /// The `time` dimension — existence at a stated time.
+    pub const TIME: &'static str = "time";
+    /// The `location` dimension — occurrence at coordinates.
+    pub const LOCATION: &'static str = "location";
+    /// The `environment` dimension — ambient conditions in bounds.
+    pub const ENVIRONMENT: &'static str = "environment";
+    /// The `authorization` dimension — action permitted by policy.
+    pub const AUTHORIZATION: &'static str = "authorization";
+    /// The `identity` dimension — device or person is genuine.
+    pub const IDENTITY: &'static str = "identity";
+    /// The `oracle` dimension — external data had a stated value.
+    pub const ORACLE: &'static str = "oracle";
+
+    /// The `data` dimension — the primary content attestation.
+    pub fn data() -> Self {
+        Self(Self::DATA.into())
+    }
+    /// The `person` dimension — a human witnessed or authorized.
+    pub fn person() -> Self {
+        Self(Self::PERSON.into())
+    }
+    /// The `time` dimension — existence at a stated time.
+    pub fn time() -> Self {
+        Self(Self::TIME.into())
+    }
+    /// The `location` dimension — occurrence at coordinates.
+    pub fn location() -> Self {
+        Self(Self::LOCATION.into())
+    }
+    /// The `environment` dimension — ambient conditions in bounds.
+    pub fn environment() -> Self {
+        Self(Self::ENVIRONMENT.into())
+    }
+    /// The `authorization` dimension — action permitted by policy.
+    pub fn authorization() -> Self {
+        Self(Self::AUTHORIZATION.into())
+    }
+    /// The `identity` dimension — device or person is genuine.
+    pub fn identity() -> Self {
+        Self(Self::IDENTITY.into())
+    }
+    /// The `oracle` dimension — external data had a stated value.
+    pub fn oracle() -> Self {
+        Self(Self::ORACLE.into())
+    }
+
+    /// Build a custom dimension tag (scheme-registered extensions).
+    pub fn custom(name: &str) -> Self {
+        Self(name.into())
+    }
+
+    /// The tag's string value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A named registry with entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ValueRegistry {
+    /// Registry name (for error messages and publication).
+    pub registry_name: String,
+    /// The entries.
+    pub entries: Vec<Entry>,
+}
+
+impl ValueRegistry {
+    /// An empty registry.
+    pub fn new(name: &str) -> Self {
+        Self {
+            registry_name: name.to_string(),
+            entries: Vec::new(),
+        }
+    }
+
+    /// Register an entry.
+    pub fn register(&mut self, entry: Entry) {
+        self.entries.push(entry);
+    }
+
+    /// Look up an entry by name.
+    pub fn get(&self, name: &str) -> Option<&Entry> {
+        self.entries.iter().find(|e| e.name == name)
+    }
+
+    /// Whether the entry exists with the given status usable by new
+    /// attestations (active or deprecated).
+    pub fn contains(&self, name: &str) -> bool {
+        self.get(name)
+            .map(|e| e.status != Status::Retired)
+            .unwrap_or(false)
+    }
+
+    /// Returns the entry when it can be used for *new* attestations;
+    /// retired entries cannot sign new artifacts.
+    pub fn usable(&self, name: &str) -> Option<&Entry> {
+        self.get(name).filter(|e| e.status != Status::Retired)
+    }
+
+    /// The status of an entry, if registered.
+    pub fn status(&self, name: &str) -> Option<Status> {
+        self.get(name).map(|e| e.status)
+    }
+
+    /// Transition an entry's status (the deprecation process §20).
+    ///
+    /// # Errors
+    ///
+    /// Returns a registry error when the entry is unknown.
+    pub fn set_status(&mut self, name: &str, status: Status) -> SignatifResult<()> {
+        let entry = self
+            .entries
+            .iter_mut()
+            .find(|e| e.name == name)
+            .ok_or_else(|| SignatifError::Registry {
+                registry: self.registry_name.clone(),
+                entry: name.to_string(),
+            })?;
+        entry.status = status;
+        Ok(())
+    }
+}
+
+/// The five scheme-maintained registries in one bundle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Registry {
+    /// Trust dimension tag registry.
+    pub dimensions: ValueRegistry,
+    /// Algorithm identifier registry (classical, post-quantum,
+    /// composite) with status.
+    pub algorithms: ValueRegistry,
+    /// Ceremony type registry.
+    pub ceremony_types: ValueRegistry,
+    /// Format profile registry.
+    pub format_profiles: ValueRegistry,
+    /// Scope dimension registry.
+    pub scope_dimensions: ValueRegistry,
+}
+
+impl Registry {
+    /// The five registries populated with the framework's initial
+    /// values (Annex C: initial content is the scheme's decision at
+    /// establishment; these are Confium's defaults).
+    pub fn with_initial_values() -> Self {
+        let mut dimensions = ValueRegistry::new("trust-dimension");
+        for (name, desc, anchor) in [
+            (
+                DimensionTag::DATA,
+                "The primary content (measured value, record)",
+                "Transparency log",
+            ),
+            (
+                DimensionTag::PERSON,
+                "A human witnessed or authorized the act",
+                "Hardware token",
+            ),
+            (
+                DimensionTag::TIME,
+                "The artifact existed at a stated time",
+                "External timestamp source",
+            ),
+            (
+                DimensionTag::LOCATION,
+                "The event occurred at stated coordinates",
+                "Location authority signal",
+            ),
+            (
+                DimensionTag::ENVIRONMENT,
+                "Ambient conditions were within stated bounds",
+                "Calibrated sensor",
+            ),
+            (
+                DimensionTag::AUTHORIZATION,
+                "The action was permitted under a policy",
+                "Regulatory framework",
+            ),
+            (
+                DimensionTag::IDENTITY,
+                "The device or person is genuine",
+                "Identity authority",
+            ),
+            (
+                DimensionTag::ORACLE,
+                "External data had a stated value at a time",
+                "Multi-source agreement",
+            ),
+        ] {
+            dimensions.register(Entry {
+                name: name.to_string(),
+                description: desc.into(),
+                status: Status::Active,
+                reference: anchor.into(),
+            });
+        }
+
+        let mut algorithms = ValueRegistry::new("algorithm");
+        for (name, description, reference) in [
+            (
+                "Ed25519",
+                "Edwards-curve digital signature (classical)",
+                "RFC 8032",
+            ),
+            (
+                "ECDSA-P256",
+                "ECDSA over NIST P-256 (classical)",
+                "FIPS 186-4",
+            ),
+            (
+                "ML-DSA-44",
+                "Module-lattice signature (post-quantum)",
+                "FIPS 204",
+            ),
+            (
+                "ML-DSA-65",
+                "Module-lattice signature (post-quantum)",
+                "FIPS 204",
+            ),
+            (
+                "ML-DSA-87",
+                "Module-lattice signature (post-quantum)",
+                "FIPS 204",
+            ),
+            (
+                "SLH-DSA-128s",
+                "Stateless hash-based signature (post-quantum)",
+                "FIPS 205",
+            ),
+            (
+                "Composite-Ed25519-MLDSA65",
+                "AND-composition Ed25519 + ML-DSA-65 (composite)",
+                "SIGNATIF §9.4",
+            ),
+            (
+                "Threshold-CMP20-P256",
+                "CMP20 threshold ECDSA P-256 aggregate",
+                "Confium confium-tc-cmp20",
+            ),
+            (
+                "Threshold-FROST-Ed25519",
+                "FROST threshold Ed25519 aggregate",
+                "Confium confium-tc-frost-ed25519",
+            ),
+        ] {
+            algorithms.register(Entry {
+                name: name.into(),
+                description: description.into(),
+                status: Status::Active,
+                reference: reference.into(),
+            });
+        }
+
+        let mut ceremony_types = ValueRegistry::new("ceremony-type");
+        for name in ["dkg", "reshare", "sign", "revoke", "rotation"] {
+            ceremony_types.register(Entry {
+                name: name.into(),
+                description: format!("Threshold {name} ceremony"),
+                status: Status::Active,
+                reference: "SIGNATIF §17".into(),
+            });
+        }
+
+        let mut format_profiles = ValueRegistry::new("format-profile");
+        for (name, reference) in [
+            ("/conf/format-cose", "RFC 8152 COSE Sig_Structure"),
+            ("/conf/format-jws", "RFC 7515 JWS detached content"),
+            ("/conf/format-xmldsig", "W3C XML Signature + Exclusive C14N"),
+        ] {
+            format_profiles.register(Entry {
+                name: name.into(),
+                description: "Signature envelope format profile".into(),
+                status: Status::Active,
+                reference: reference.into(),
+            });
+        }
+
+        let mut scope_dimensions = ValueRegistry::new("scope-dimension");
+        for name in ["domain", "subdomain", "class", "instance", "identity"] {
+            scope_dimensions.register(Entry {
+                name: name.into(),
+                description: format!("Scope dimension `{name}`"),
+                status: Status::Active,
+                reference: "SIGNATIF §11".into(),
+            });
+        }
+
+        Self {
+            dimensions,
+            algorithms,
+            ceremony_types,
+            format_profiles,
+            scope_dimensions,
+        }
+    }
+
+    /// Deterministic publication bytes for a registry (JCS).
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn publication_bytes(&self) -> SignatifResult<Vec<u8>> {
+        let v = serde_json::to_value(self).expect("registry serializes");
+        Ok(crate::jcs::canonicalize(&v)?.into_bytes())
+    }
+
+    /// Declare a scheme-registered extension dimension.
+    pub fn register_dimension(&mut self, tag: &str, description: &str) {
+        self.dimensions.register(Entry {
+            name: tag.into(),
+            description: description.into(),
+            status: Status::Active,
+            reference: "scheme-registered".into(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn initial_values_populate_all_five() {
+        let r = Registry::with_initial_values();
+        assert!(r.dimensions.entries.len() >= 8);
+        assert!(r.algorithms.get("Ed25519").is_some());
+        assert!(r.algorithms.get("ML-DSA-65").is_some());
+        assert!(r.ceremony_types.get("dkg").is_some());
+        assert!(r.format_profiles.get("/conf/format-cose").is_some());
+        assert!(r.scope_dimensions.get("domain").is_some());
+    }
+
+    #[test]
+    fn deprecation_lifecycle() {
+        let mut r = Registry::with_initial_values();
+        r.algorithms
+            .set_status("ECDSA-P256", Status::Deprecated)
+            .unwrap();
+        assert_eq!(r.algorithms.status("ECDSA-P256"), Some(Status::Deprecated));
+        assert!(r.algorithms.usable("ECDSA-P256").is_some());
+        r.algorithms
+            .set_status("ECDSA-P256", Status::Retired)
+            .unwrap();
+        assert!(r.algorithms.usable("ECDSA-P256").is_none());
+        assert!(r.algorithms.set_status("nope", Status::Active).is_err());
+    }
+
+    #[test]
+    fn scheme_extension_dimensions() {
+        let mut r = Registry::with_initial_values();
+        r.register_dimension("cnml:instrument-class", "CNML instrument classification");
+        assert!(r.dimensions.contains("cnml:instrument-class"));
+        let bytes = r.publication_bytes().unwrap();
+        assert!(!bytes.is_empty());
+    }
+}

--- a/crates/confium-signatif/src/revocation.rs
+++ b/crates/confium-signatif/src/revocation.rs
@@ -1,0 +1,340 @@
+//! Revocation semantics (SIGNATIF §12).
+//!
+//! Four pieces:
+//!
+//! - [`Crl`] — the signed, time-stamped list of revoked authority
+//!   credentials with reason, validity period, and a transparency-log
+//!   reference for its own publication;
+//! - [`AuthorityStateBinding`] — the hash-binding that ties an
+//!   artifact to the authority states under which it was produced;
+//! - [`RevocationIndex`] — propagation and query: when a state is
+//!   revoked, every transitively bound artifact is *marked* (never
+//!   deleted), reversibly if the revocation is corrected;
+//! - [`RevocationView`] — the offline-verifier lens consumed by the
+//!   pipeline, including the CRL grace-period policy.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+/// Default offline CRL grace period before a stale CRL hard-rejects.
+pub const DEFAULT_GRACE_PERIOD: Duration = Duration::hours(24);
+
+/// Why a credential was revoked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RevocationReason {
+    /// Cryptographic key compromise.
+    KeyCompromise,
+    /// The authority ceased operation or affiliation ended.
+    CessationOfOperation,
+    /// Issued in error or superseded.
+    Superseded,
+    /// Withdrawn by the authority (policy).
+    Withdrawn,
+}
+
+/// One entry in a CRL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RevokedEntry {
+    /// Fingerprint of the revoked credential.
+    pub fingerprint: String,
+    /// When it was revoked.
+    pub revoked_at: DateTime<Utc>,
+    /// Why.
+    pub reason: RevocationReason,
+}
+
+/// A certificate revocation list: signed by the issuing trust
+/// authority, timestamped, validity-bounded, log-recorded.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Crl {
+    /// The issuing trust authority's identifier.
+    pub issuer: String,
+    /// Revoked credentials.
+    pub revoked: Vec<RevokedEntry>,
+    /// CRL validity start.
+    pub this_update: DateTime<Utc>,
+    /// CRL validity end.
+    pub next_update: DateTime<Utc>,
+    /// Transparency-log sequence of this CRL's own publication.
+    pub log_sequence: u64,
+    /// The issuer's signature over the canonical CRL body.
+    pub signature: Vec<u8>,
+}
+
+impl Crl {
+    /// The canonical signing bytes (JCS of the CRL without signature).
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn signing_bytes(&self) -> crate::error::SignatifResult<Vec<u8>> {
+        let mut copy = self.clone();
+        copy.signature = Vec::new();
+        Ok(
+            crate::jcs::canonicalize(&serde_json::to_value(&copy).expect("crl serializes"))?
+                .into_bytes(),
+        )
+    }
+
+    /// Whether the CRL covers `fingerprint` with a revocation time at
+    /// or before `at`.
+    pub fn revokes(&self, fingerprint: &str, at: DateTime<Utc>) -> Option<&RevokedEntry> {
+        self.revoked
+            .iter()
+            .find(|e| e.fingerprint == fingerprint && e.revoked_at <= at)
+    }
+
+    /// Whether the CRL is stale: `now` past `next_update`.
+    pub fn is_stale(&self, now: DateTime<Utc>) -> bool {
+        now > self.next_update
+    }
+}
+
+/// The hash-binding of an artifact to the authority states under
+/// which it was produced (`hash-binding` requirement): the artifact's
+/// canonical payload hash plus the fingerprints of every authority on
+/// every verified path.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthorityStateBinding {
+    /// The bound artifact's canonical payload hash (hex).
+    pub artifact_hash: String,
+    /// Fingerprints of authority states the artifact depends on.
+    pub authority_fingerprints: Vec<String>,
+    /// When the binding was recorded.
+    pub bound_at: DateTime<Utc>,
+}
+
+/// Revocation status of a signer as seen by the pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RevocationStatus {
+    /// Not revoked; CRL fresh.
+    Good,
+    /// Not revoked, but the CRL is within the grace window — soft.
+    GraceDowngrade,
+    /// Revoked — hard failure.
+    Revoked,
+}
+
+/// The offline-verifier revocation lens.
+pub trait RevocationView {
+    /// Status of the authority identified by `id` at time `now`.
+    fn authority_status(&self, id: &str, now: DateTime<Utc>) -> RevocationStatus;
+
+    /// Age of the freshest CRL consulted (zero when none exist).
+    fn max_crl_age(&self, now: DateTime<Utc>) -> Duration;
+}
+
+/// A view with no revocations — for sealed offline bundles with empty
+/// CRLs and for tests.
+#[derive(Debug, Clone, Copy)]
+pub struct NoRevocations;
+
+impl RevocationView for NoRevocations {
+    fn authority_status(&self, _id: &str, _now: DateTime<Utc>) -> RevocationStatus {
+        RevocationStatus::Good
+    }
+
+    fn max_crl_age(&self, _now: DateTime<Utc>) -> Duration {
+        Duration::zero()
+    }
+}
+
+/// A concrete view over a set of CRLs.
+#[derive(Debug, Clone, Default)]
+pub struct CrlView {
+    /// Fingerprints of the authorities whose status is being asked.
+    pub authority_fingerprints: BTreeMap<String, String>,
+    /// The CRLs held (cached for offline verification).
+    pub crls: Vec<Crl>,
+}
+
+impl RevocationView for CrlView {
+    fn authority_status(&self, id: &str, now: DateTime<Utc>) -> RevocationStatus {
+        let Some(fp) = self.authority_fingerprints.get(id) else {
+            return RevocationStatus::Good;
+        };
+        let stale = self.crls.iter().all(|c| c.is_stale(now));
+        for crl in &self.crls {
+            if crl.revokes(fp, now).is_some() {
+                return RevocationStatus::Revoked;
+            }
+        }
+        if stale && !self.crls.is_empty() {
+            RevocationStatus::GraceDowngrade
+        } else {
+            RevocationStatus::Good
+        }
+    }
+
+    fn max_crl_age(&self, now: DateTime<Utc>) -> Duration {
+        self.crls
+            .iter()
+            .map(|c| now.signed_duration_since(c.this_update))
+            .max()
+            .unwrap_or_else(Duration::zero)
+    }
+}
+
+/// Artifact marking: revoked-but-not-deleted, reversible.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactMark {
+    /// Bound to a revoked authority state.
+    Marked,
+    /// Mark cleared after a corrected revocation.
+    Cleared,
+}
+
+/// The propagation and query index: artifacts ↔ authority states.
+#[derive(Debug, Clone, Default)]
+pub struct RevocationIndex {
+    bindings: Vec<AuthorityStateBinding>,
+    marks: BTreeMap<String, ArtifactMark>,
+    revoked_states: Vec<String>,
+}
+
+impl RevocationIndex {
+    /// An empty index.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record an artifact's binding to authority states.
+    pub fn bind(&mut self, binding: AuthorityStateBinding) {
+        self.bindings.push(binding);
+    }
+
+    /// Revoke an authority state (by fingerprint) and propagate: every
+    /// artifact transitively bound to that state is **marked**, not
+    /// deleted; the marking is queryable and reversible.
+    pub fn revoke_state(&mut self, fingerprint: &str) {
+        self.revoked_states.push(fingerprint.to_string());
+        for b in &self.bindings {
+            if b.authority_fingerprints.iter().any(|f| f == fingerprint) {
+                self.marks
+                    .insert(b.artifact_hash.clone(), ArtifactMark::Marked);
+            }
+        }
+    }
+
+    /// Correct a revocation: un-mark artifacts bound to the state.
+    pub fn correct_state(&mut self, fingerprint: &str) {
+        self.revoked_states.retain(|f| f != fingerprint);
+        for b in &self.bindings {
+            if b.authority_fingerprints.iter().any(|f| f == fingerprint) {
+                self.marks
+                    .insert(b.artifact_hash.clone(), ArtifactMark::Cleared);
+            }
+        }
+    }
+
+    /// Forward query: the states an artifact is bound to and its
+    /// current marking.
+    pub fn artifact_status(&self, artifact_hash: &str) -> (Vec<String>, Option<ArtifactMark>) {
+        let states = self
+            .bindings
+            .iter()
+            .find(|b| b.artifact_hash == artifact_hash)
+            .map(|b| b.authority_fingerprints.clone())
+            .unwrap_or_default();
+        (states, self.marks.get(artifact_hash).copied())
+    }
+
+    /// Reverse query: artifacts bound to a given state.
+    pub fn artifacts_for_state(&self, fingerprint: &str) -> Vec<String> {
+        self.bindings
+            .iter()
+            .filter(|b| b.authority_fingerprints.iter().any(|f| f == fingerprint))
+            .map(|b| b.artifact_hash.clone())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn crl(revoked: Vec<RevokedEntry>) -> Crl {
+        Crl {
+            issuer: "root".into(),
+            revoked,
+            this_update: Utc::now() - Duration::hours(1),
+            next_update: Utc::now() + Duration::days(7),
+            log_sequence: 42,
+            signature: vec![],
+        }
+    }
+
+    #[test]
+    fn crl_matches_by_fingerprint_and_time() {
+        let fp = "abc";
+        let c = crl(vec![RevokedEntry {
+            fingerprint: fp.into(),
+            revoked_at: Utc::now() - Duration::minutes(5),
+            reason: RevocationReason::KeyCompromise,
+        }]);
+        assert!(c.revokes(fp, Utc::now()).is_some());
+        assert!(c.revokes(fp, Utc::now() - Duration::hours(1)).is_none());
+        assert!(c.revokes("other", Utc::now()).is_none());
+    }
+
+    #[test]
+    fn view_reports_revoked_and_stale_grace() {
+        let fp = "abc";
+        let mut view = CrlView::default();
+        view.authority_fingerprints.insert("end".into(), fp.into());
+        view.crls.push(crl(vec![RevokedEntry {
+            fingerprint: fp.into(),
+            revoked_at: Utc::now(),
+            reason: RevocationReason::Withdrawn,
+        }]));
+        assert_eq!(
+            view.authority_status("end", Utc::now()),
+            RevocationStatus::Revoked
+        );
+
+        let fresh_view = CrlView {
+            authority_fingerprints: [("end".to_string(), "abc".to_string())]
+                .into_iter()
+                .collect(),
+            crls: vec![crl(vec![])],
+        };
+        assert_eq!(
+            fresh_view.authority_status("end", Utc::now()),
+            RevocationStatus::Good
+        );
+
+        let mut stale = fresh_view.clone();
+        stale.crls[0].next_update = Utc::now() - Duration::hours(1);
+        assert_eq!(
+            stale.authority_status("end", Utc::now()),
+            RevocationStatus::GraceDowngrade
+        );
+    }
+
+    #[test]
+    fn propagation_marks_reversibly() {
+        let mut idx = RevocationIndex::new();
+        idx.bind(AuthorityStateBinding {
+            artifact_hash: "h1".into(),
+            authority_fingerprints: vec!["fp-root".into(), "fp-end".into()],
+            bound_at: Utc::now(),
+        });
+        idx.bind(AuthorityStateBinding {
+            artifact_hash: "h2".into(),
+            authority_fingerprints: vec!["fp-other".into()],
+            bound_at: Utc::now(),
+        });
+
+        idx.revoke_state("fp-end");
+        assert_eq!(idx.artifact_status("h1").1, Some(ArtifactMark::Marked));
+        assert_eq!(idx.artifact_status("h2").1, None);
+        assert_eq!(idx.artifacts_for_state("fp-end"), vec!["h1".to_string()]);
+
+        idx.correct_state("fp-end");
+        assert_eq!(idx.artifact_status("h1").1, Some(ArtifactMark::Cleared));
+    }
+}

--- a/crates/confium-signatif/src/scope.rs
+++ b/crates/confium-signatif/src/scope.rs
@@ -1,0 +1,200 @@
+//! The multi-dimensional authorization scope lattice (SIGNATIF §11).
+//!
+//! A trust authority's scope is a set of independent dimensions —
+//! `domain`, `subdomain`, `class`, `instance`, `identity` — each holding
+//! a [`ScopeValue`] from a three-level lattice:
+//!
+//! ```text
+//! Wildcard ⊇ Set { .. } ⊇ Single _
+//! ```
+//!
+//! Delegation must narrow monotonically: on every dimension the child
+//! value must be a subset of (or equal to) the parent value. Widening
+//! any dimension at any link is a hard verification failure. Unknown
+//! dimensions are carried in `extra` so schemes can extend the model
+//! without breaking verifiers that do not recognize the extension; a
+//! dimension absent from the parent is treated as unconstrained.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// One dimension's value in the scope lattice. The default is
+/// [`ScopeValue::Wildcard`]: an unconstrained dimension.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum ScopeValue {
+    /// Unconstrained — the top of the lattice.
+    #[default]
+    Wildcard,
+    /// One of a finite set of values.
+    Set(BTreeSet<String>),
+    /// Exactly one value — the bottom of the lattice.
+    Single(String),
+}
+
+impl ScopeValue {
+    /// Returns true when `self` is a subset of (or equal to) `parent`
+    /// in the lattice: wildcard encompasses anything; a set encompasses
+    /// its subsets and singles; a single encompasses only itself.
+    pub fn narrows_within(&self, parent: &ScopeValue) -> bool {
+        match (self, parent) {
+            (_, ScopeValue::Wildcard) => true,
+            (ScopeValue::Single(a), ScopeValue::Single(b)) => a == b,
+            (ScopeValue::Single(a), ScopeValue::Set(sup)) => sup.contains(a),
+            (ScopeValue::Set(sub), ScopeValue::Set(sup)) => sub.is_subset(sup),
+            (ScopeValue::Set(_), ScopeValue::Single(_)) => false,
+            (ScopeValue::Wildcard, _) => false,
+        }
+    }
+}
+
+/// A multi-dimensional scope: the five named SIGNATIF dimensions plus
+/// an extension map for scheme-registered dimensions.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeDimensions {
+    /// Top-level business or regulatory domain.
+    pub domain: ScopeValue,
+    /// Subdivision of the domain.
+    pub subdomain: ScopeValue,
+    /// Class of objects the authority may attest.
+    pub class: ScopeValue,
+    /// A specific instance identifier (batch, serial, lot).
+    pub instance: ScopeValue,
+    /// Authorized actor identity.
+    pub identity: ScopeValue,
+    /// Scheme-registered extension dimensions.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub extra: BTreeMap<String, ScopeValue>,
+}
+
+impl ScopeDimensions {
+    /// Unconstrained scope (all wildcards).
+    pub fn unconstrained() -> Self {
+        Self::default()
+    }
+
+    /// Iterate over `(dimension, value)` pairs, named dimensions first.
+    pub fn dimensions(&self) -> impl Iterator<Item = (&'static str, &ScopeValue)> {
+        [
+            ("domain", &self.domain),
+            ("subdomain", &self.subdomain),
+            ("class", &self.class),
+            ("instance", &self.instance),
+            ("identity", &self.identity),
+        ]
+        .into_iter()
+    }
+
+    /// Look up a dimension by name, including extensions.
+    pub fn get(&self, dimension: &str) -> Option<&ScopeValue> {
+        match dimension {
+            "domain" => Some(&self.domain),
+            "subdomain" => Some(&self.subdomain),
+            "class" => Some(&self.class),
+            "instance" => Some(&self.instance),
+            "identity" => Some(&self.identity),
+            other => self.extra.get(other),
+        }
+    }
+
+    /// Set a dimension value by name (including extensions).
+    pub fn set(&mut self, dimension: &str, value: ScopeValue) {
+        match dimension {
+            "domain" => self.domain = value,
+            "subdomain" => self.subdomain = value,
+            "class" => self.class = value,
+            "instance" => self.instance = value,
+            "identity" => self.identity = value,
+            other => {
+                self.extra.insert(other.to_string(), value);
+            }
+        }
+    }
+
+    /// The monotonic narrowing invariant: `self` (child) narrows within
+    /// `parent` on every dimension. Dimensions absent from the parent
+    /// are unconstrained by the parent and therefore always satisfied.
+    pub fn narrows_within(&self, parent: &ScopeDimensions) -> bool {
+        self.first_widened_dimension(parent).is_none()
+    }
+
+    /// Returns the first dimension on which `self` widens relative to
+    /// `parent`, if any — used to produce precise hard-failure errors.
+    pub fn first_widened_dimension(&self, parent: &ScopeDimensions) -> Option<String> {
+        for (name, child_value) in self.dimensions() {
+            if let Some(parent_value) = parent.get(name) {
+                if !child_value.narrows_within(parent_value) {
+                    return Some(name.to_string());
+                }
+            }
+        }
+        for (name, child_value) in &self.extra {
+            if let Some(parent_value) = parent.get(name) {
+                if !child_value.narrows_within(parent_value) {
+                    return Some(name.clone());
+                }
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn single(s: &str) -> ScopeValue {
+        ScopeValue::Single(s.into())
+    }
+
+    fn set(items: &[&str]) -> ScopeValue {
+        ScopeValue::Set(items.iter().map(|s| s.to_string()).collect())
+    }
+
+    #[test]
+    fn lattice_narrowing() {
+        let wildcard = ScopeValue::Wildcard;
+        let two = set(&["pharma", "food"]);
+        let one = set(&["pharma"]);
+        let exact = single("pharma");
+
+        assert!(exact.narrows_within(&one));
+        assert!(one.narrows_within(&two));
+        assert!(two.narrows_within(&wildcard));
+        assert!(exact.narrows_within(&wildcard));
+
+        assert!(!two.narrows_within(&one));
+        assert!(!one.narrows_within(&exact));
+        assert!(!single("food").narrows_within(&one));
+    }
+
+    #[test]
+    fn monotonic_narrowing_invariant() {
+        let mut parent = ScopeDimensions::unconstrained();
+        parent.set("domain", set(&["pharma", "food"]));
+        parent.set("class", single("certificate"));
+
+        let mut child = parent.clone();
+        child.set("domain", single("pharma"));
+        assert!(child.narrows_within(&parent));
+
+        let mut widening = parent.clone();
+        widening.set("domain", ScopeValue::Wildcard);
+        assert_eq!(
+            widening.first_widened_dimension(&parent),
+            Some("domain".to_string())
+        );
+        assert!(!widening.narrows_within(&parent));
+    }
+
+    #[test]
+    fn extension_dimensions_extend_without_breaking() {
+        let parent = ScopeDimensions::unconstrained();
+        let mut child = ScopeDimensions::unconstrained();
+        child.set("cnml:instrument-class", single("mass"));
+        // Parent lacks the dimension => unconstrained => narrow holds.
+        assert!(child.narrows_within(&parent));
+    }
+}

--- a/crates/confium-signatif/src/time.rs
+++ b/crates/confium-signatif/src/time.rs
@@ -1,0 +1,176 @@
+//! The time dimension: external time anchoring (SIGNATIF §8.8).
+//!
+//! The time dimension is attested by a **time key** — a co-signature
+//! from a time authority recording that the artifact hash existed at a
+//! stated time, anchored to an external, irrefutable time source
+//! (OpenTimestamps commitments in Confium). The signer's self-asserted
+//! timestamp is never the sole evidence.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::error::{SignatifError, SignatifResult};
+use crate::graph::SignatureVerifier;
+use crate::jcs;
+
+/// A time authority's attestation over an artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeAttestation {
+    /// The time authority's identifier.
+    pub authority: String,
+    /// The artifact's canonical payload hash (hex).
+    pub artifact_hash: String,
+    /// When the authority attests the artifact existed.
+    pub attested_at: DateTime<Utc>,
+    /// The external anchor: serialized OpenTimestamps proof (or
+    /// equivalent) binding the hash to an irrefutable time source.
+    pub external_anchor: Vec<u8>,
+    /// The time authority's signature over the attestation body.
+    pub signature: Vec<u8>,
+}
+
+impl TimeAttestation {
+    /// The canonical signing bytes.
+    ///
+    /// # Errors
+    ///
+    /// Propagates canonicalization errors.
+    pub fn signing_bytes(&self) -> SignatifResult<Vec<u8>> {
+        let v = serde_json::json!({
+            "authority": self.authority,
+            "artifact_hash": self.artifact_hash,
+            "attested_at": self.attested_at.to_rfc3339(),
+            "external_anchor": hex::encode(&self.external_anchor),
+        });
+        Ok(jcs::canonicalize(&v)?.into_bytes())
+    }
+
+    /// Verify the attestation: the authority's signature, and that an
+    /// external anchor is present (the anchor itself is verified
+    /// against the time source by the OTS layer).
+    ///
+    /// # Errors
+    ///
+    /// Signature or anchor errors.
+    pub fn verify(
+        &self,
+        authority_key: &[u8],
+        verifier: &dyn SignatureVerifier,
+    ) -> SignatifResult<()> {
+        if self.external_anchor.is_empty() {
+            return Err(SignatifError::BadSignature {
+                context: "time attestation lacks an external anchor".into(),
+            });
+        }
+        let msg = self.signing_bytes()?;
+        if !verifier.verify(authority_key, &msg, &self.signature) {
+            return Err(SignatifError::BadSignature {
+                context: format!("time authority {}", self.authority),
+            });
+        }
+        Ok(())
+    }
+
+    /// Freshness against a window: fresh inside `window`, stale
+    /// (downgrade) inside `window + grace`, rejected beyond.
+    pub fn freshness(
+        &self,
+        now: DateTime<Utc>,
+        window: chrono::Duration,
+        grace: chrono::Duration,
+    ) -> TimeFreshness {
+        let age = now.signed_duration_since(self.attested_at);
+        if age <= window {
+            TimeFreshness::Fresh
+        } else if age <= window + grace {
+            TimeFreshness::Stale
+        } else {
+            TimeFreshness::Expired
+        }
+    }
+}
+
+/// Freshness outcome for the pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TimeFreshness {
+    /// Inside the window.
+    Fresh,
+    /// Inside the grace period — downgrade.
+    Stale,
+    /// Beyond grace — reject.
+    Expired,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer;
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    struct Ed25519Verifier;
+
+    impl SignatureVerifier for Ed25519Verifier {
+        fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+            use ed25519_dalek::Signature;
+            use ed25519_dalek::Verifier;
+            let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+                return false;
+            };
+            let Ok(signature) = Signature::from_slice(sig) else {
+                return false;
+            };
+            vk.verify(msg, &signature).is_ok()
+        }
+    }
+
+    fn attestation() -> (TimeAttestation, ed25519_dalek::SigningKey) {
+        let sk = generate_key();
+        let mut a = TimeAttestation {
+            authority: "time-authority-1".into(),
+            artifact_hash: hex::encode([1u8; 32]),
+            attested_at: Utc::now(),
+            external_anchor: b"ots-proof".to_vec(),
+            signature: vec![],
+        };
+        a.signature = sk.sign(&a.signing_bytes().unwrap()).to_bytes().to_vec();
+        (a, sk)
+    }
+
+    #[test]
+    fn verifies_with_external_anchor() {
+        let (a, sk) = attestation();
+        assert!(
+            a.verify(sk.verifying_key().as_bytes(), &Ed25519Verifier)
+                .is_ok()
+        );
+        let mut stripped = a.clone();
+        stripped.external_anchor = vec![];
+        assert!(
+            stripped
+                .verify(sk.verifying_key().as_bytes(), &Ed25519Verifier)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn freshness_ladder() {
+        let (mut a, _) = attestation();
+        let window = chrono::Duration::minutes(5);
+        let grace = chrono::Duration::minutes(5);
+        a.attested_at = Utc::now() - chrono::Duration::minutes(1);
+        assert_eq!(a.freshness(Utc::now(), window, grace), TimeFreshness::Fresh);
+        a.attested_at = Utc::now() - chrono::Duration::minutes(8);
+        assert_eq!(a.freshness(Utc::now(), window, grace), TimeFreshness::Stale);
+        a.attested_at = Utc::now() - chrono::Duration::minutes(30);
+        assert_eq!(
+            a.freshness(Utc::now(), window, grace),
+            TimeFreshness::Expired
+        );
+    }
+}


### PR DESCRIPTION
## What

First working slice of **Confium as the SIGNATIF implementation tool** (the framework layer a domain scheme like CNML adopts). New crate `confium-signatif`, 4.2k lines, 48 tests.

| Module | SIGNATIF clause | Content |
|---|---|---|
| `graph` | 7 | Trust-graph DAG, delegation credentials, all-paths path-finding, per-link signature + scope-narrowing checks, cycle rejection |
| `bundle` | 7 | Versioned, signed, offline-distributable trust anchor bundles |
| `discovery` | 7, 16 | Embedded / log-reference / hybrid chain delivery + caching resolver |
| `scope` | 11 | 5-dimension lattice (wildcard/set/single), monotonic narrowing invariant, extension dimensions |
| `artifact` | 8 | Dimension-tagged co-signature blocks over one canonical payload hash; replay protection; living artifacts; wrapping prevention; semantic versioning |
| `jcs` | 8, Annex E | RFC 8785 canonicalization (UTF-16 key order, minimal escapes, shortest floats, -0 normalization) |
| `pipeline` + `coverage` | 14 | Hard/soft check pipeline with short-circuit, objective coverage report, classification ladder, acceptance policy, freshness window + grace |
| `revocation` | 12 | Signed CRLs, hash-bindings, transitive reversible propagation, forward/reverse query, offline grace |
| `ceremony` | 17 | Transcripts with member participation signatures; 5-step audit algorithm |
| `registry` | Annex C | The five scheme registries with active/deprecated/retired lifecycle |
| `multilog` | 13 | M-of-K inclusion policy; witness gossip quorum with split-view detection |
| `time` | 8.8 | Time-key attestations requiring external anchors; freshness ladder |
| `passport` | 16 | Deterministic passports; 256-bit nonce challenge-response |

## Tests demonstrate

Full classification ladder (unverified → basic → verified → attested → certified), payload tamper detection, cross-artifact replay rejection, scope-widening hard failure, forged-delegation rejection, gossip split-view detection, multi-root path diversity.

## Next (tracked locally in TODO.signatif/)

pki scope-lattice wiring (02), real ML-DSA + composite (07), FTA/nested threshold (08), manifest v2 (09), ATS + conformance report (15), CNML adoption example (16).

The crate is dependency-lean for now (framework-level types); the Confium-substrate integrations (composite COSE encoding, transparency log client, ML-DSA verifier fleet) land with their respective TODOs.
