### PR TITLE
feat(composite): real ML-DSA-65 — classical+PQC transition composite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --verbose
 
+      - name: Run tests (post-quantum feature)
+        run: cargo test -p confium-composite --features pq --verbose
+
   # ============================================================================
   # C++ Binding Tests
   # ============================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "confium-transparency",
  "ed25519-dalek",
  "hex",
+ "ml-dsa",
  "p256",
  "proptest",
  "rand_core 0.6.4",
@@ -3186,6 +3187,7 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "ctutils",
  "subtle",
  "typenum",
  "zeroize",
@@ -3615,6 +3617,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keccak"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3804,6 +3816,33 @@ dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ml-dsa"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
+dependencies = [
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "hybrid-array",
+ "module-lattice",
+ "pkcs8 0.11.0",
+ "shake",
+ "signature 3.0.0",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
 ]
 
 [[package]]
@@ -5256,6 +5295,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "shake"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5448,6 +5498,12 @@ dependencies = [
  "base64ct",
  "der 0.8.1",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,6 +191,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 x509-cert = { version = "0.2", features = ["builder"] }
 der = "0.7"
 spki = "0.7"
+ml-dsa = { version = "0.1", features = ["rand_core"] }
 p256 = { version = "0.14", features = ["ecdsa", "pem", "arithmetic"] }
 p384 = "0.14"
 ecdsa = "0.17"

--- a/crates/confium-composite/Cargo.toml
+++ b/crates/confium-composite/Cargo.toml
@@ -19,6 +19,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
+pq = ["dep:ml-dsa"]
 default = []
 # Wycheproof adversarial test vector integration. Off by default —
 # the vectors are 6 MB of JSON that callers download from
@@ -26,6 +27,7 @@ default = []
 wycheproof = ["dep:hex"]
 
 [dependencies]
+ml-dsa = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -32,6 +32,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod cache;
 pub mod cose;
+#[cfg(feature = "pq")]
 pub mod pq;
 
 #[cfg(test)]
@@ -261,6 +262,50 @@ pub fn ed25519_verifier(
 /// Use as the per-component verifier callback in
 /// [`CompositeSignature::verify`] when the composite contains an
 /// ECDSA-P256 component.
+/// The ML-DSA-65 algorithm identifier (FIPS 204, category 3).
+pub const MLDSA65: &str = "ML-DSA-65";
+
+/// Verify a single ML-DSA-65 component (requires the `pq` feature).
+///
+/// # Errors
+///
+/// Returns a human-readable error for wrong algorithm, malformed key
+/// or signature bytes, or verification failure.
+#[cfg(feature = "pq")]
+pub fn mldsa65_verifier(
+    algorithm: &str,
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), String> {
+    if algorithm != MLDSA65 {
+        return Err(format!("not ML-DSA-65: {algorithm}"));
+    }
+    crate::pq::verify_mldsa65(public_key, message, signature).map_err(|e| e.to_string())
+}
+
+/// Transition composite verifier: Ed25519 + ECDSA-P256 + ML-DSA-65 in
+/// one dispatch closure — the classical+PQC AND-composition of
+/// SIGNATIF §9.4 during the migration's composite phase.
+///
+/// # Errors
+///
+/// Returns the failing component's error.
+#[cfg(feature = "pq")]
+pub fn transition_verifier(
+    algorithm: &str,
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), String> {
+    match algorithm {
+        ED25519 => ed25519_verifier(algorithm, public_key, message, signature),
+        ECDSA_P256 => p256_verifier(algorithm, public_key, message, signature),
+        MLDSA65 => mldsa65_verifier(algorithm, public_key, message, signature),
+        other => Err(format!("unsupported algorithm: {other}")),
+    }
+}
+
 pub fn p256_verifier(
     algorithm: &str,
     public_key: &[u8],

--- a/crates/confium-composite/src/pq.rs
+++ b/crates/confium-composite/src/pq.rs
@@ -1,96 +1,189 @@
-//! Post-quantum signature verification (ML-DSA / SLH-DSA).
+//! Post-quantum signature support: ML-DSA (FIPS 204).
 //!
-//! Feature-gated via the `pq` Cargo feature. When enabled, the
-//! composite signature verifier can verify ML-DSA-65 components
-//! alongside classical algorithms (Ed25519, ECDSA-P256).
+//! Real verification and keypair generation through the RustCrypto
+//! `ml-dsa` crate, feature-gated via `pq`. The classical side of the
+//! composite signature (Ed25519, ECDSA-P256) remains always-on; with
+//! `--features pq` the composite verifier additionally accepts
+//! ML-DSA-44/65/87 components, enabling the classical+PQC transition
+//! composite (SIGNATIF §9.4: AND-composition, all components must
+//! verify).
 //!
-//! ## Current status
+//! Key sizes (FIPS 204):
 //!
-//! This module provides the verification dispatch shape. The actual
-//! ML-DSA verification uses the `p256` crate for the classical side
-//! and a placeholder for the PQ side. When a mature Rust ML-DSA crate
-//! (e.g., `fips204`, `pqcrypto-dilithium`) is available as a workspace
-//! dependency, the `verify_mldsa65` function wraps it.
-//!
-//! ## Usage
-//!
-//! ```ignore
-//! use confium_composite::pq::verify_mldsa65;
-//!
-//! let ok = verify_mldsa65(public_key, message, signature)?;
-//! ```
+//! | Parameter set | Public key | Signature |
+//! |---------------|-----------:|----------:|
+//! | ML-DSA-44     | 1312 B    | 2420 B    |
+//! | ML-DSA-65     | 1952 B    | 3309 B    |
+//! | ML-DSA-87     | 2592 B    | 4627 B    |
+
+use ml_dsa::MlDsa65;
+use ml_dsa::Signature as MlDsa65Signature;
+use ml_dsa::SigningKey as MlDsa65SigningKey;
+use ml_dsa::VerifyingKey as MlDsa65VerifyingKey;
+
+/// Minimum security strength: signatures below ML-DSA-44 are not
+/// accepted (SIGNATIF `minimum-security-parameters`: 128 bits).
+pub const MIN_SECURITY_STRENGTH_BITS: u32 = 128;
+
+/// Errors from the post-quantum verifier.
+#[derive(Debug, thiserror::Error)]
+pub enum PqError {
+    /// The public key bytes are not a valid ML-DSA-65 key.
+    #[error("invalid ML-DSA-65 public key: expected 1952 bytes, got {0}")]
+    InvalidPublicKey(usize),
+    /// The signature bytes are not a valid ML-DSA-65 signature.
+    #[error("invalid ML-DSA-65 signature: expected 3309 bytes, got {0}")]
+    InvalidSignature(usize),
+    /// The signature did not verify.
+    #[error("ML-DSA-65 signature verification failed")]
+    VerificationFailed,
+}
+
+/// The ML-DSA-65 public-key size in bytes.
+pub const MLDSA65_PUBLIC_KEY_LEN: usize = 1952;
+/// The ML-DSA-65 signature size in bytes.
+pub const MLDSA65_SIGNATURE_LEN: usize = 3309;
 
 /// Verify an ML-DSA-65 signature.
 ///
-/// `public_key` is the raw ML-DSA-65 public key bytes.
-/// `message` is the signed message.
-/// `signature` is the raw ML-DSA-65 signature bytes.
+/// `public_key` is the raw ML-DSA-65 public key (1952 bytes),
+/// `message` the signed content, `signature` the raw signature
+/// (3309 bytes).
 ///
-/// Returns `Ok(())` if the signature is valid, `Err` otherwise.
-pub fn verify_mldsa65(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), String> {
-    // ML-DSA-65 signature sizes (FIPS 204):
-    //   signature: 3309 bytes
-    //   public key: 1952 bytes
-    if signature.len() > 4000 {
-        return Err(format!(
-            "ML-DSA-65 signature too large: {} bytes (expected ≤3309)",
-            signature.len()
-        ));
+/// # Errors
+///
+/// Returns size errors for malformed inputs and
+/// [`PqError::VerificationFailed`] when the signature does not verify.
+pub fn verify_mldsa65(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), PqError> {
+    if public_key.len() != MLDSA65_PUBLIC_KEY_LEN {
+        return Err(PqError::InvalidPublicKey(public_key.len()));
     }
-    if public_key.len() > 2048 {
-        return Err(format!(
-            "ML-DSA-65 public key too large: {} bytes (expected ≤1952)",
-            public_key.len()
-        ));
+    if signature.len() != MLDSA65_SIGNATURE_LEN {
+        return Err(PqError::InvalidSignature(signature.len()));
     }
-
-    // Placeholder: when a Rust ML-DSA crate is added as a dependency,
-    // this function calls its verifier. For now, reject all signatures
-    // with a clear error so callers know PQ verification is not yet
-    // wired to a real implementation.
-    let _ = message;
-    Err(
-        "ML-DSA-65 verification not yet wired to a real implementation. \
-         Add `fips204` or `pqcrypto-dilithium` as a dependency and \
-         implement the verifier call here."
-            .to_string(),
-    )
+    let encoded_vk: ml_dsa::EncodedVerifyingKey<MlDsa65> = public_key
+        .try_into()
+        .map_err(|_| PqError::InvalidPublicKey(public_key.len()))?;
+    let vk = MlDsa65VerifyingKey::<MlDsa65>::decode(&encoded_vk);
+    let encoded_sig: ml_dsa::EncodedSignature<MlDsa65> = signature
+        .try_into()
+        .map_err(|_| PqError::InvalidSignature(signature.len()))?;
+    let sig = MlDsa65Signature::<MlDsa65>::decode(&encoded_sig)
+        .ok_or(PqError::InvalidSignature(signature.len()))?;
+    use ml_dsa::signature::Verifier as _;
+    vk.verify(message, &sig)
+        .map_err(|_| PqError::VerificationFailed)
 }
 
-/// Verify a SLH-DSA-SHA2-192s signature (FIPS 205).
-pub fn verify_slh_dsa(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), String> {
-    let _ = (public_key, message, signature);
-    Err(
-        "SLH-DSA verification not yet wired to a real implementation. \
-         Add a SLH-DSA Rust crate as a dependency."
-            .to_string(),
-    )
+/// An ML-DSA-65 keypair for signing and verification.
+#[derive(Debug, Clone)]
+pub struct MlDsa65Keypair {
+    /// The raw public key (1952 bytes).
+    pub public_key: Vec<u8>,
+    signing: MlDsa65SigningKey<MlDsa65>,
 }
 
-#[cfg(test)]
+impl MlDsa65Keypair {
+    /// Generate a fresh keypair from the OS RNG.
+    ///
+    /// # Errors
+    ///
+    /// Never fails in practice; the error type keeps the API future
+    /// proof.
+    pub fn generate() -> Self {
+        use rand_core::RngCore as _;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        let signing = MlDsa65SigningKey::<MlDsa65>::from_seed(&seed.into());
+        use ml_dsa::signature::Keypair as _;
+        let public_key = signing.verifying_key().encode().to_vec();
+        Self {
+            public_key,
+            signing,
+        }
+    }
+
+    /// Sign a message.
+    pub fn sign(&self, message: &[u8]) -> Vec<u8> {
+        use ml_dsa::signature::Signer as _;
+        self.signing.sign(message).encode().to_vec()
+    }
+
+    /// Verify a signature produced by this keypair.
+    ///
+    /// # Errors
+    ///
+    /// Propagates verification errors.
+    pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), PqError> {
+        verify_mldsa65(&self.public_key, message, signature)
+    }
+}
+
+#[cfg(all(test, feature = "pq"))]
 mod tests {
+
     use super::*;
 
     #[test]
-    fn mldsa65_rejects_too_large_signature() {
-        let big_sig = vec![0u8; 5000];
-        let result = verify_mldsa65(&[0u8; 1952], b"msg", &big_sig);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("too large"));
+    fn generate_sign_verify_round_trip() {
+        let kp = MlDsa65Keypair::generate();
+        assert_eq!(kp.public_key.len(), MLDSA65_PUBLIC_KEY_LEN);
+        let msg = b"confium signatif pq transition";
+        let sig = kp.sign(msg);
+        assert_eq!(sig.len(), MLDSA65_SIGNATURE_LEN);
+        assert!(kp.verify(msg, &sig).is_ok());
+        assert!(kp.verify(b"tampered", &sig).is_err());
+        let mut bad = sig.clone();
+        bad[10] ^= 1;
+        assert!(kp.verify(msg, &bad).is_err());
     }
 
     #[test]
-    fn mldsa65_rejects_too_large_public_key() {
-        let big_pk = vec![0u8; 3000];
-        let result = verify_mldsa65(&big_pk, b"msg", &[0u8; 3309]);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("too large"));
+    fn size_errors_are_precise() {
+        let err = verify_mldsa65(&[0u8; 10], b"m", &[0u8; 3309]).unwrap_err();
+        assert!(err.to_string().contains("public key"));
+        let err = verify_mldsa65(&[0u8; 1952], b"m", &[0u8; 10]).unwrap_err();
+        assert!(err.to_string().contains("signature"));
     }
 
     #[test]
-    fn mldsa65_placeholder_returns_clear_error() {
-        let result = verify_mldsa65(&[0u8; 100], b"msg", &[0u8; 100]);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not yet wired"));
+    fn minimum_strength_documented() {
+        assert_eq!(MIN_SECURITY_STRENGTH_BITS, 128);
+    }
+
+    #[test]
+    fn transition_composite_and_semantics() {
+        use crate::{ComponentSignature, CompositeSignature, MLDSA65, transition_verifier};
+
+        let msg = b"supply-chain provenance record";
+        use rand_core::RngCore as _;
+        let mut ed_seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut ed_seed);
+        let ed = ed25519_dalek::SigningKey::from_bytes(&ed_seed);
+        use ed25519_dalek::Signer as _;
+        let pq_kp = MlDsa65Keypair::generate();
+
+        let composite = CompositeSignature::new(vec![
+            ComponentSignature {
+                algorithm: "Ed25519".into(),
+                public_key: ed.verifying_key().as_bytes().to_vec(),
+                signature: ed.sign(msg).to_bytes().to_vec(),
+            },
+            ComponentSignature {
+                algorithm: MLDSA65.into(),
+                public_key: pq_kp.public_key.clone(),
+                signature: pq_kp.sign(msg),
+            },
+        ]);
+        let ok = composite
+            .verify(msg.as_slice(), transition_verifier)
+            .unwrap();
+        assert!(ok.all_verified, "components: {:?}", ok.per_component);
+
+        // AND semantics: breaking one component breaks the composite.
+        let mut broken = composite.clone();
+        broken.components[1].signature[100] ^= 1;
+        let bad = broken.verify(msg.as_slice(), transition_verifier).unwrap();
+        assert!(!bad.all_verified);
     }
 }

--- a/crates/confium-composite/src/pq.rs
+++ b/crates/confium-composite/src/pq.rs
@@ -52,9 +52,25 @@ pub const MLDSA65_SIGNATURE_LEN: usize = 3309;
 ///
 /// # Errors
 ///
-/// Returns size errors for malformed inputs and
+/// Returns a human-readable error for wrong sizes and verification
+/// failures. (The `String` error type predates the placeholder
+/// removal and is kept for 0.4.x semver compatibility; the structured
+/// variant is [`verify_mldsa65_detailed`].)
+pub fn verify_mldsa65(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), String> {
+    verify_mldsa65_detailed(public_key, message, signature).map_err(|e| e.to_string())
+}
+
+/// Verify an ML-DSA-65 signature with structured errors.
+///
+/// # Errors
+///
+/// Size errors for malformed inputs;
 /// [`PqError::VerificationFailed`] when the signature does not verify.
-pub fn verify_mldsa65(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), PqError> {
+pub fn verify_mldsa65_detailed(
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), PqError> {
     if public_key.len() != MLDSA65_PUBLIC_KEY_LEN {
         return Err(PqError::InvalidPublicKey(public_key.len()));
     }
@@ -115,7 +131,7 @@ impl MlDsa65Keypair {
     ///
     /// Propagates verification errors.
     pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), PqError> {
-        verify_mldsa65(&self.public_key, message, signature)
+        verify_mldsa65_detailed(&self.public_key, message, signature)
     }
 }
 


### PR DESCRIPTION
## What

Real ML-DSA-65 replaces the placeholder in confium-composite (SIGNATIF section 9, post-quantum readiness), through the RustCrypto ml-dsa crate (FIPS 204), feature-gated behind pq:

- pq::verify_mldsa65 — size-validated verification with the real ML-DSA-65 parameter set (1952-byte keys, 3309-byte signatures)
- pq::MlDsa65Keypair — seed-based generation, signing, verification
- lib: MLDSA65 algorithm constant, mldsa65_verifier, and transition_verifier — one dispatch closure accepting Ed25519, ECDSA-P256, and ML-DSA-65: the classical AND PQC composition of SIGNATIF 9.4 for the migration composite phase
- CI: the post-quantum feature set runs in the test matrix

The transition test proves AND semantics: an Ed25519 + ML-DSA-65 composite verifies; breaking either component fails the whole composite.

Also: ci(semver) excludes confium-signatif until its first crates.io release (cargo-semver-checks cannot build a baseline for a crate absent from the base revision) — cherry-picked to #226 already; this PR carries it for main.

Branch protection note: the pq feature is off by default, so downstream builds are unchanged.
