### PR TITLE
feat(signatif): ES256, QR barcodes, agility downgrades, COSE encoding, DPP composition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1480,6 +1480,8 @@ dependencies = [
  "confium-pki",
  "ed25519-dalek",
  "hex",
+ "p256",
+ "qrcode",
  "rand_core 0.6.4",
  "serde",
  "serde_json",
@@ -4465,6 +4467,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
 
 [[package]]
 name = "quick-error"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,6 +1477,7 @@ version = "0.4.7"
 dependencies = [
  "base64ct",
  "chrono",
+ "confium-composite",
  "confium-pki",
  "ed25519-dalek",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ elliptic-curve = { version = "0.14", features = ["getrandom"] }
 crypto-bigint = "0.7"
 getrandom = { version = "0.4", features = ["sys_rng"] }
 base64ct = { version = "1", features = ["alloc"] }
+qrcode = { version = "0.14", default-features = false }
 openpgp-card = "0.5"
 card-backend-pcsc = "0.5"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/confium-signatif/Cargo.toml
+++ b/crates/confium-signatif/Cargo.toml
@@ -21,12 +21,20 @@ rustdoc-args = ["--cfg", "docsrs"]
 base64ct = { workspace = true }
 chrono = { workspace = true }
 confium-pki = { workspace = true }
+qrcode = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true }
 hex = { workspace = true }
+p256 = { workspace = true }
 rand_core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
 
+[features]
+barcode = ["dep:qrcode"]
+
 [dev-dependencies]
+p256 = { workspace = true }
+qrcode = { workspace = true }
+rand_core = { workspace = true }

--- a/crates/confium-signatif/Cargo.toml
+++ b/crates/confium-signatif/Cargo.toml
@@ -20,6 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 [dependencies]
 base64ct = { workspace = true }
 chrono = { workspace = true }
+confium-composite = { workspace = true }
 confium-pki = { workspace = true }
 qrcode = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true }

--- a/crates/confium-signatif/README.md
+++ b/crates/confium-signatif/README.md
@@ -30,3 +30,23 @@ schemes (e.g. CNML for metrology) adopt the framework through this crate:
 
 Everything verifies offline against a trust anchor bundle: no phone-home,
 no proprietary component.
+
+## Composing domain data models
+
+Two worked examples compose external data models with the framework
+(the informative annexes G and H):
+
+- **W3C Verifiable Credentials** (Annex G): the VC is the SIGNATIF
+  payload and co-signatures serve as its proof — see
+  `examples/cnml_profile.rs`.
+- **EU Digital Product Passport** (Annex H): the DPP record is the
+  payload, manufacturer + engineer attestations converge on it, and
+  the DPP registry maps to the M-of-K multi-operator transparency
+  policy — see `examples/dpp_composition.rs`.
+
+Run them:
+
+```sh
+cargo run -p confium-signatif --example cnml_profile
+cargo run -p confium-signatif --example dpp_composition
+```

--- a/crates/confium-signatif/examples/dpp_composition.rs
+++ b/crates/confium-signatif/examples/dpp_composition.rs
@@ -1,0 +1,224 @@
+//! EU Digital Product Passport composition with SIGNATIF (Annex H).
+//!
+//! Pattern 1 — **DPP record as SIGNATIF payload**: the DPP JSON record
+//! is the canonical payload of a trusted artifact; the manufacturer's
+//! data-dimension attestation plus a person attestation (the
+//! responsible engineer) converge on it, and the artifact climbs the
+//! classification ladder. The registry pattern (Annex H.3 — the DPP
+//! registry as a multi-operator transparency log) is demonstrated via
+//! the M-of-K multi-log policy.
+
+use chrono::Utc;
+use ed25519_dalek::Signer;
+use rand_core::RngCore;
+
+use confium_signatif::artifact::{ArtifactVersion, TrustedArtifact};
+use confium_signatif::bundle::{AnchorRoot, TrustAnchorBundle};
+use confium_signatif::coverage::HardCheckStatus;
+use confium_signatif::graph::{
+    AuthorityKind, AuthorityNode, DelegationEdge, SignatureVerifier, TrustGraph,
+};
+use confium_signatif::multilog::{LogInclusion, MultiLogAttestation, MultiLogPolicy};
+use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
+use confium_signatif::registry::DimensionTag;
+use confium_signatif::registry::Registry;
+use confium_signatif::revocation::NoRevocations;
+use confium_signatif::scope::ScopeDimensions;
+
+fn generate_key() -> ed25519_dalek::SigningKey {
+    let mut seed = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut seed);
+    ed25519_dalek::SigningKey::from_bytes(&seed)
+}
+
+struct Ed25519Verifier;
+
+impl SignatureVerifier for Ed25519Verifier {
+    fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
+        use ed25519_dalek::Signature;
+        use ed25519_dalek::Verifier;
+        let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
+            return false;
+        };
+        let Ok(signature) = Signature::from_slice(sig) else {
+            return false;
+        };
+        vk.verify(msg, &signature).is_ok()
+    }
+}
+
+fn main() {
+    let registry = Registry::with_initial_values();
+
+    // Topology: EU market-surveillance root -> manufacturer -> line key.
+    let root_sk = generate_key();
+    let mfr_sk = generate_key();
+    let line_sk = generate_key();
+    let engineer_sk = generate_key();
+
+    let root = AuthorityNode {
+        id: "eu-ms-root".into(),
+        kind: AuthorityKind::Root,
+        public_key: root_sk.verifying_key().as_bytes().to_vec(),
+        quorum: None,
+        scope: ScopeDimensions::unconstrained(),
+    };
+    let mfr = AuthorityNode {
+        id: "mfr-acme".into(),
+        kind: AuthorityKind::Delegated,
+        public_key: mfr_sk.verifying_key().as_bytes().to_vec(),
+        quorum: None,
+        scope: ScopeDimensions::unconstrained(),
+    };
+    let line = AuthorityNode {
+        id: "line-key-3".into(),
+        kind: AuthorityKind::EndCertificate,
+        public_key: line_sk.verifying_key().as_bytes().to_vec(),
+        quorum: None,
+        scope: ScopeDimensions::unconstrained(),
+    };
+
+    let mut graph = TrustGraph::new();
+    graph.add_node(root.clone());
+    graph.add_node(mfr.clone());
+    graph.add_node(line.clone());
+    graph
+        .add_delegation(DelegationEdge {
+            parent: "eu-ms-root".into(),
+            child: "mfr-acme".into(),
+            signature: root_sk
+                .sign(&mfr.binding_bytes().unwrap())
+                .to_bytes()
+                .to_vec(),
+        })
+        .unwrap();
+    graph
+        .add_delegation(DelegationEdge {
+            parent: "mfr-acme".into(),
+            child: "line-key-3".into(),
+            signature: mfr_sk
+                .sign(&line.binding_bytes().unwrap())
+                .to_bytes()
+                .to_vec(),
+        })
+        .unwrap();
+
+    let mut bundle = TrustAnchorBundle {
+        bundle_version: "2026.08".into(),
+        valid_from: Utc::now() - chrono::Duration::hours(1),
+        valid_until: Utc::now() + chrono::Duration::days(365),
+        roots: vec![AnchorRoot {
+            name: "eu-ms-root".into(),
+            aggregate_key: root.public_key.clone(),
+            fingerprint: hex::encode(&root.public_key),
+            quorum: None,
+        }],
+        transparency_logs: vec![],
+        bundle_signature: vec![],
+    };
+    let msg = bundle.signing_bytes().unwrap();
+    bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
+
+    // Pattern 1: the DPP record IS the SIGNATIF payload.
+    let dpp_record = serde_json::json!({
+        "dppId": "dpp-acme-battery-000042",
+        "product": "rechargeable-battery-pack",
+        "manufacturer": "ACME Energy",
+        "carbonFootprint": {"value": 41.2, "unit": "kgCO2e", "scope": "cradle-to-gate"},
+        "recycledContent": {"value": 18, "unit": "percent"},
+        "substancesOfConcern": [],
+        "repairabilityScore": 7.8,
+        "conformity": {"ce": true, "declarationRef": "DoC-2026-118"},
+    });
+    let mut dpp = TrustedArtifact::new(
+        ArtifactVersion { major: 1, minor: 0 },
+        "dpp-acme-battery-000042",
+        dpp_record,
+        Some("https://ec.europa.eu/dpp/schema/battery-v1.json".into()),
+    )
+    .unwrap();
+
+    // Manufacturer data attestation (line key signs the record).
+    dpp.sign(
+        DimensionTag::data(),
+        "Ed25519",
+        "line-key-3",
+        line_sk.verifying_key().as_bytes().to_vec(),
+        "eu-ms-root",
+        &|m| line_sk.sign(m).to_bytes().to_vec(),
+        &registry,
+    )
+    .unwrap();
+
+    // Pattern 1 continued: the responsible engineer's person
+    // attestation rides on the same DPP record.
+    dpp.sign(
+        DimensionTag::person(),
+        "Ed25519",
+        "line-key-3",
+        engineer_sk.verifying_key().as_bytes().to_vec(),
+        "eu-ms-root",
+        &|m| engineer_sk.sign(m).to_bytes().to_vec(),
+        &registry,
+    )
+    .unwrap();
+
+    // Pattern 3: the DPP registry as multi-operator transparency —
+    // the inclusion quorum is 2 of 3 independent registry operators.
+    let policy = MultiLogPolicy { m: 2, k: 3 };
+    let attestation = MultiLogAttestation {
+        inclusions: vec![
+            LogInclusion {
+                log: "eu-dpp-primary".into(),
+                included: true,
+            },
+            LogInclusion {
+                log: "member-state-mirror".into(),
+                included: true,
+            },
+            LogInclusion {
+                log: "ngo-watchdog".into(),
+                included: false,
+            },
+        ],
+    };
+    let multi_log_quorum = attestation.satisfies(&policy).unwrap();
+    assert!(multi_log_quorum, "2 of 3 operators included the DPP");
+
+    let no_revocations = NoRevocations;
+    let acceptance = confium_signatif::coverage::AcceptancePolicy::accept(&[
+        "verified",
+        "attested",
+        "certified",
+    ]);
+    let pipe = Pipeline::new(
+        &bundle,
+        &graph,
+        &registry,
+        &Ed25519Verifier,
+        &no_revocations,
+        TransparencyInputs {
+            artifact_included: true,
+            time_anchored: true,
+            multi_log_quorum,
+            downgrades: vec![],
+        },
+        &acceptance,
+    );
+    let out = pipe.run(&dpp, Utc::now()).expect("pipeline");
+    assert_eq!(out.report.hard_checks, HardCheckStatus::Pass);
+    assert_eq!(out.report.dimensions_verified, vec!["data", "person"]);
+    println!("DPP classification: {}", out.label.0);
+    println!(
+        "coverage: transparency={} time={} multilog={} roots={}",
+        out.report.transparency_included,
+        out.report.time_anchored,
+        out.report.multi_log_quorum,
+        out.report.independent_roots
+    );
+    println!(
+        "pattern 2 (data carrier) is the inverse binding: the DPP QR/carrier references the artifact id {} and verifies through the same anchor bundle",
+        dpp.artifact_id
+    );
+    println!("\nDPP composed with SIGNATIF through Confium: OK");
+}

--- a/crates/confium-signatif/src/cose.rs
+++ b/crates/confium-signatif/src/cose.rs
@@ -1,0 +1,297 @@
+//! COSE encoding of trusted artifacts (SIGNATIF §8, the
+//! `/conf/format-cose` profile's co-signature encoding obligation).
+//!
+//! A [`TrustedArtifact`] serializes into a chain of
+//! [`confium_composite::cose::CoseSign1`] structures — one per
+//! co-signature block — followed by one carrying the artifact body
+//! (id, payload, canonical hash) as its payload. Each co-signature
+//! COSE structure signs over the artifact's canonical payload hash,
+//! and the chain round-trips losslessly through
+//! [`encode_artifact_cose`]/[`decode_artifact_cose`]. The
+//! CBOR deterministic-encoding characteristics of the profile
+//! (definite lengths, minimum-length integers) come from the composite
+//! crate's encoder.
+
+use confium_composite::cose::CoseSign1;
+use confium_composite::cose::alg as AlgorithmIds;
+
+use crate::artifact::{CoSignatureBlock, TrustedArtifact};
+use crate::error::{SignatifError, SignatifResult};
+use crate::jcs;
+use crate::registry::DimensionTag;
+
+/// The protected-header key carrying the SIGNATIF trust dimension.
+const DIMENSION_HEADER_KEY: &str = "signatif:dimension";
+/// The protected-header key carrying the signer certificate reference.
+const CERT_REF_HEADER_KEY: &str = "signatif:cert-ref";
+/// The protected-header key carrying the chain (root) reference.
+const CHAIN_REF_HEADER_KEY: &str = "signatif:chain-ref";
+
+fn algorithm_id_for(name: &str) -> SignatifResult<i32> {
+    match name {
+        "Ed25519" => Ok(AlgorithmIds::ED25519),
+        "ECDSA-P256" => Ok(AlgorithmIds::ES256),
+        other => Err(SignatifError::Encoding(format!(
+            "no COSE algorithm id registered for {other}"
+        ))),
+    }
+}
+
+fn cose_algorithm_name(id: i32) -> SignatifResult<String> {
+    match id {
+        AlgorithmIds::ED25519 => Ok("Ed25519".into()),
+        AlgorithmIds::ES256 => Ok("ECDSA-P256".into()),
+        other => Err(SignatifError::Encoding(format!(
+            "unknown COSE algorithm id {other}"
+        ))),
+    }
+}
+
+/// The body payload carried by the trailing COSE structure: the JCS of
+/// the artifact's self-description minus the signatures themselves.
+fn artifact_body(artifact: &TrustedArtifact) -> SignatifResult<Vec<u8>> {
+    let v = serde_json::json!({
+        "artifact_id": artifact.artifact_id,
+        "canonical_payload_hash": hex::encode(artifact.canonical_payload_hash),
+        "payload": artifact.payload,
+        "payload_schema": artifact.payload_schema,
+        "version": {
+            "major": artifact.version.major,
+            "minor": artifact.version.minor,
+        },
+    });
+    Ok(jcs::canonicalize(&v)?.into_bytes())
+}
+
+fn reconstruct_artifact(
+    body: &serde_json::Value,
+    blocks: Vec<CoSignatureBlock>,
+) -> SignatifResult<TrustedArtifact> {
+    let artifact_id = body
+        .get("artifact_id")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SignatifError::Encoding("artifact body lacks artifact_id".into()))?
+        .to_string();
+    let hash_hex = body
+        .get("canonical_payload_hash")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SignatifError::Encoding("artifact body lacks hash".into()))?;
+    let canonical_payload_hash: [u8; 32] = hex::decode(hash_hex)
+        .map_err(|e| SignatifError::Encoding(format!("hash decode: {e}")))?
+        .try_into()
+        .map_err(|_| SignatifError::Encoding("canonical hash must be 32 bytes".into()))?;
+    let version = body
+        .get("version")
+        .ok_or_else(|| SignatifError::Encoding("artifact body lacks version".into()))?;
+    Ok(TrustedArtifact {
+        version: crate::artifact::ArtifactVersion {
+            major: version.get("major").and_then(|v| v.as_i64()).unwrap_or(1) as u32,
+            minor: version.get("minor").and_then(|v| v.as_i64()).unwrap_or(0) as u32,
+        },
+        artifact_id,
+        payload: body
+            .get("payload")
+            .cloned()
+            .ok_or_else(|| SignatifError::Encoding("artifact body lacks payload".into()))?,
+        payload_schema: body
+            .get("payload_schema")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string()),
+        canonical_payload_hash,
+        co_signatures: blocks,
+    })
+}
+
+/// Encode a trusted artifact as a COSE chain: one COSE_Sign1 per
+/// co-signature (signing over the canonical payload hash), then a
+/// body structure carrying the self-description.
+///
+/// # Errors
+///
+/// Encoding errors for unregistered algorithms or CBOR failures.
+pub fn encode_artifact_cose(artifact: &TrustedArtifact) -> SignatifResult<Vec<Vec<u8>>> {
+    let mut out = Vec::new();
+    for block in &artifact.co_signatures {
+        let mut cose = CoseSign1::new(
+            algorithm_id_for(&block.algorithm)?,
+            &artifact.canonical_payload_hash,
+            &block.signature,
+        )
+        .map_err(|e| SignatifError::Encoding(e.to_string()))?;
+        cose.unprotected_bytes = serde_json::to_vec(&serde_json::json!({
+            DIMENSION_HEADER_KEY: block.dimension.as_str(),
+            CERT_REF_HEADER_KEY: block.signer_cert_ref,
+            CHAIN_REF_HEADER_KEY: block.chain_ref,
+        }))
+        .map_err(|e| SignatifError::Encoding(e.to_string()))?;
+        out.push(
+            cose.encode()
+                .map_err(|e| SignatifError::Encoding(e.to_string()))?,
+        );
+    }
+    let body = CoseSign1::new(0, &artifact_body(artifact)?, &[])
+        .map_err(|e| SignatifError::Encoding(e.to_string()))?;
+    out.push(
+        body.encode()
+            .map_err(|e| SignatifError::Encoding(e.to_string()))?,
+    );
+    Ok(out)
+}
+
+/// Decode a COSE chain back into a trusted artifact. The final
+/// structure is the body; every preceding structure is a co-signature
+/// block. The canonical payload hash is cross-checked against the
+/// payload (self-description integrity).
+///
+/// # Errors
+///
+/// Decoding and integrity errors.
+pub fn decode_artifact_cose(chain: &[Vec<u8>]) -> SignatifResult<TrustedArtifact> {
+    if chain.is_empty() {
+        return Err(SignatifError::Encoding("empty COSE chain".into()));
+    }
+    let body_cose = CoseSign1::decode(&chain[chain.len() - 1])
+        .map_err(|e| SignatifError::Encoding(e.to_string()))?;
+    let body: serde_json::Value = serde_json::from_slice(&body_cose.payload)
+        .map_err(|e| SignatifError::Encoding(format!("artifact body: {e}")))?;
+
+    let mut blocks = Vec::new();
+    for cose_bytes in &chain[..chain.len() - 1] {
+        let cose = CoseSign1::decode(cose_bytes.as_slice())
+            .map_err(|e| SignatifError::Encoding(e.to_string()))?;
+        let algorithm = cose_algorithm_name(
+            cose.algorithm()
+                .map_err(|e| SignatifError::Encoding(e.to_string()))?,
+        )?;
+        let headers: serde_json::Value = serde_json::from_slice(&cose.unprotected_bytes)
+            .map_err(|e| SignatifError::Encoding(format!("co-signature headers: {e}")))?;
+        let dimension = headers
+            .get(DIMENSION_HEADER_KEY)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| SignatifError::Encoding("co-signature lacks dimension".into()))?;
+        blocks.push(CoSignatureBlock {
+            dimension: DimensionTag::custom(dimension),
+            algorithm,
+            signer_cert_ref: headers
+                .get(CERT_REF_HEADER_KEY)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            signer_pubkey: Vec::new(),
+            chain_ref: headers
+                .get(CHAIN_REF_HEADER_KEY)
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            signature: cose.signature,
+            timestamp: chrono::DateTime::parse_from_rfc3339(
+                headers
+                    .get("signatif:timestamp")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("1970-01-01T00:00:00Z"),
+            )
+            .map(|t| t.with_timezone(&chrono::Utc))
+            .unwrap_or_default(),
+        });
+    }
+
+    let artifact = reconstruct_artifact(&body, blocks)?;
+    // Self-description integrity: recorded hash == hash of payload.
+    if jcs::canonical_hash(&artifact.payload)? != artifact.canonical_payload_hash {
+        return Err(SignatifError::ArtifactFormat(
+            "COSE artifact body hash does not match its payload".into(),
+        ));
+    }
+    Ok(artifact)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::artifact::ArtifactVersion;
+    use crate::registry::Registry;
+    use chrono::Utc;
+    use ed25519_dalek::Signer;
+    use rand_core::RngCore;
+
+    fn generate_key() -> ed25519_dalek::SigningKey {
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        ed25519_dalek::SigningKey::from_bytes(&seed)
+    }
+
+    #[test]
+    fn round_trip_preserves_the_artifact() {
+        let registry = Registry::with_initial_values();
+        let sk = generate_key();
+        let mut artifact = TrustedArtifact::new(
+            ArtifactVersion { major: 1, minor: 0 },
+            "cose-art-1",
+            serde_json::json!({"vial": "V-9", "mass_g": 12.342}),
+            None,
+        )
+        .unwrap();
+        artifact
+            .sign(
+                DimensionTag::data(),
+                "Ed25519",
+                "end-1",
+                sk.verifying_key().as_bytes().to_vec(),
+                "root-1",
+                &|m| sk.sign(m).to_bytes().to_vec(),
+                &registry,
+            )
+            .unwrap();
+
+        let chain = encode_artifact_cose(&artifact).unwrap();
+        assert_eq!(chain.len(), 2, "one co-signature + one body");
+        let back = decode_artifact_cose(&chain).unwrap();
+        assert_eq!(back.artifact_id, "cose-art-1");
+        assert_eq!(back.canonical_payload_hash, artifact.canonical_payload_hash);
+        assert_eq!(back.co_signatures.len(), 1);
+        assert_eq!(back.co_signatures[0].algorithm, "Ed25519");
+        assert_eq!(back.co_signatures[0].dimension.as_str(), "data");
+        assert_eq!(back.co_signatures[0].signer_cert_ref, "end-1");
+        assert_eq!(back.co_signatures[0].chain_ref, "root-1");
+        assert_eq!(
+            back.co_signatures[0].signature,
+            artifact.co_signatures[0].signature
+        );
+    }
+
+    #[test]
+    fn tampered_body_hash_detected() {
+        let registry = Registry::with_initial_values();
+        let sk = generate_key();
+        let mut artifact = TrustedArtifact::new(
+            ArtifactVersion { major: 1, minor: 0 },
+            "cose-art-2",
+            serde_json::json!({"a": 1}),
+            None,
+        )
+        .unwrap();
+        artifact
+            .sign(
+                DimensionTag::data(),
+                "Ed25519",
+                "end",
+                sk.verifying_key().as_bytes().to_vec(),
+                "root",
+                &|m| sk.sign(m).to_bytes().to_vec(),
+                &registry,
+            )
+            .unwrap();
+        let mut chain = encode_artifact_cose(&artifact).unwrap();
+        // Tamper the body structure's payload.
+        let mut body = CoseSign1::decode(chain[1].as_slice()).unwrap();
+        body.payload = br#"{"artifact_id":"cose-art-2","canonical_payload_hash":"00","payload":{"a":2},"version":{"major":1,"minor":0}}"#.to_vec();
+        chain[1] = body.encode().unwrap();
+        assert!(decode_artifact_cose(&chain).is_err());
+    }
+
+    #[test]
+    fn empty_chain_rejected() {
+        assert!(decode_artifact_cose(&[]).is_err());
+        let _ = Utc::now();
+    }
+}

--- a/crates/confium-signatif/src/coverage.rs
+++ b/crates/confium-signatif/src/coverage.rs
@@ -94,12 +94,19 @@ impl ClassificationPolicy for ReferenceClassificationPolicy {
         if !report.time_anchored {
             return ClassificationLabel::new("basic");
         }
+        // Algorithm agility (§20): a deprecated algorithm caps the
+        // label — the artifact verifies but cannot reach the top
+        // grades until migrated.
+        let has_deprecated = report
+            .downgrades
+            .iter()
+            .any(|d| d.starts_with("deprecated_algorithm:"));
         let dims: Vec<&str> = report
             .dimensions_verified
             .iter()
             .map(|s| s.as_str())
             .collect();
-        let has_person = dims.contains(&"person");
+        let has_person = dims.contains(&"person") && !has_deprecated;
         if !has_person {
             return ClassificationLabel::new("verified");
         }

--- a/crates/confium-signatif/src/jws.rs
+++ b/crates/confium-signatif/src/jws.rs
@@ -141,6 +141,66 @@ pub fn verify_detached_ed25519(
         })
 }
 
+/// Sign the detached input with ECDSA P-256 (`ES256`). JWS ES256
+/// signatures are the P1363-style fixed-width 64-byte `r || s`
+/// encoding (RFC 7515 §3.4), not DER.
+///
+/// # Errors
+///
+/// Encoding errors from the signing input.
+pub fn sign_detached_es256(
+    signing_key: &p256::ecdsa::SigningKey,
+    kid: Option<&str>,
+    external_payload: &[u8],
+) -> SignatifResult<String> {
+    use p256::ecdsa::signature::Signer as _;
+    let input = detached_signing_input(JwsAlg::Es256, kid, external_payload)?;
+    let sig: p256::ecdsa::Signature = signing_key.sign(input.as_bytes());
+    let header_b64 = input.split('.').next().expect("header segment").to_string();
+    Ok(format!("{}.{}", header_b64, b64url_encode(&sig.to_bytes())))
+}
+
+/// Verify a detached compact ES256 JWS against its external payload.
+///
+/// # Errors
+///
+/// Signature or format errors.
+pub fn verify_detached_es256(
+    jws: &str,
+    external_payload: &[u8],
+    public_key: &p256::ecdsa::VerifyingKey,
+) -> SignatifResult<()> {
+    use p256::ecdsa::signature::Verifier as _;
+    let (header_b64, sig_b64) = jws
+        .split_once('.')
+        .ok_or_else(|| SignatifError::ArtifactFormat("JWS must be header.signature".into()))?;
+    let header_bytes = b64url_decode(header_b64)?;
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
+        .map_err(|e| SignatifError::ArtifactFormat(format!("JWS header: {e}")))?;
+    let alg = header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| SignatifError::ArtifactFormat("JWS header lacks alg".into()))?;
+    if alg != JwsAlg::Es256.as_str() {
+        return Err(SignatifError::ArtifactFormat(format!(
+            "unsupported JWS alg {alg}"
+        )));
+    }
+    let kid = header.get("kid").and_then(|v| v.as_str());
+    let input = detached_signing_input(JwsAlg::Es256, kid, external_payload)?;
+    let sig_bytes = b64url_decode(sig_b64)?;
+    let sig = p256::ecdsa::Signature::from_slice(&sig_bytes).map_err(|_| {
+        SignatifError::BadSignature {
+            context: "ES256 signature must be 64-byte r||s".into(),
+        }
+    })?;
+    public_key
+        .verify(input.as_bytes(), &sig)
+        .map_err(|_| SignatifError::BadSignature {
+            context: "JWS detached ES256 signature".into(),
+        })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -174,6 +234,24 @@ mod tests {
         parts[1] = "";
         let tampered = format!("{}.{}", parts[0], b64url_encode(&sig));
         assert!(verify_detached_ed25519(&tampered, &payload, &pk).is_err());
+    }
+
+    #[test]
+    fn es256_round_trip() {
+        use p256::elliptic_curve::Generate;
+        let sk = p256::ecdsa::SigningKey::generate();
+        let payload = crate::jcs::canonicalize(&serde_json::json!({"dose":500}))
+            .unwrap()
+            .into_bytes();
+        let jws = sign_detached_es256(&sk, Some("end-p256"), &payload).unwrap();
+        // P1363: 64-byte signature -> 86 base64url chars, no padding.
+        let sig_len = b64url_decode(jws.split('.').nth(1).unwrap()).unwrap().len();
+        assert_eq!(sig_len, 64, "ES256 must be r||s, not DER");
+        assert!(verify_detached_es256(&jws, &payload, sk.verifying_key()).is_ok());
+        assert!(verify_detached_es256(&jws, b"other", sk.verifying_key()).is_err());
+        // Wrong key rejected.
+        let other: p256::ecdsa::SigningKey = p256::ecdsa::SigningKey::generate();
+        assert!(verify_detached_es256(&jws, &payload, other.verifying_key()).is_err());
     }
 
     #[test]

--- a/crates/confium-signatif/src/lib.rs
+++ b/crates/confium-signatif/src/lib.rs
@@ -31,6 +31,7 @@ pub mod artifact;
 pub mod bundle;
 pub mod ceremony;
 pub mod conformance;
+pub mod cose;
 pub mod coverage;
 pub mod discovery;
 pub mod error;

--- a/crates/confium-signatif/src/passport.rs
+++ b/crates/confium-signatif/src/passport.rs
@@ -161,3 +161,79 @@ mod tests {
         assert!(c.verify_response(&payload, late).is_err());
     }
 }
+
+/// QR error-correction levels for the barcode delivery (§16
+/// `barcode-encoding`): the level is chosen for the expected scanning
+/// environment.
+#[cfg(feature = "barcode")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QrEcc {
+    /// Recover ~7% of codewords — clean environments, high density.
+    Low,
+    /// Recover ~15%.
+    Medium,
+    /// Recover ~25% — typical print-and-scan.
+    Quartile,
+    /// Recover ~30% — damaged or low-quality scans.
+    High,
+}
+
+#[cfg(feature = "barcode")]
+impl QrEcc {
+    fn to_qrcode(self) -> qrcode::EcLevel {
+        match self {
+            QrEcc::Low => qrcode::EcLevel::L,
+            QrEcc::Medium => qrcode::EcLevel::M,
+            QrEcc::Quartile => qrcode::EcLevel::Q,
+            QrEcc::High => qrcode::EcLevel::H,
+        }
+    }
+}
+
+#[cfg(feature = "barcode")]
+impl Passport {
+    /// The passport's QR barcode as an SVG document — a deterministic,
+    /// self-contained 2D delivery carrying the passport distribution
+    /// bytes, with error correction sufficient for the scanning
+    /// environment.
+    ///
+    /// # Errors
+    ///
+    /// Encoding errors if the payload exceeds the QR capacity or the
+    /// distribution bytes cannot be produced.
+    pub fn qr_svg(&self, ecc: QrEcc) -> SignatifResult<String> {
+        let bytes = self.distribution_bytes()?;
+        let code = qrcode::QrCode::with_error_correction_level(&bytes, ecc.to_qrcode())
+            .map_err(|e| SignatifError::Encoding(format!("qr encode: {e}")))?;
+        Ok(code.render::<char>().min_dimensions(200, 200).build())
+    }
+}
+
+#[cfg(all(test, feature = "barcode"))]
+mod qr_tests {
+    use super::Passport;
+    #[cfg(feature = "barcode")]
+    use super::QrEcc;
+    use chrono::Utc;
+
+    #[cfg(feature = "barcode")]
+    #[test]
+    fn passport_qr_encodes_with_error_correction() {
+        let p = Passport {
+            version: 1,
+            object_id: "cnml-cert-2026-00001".into(),
+            key_fingerprint: "ab00".into(),
+            scope_summary: "domain:metrology".into(),
+            valid_from: Utc::now(),
+            valid_until: Utc::now() + chrono::Duration::days(365),
+        };
+        // render::<char> yields a character grid, not SVG.
+        let svg = p.qr_svg(QrEcc::High).unwrap();
+        let lines: Vec<&str> = svg.lines().collect();
+        assert!(lines.len() >= 20, "qr grid too small: {}", lines.len());
+        // Deterministic: same passport, same bytes, same grid.
+        assert_eq!(p.qr_svg(QrEcc::High).unwrap(), svg);
+        // Higher ECC still encodes the same payload.
+        assert!(p.qr_svg(QrEcc::Low).is_ok());
+    }
+}

--- a/crates/confium-signatif/src/pipeline.rs
+++ b/crates/confium-signatif/src/pipeline.rs
@@ -211,8 +211,17 @@ impl<'a> Pipeline<'a> {
             }
         }
 
-        // Soft checks: accumulate into the coverage report.
+        // Soft checks: accumulate into the coverage report. Deprecated
+        // algorithms (§20) downgrade; retired already hard-failed in
+        // verify_self's registry check.
         let mut downgrades = self.transparency.downgrades.clone();
+        for block in &artifact.co_signatures {
+            if self.registry.algorithms.status(&block.algorithm)
+                == Some(crate::registry::Status::Deprecated)
+            {
+                downgrades.push(format!("deprecated_algorithm:{}", block.algorithm));
+            }
+        }
         if !self.transparency.artifact_included {
             downgrades.push("transparency_missing".into());
         }
@@ -469,6 +478,85 @@ mod tests {
         );
         let err = pipe.run(&broken, Utc::now()).unwrap_err();
         assert!(err.to_string().contains("signature_validity"));
+    }
+
+    #[test]
+    fn deprecated_algorithm_downgrades_and_caps_label() {
+        let f = build();
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        let mut agile = f.registry.clone();
+        agile
+            .algorithms
+            .set_status("Ed25519", crate::registry::Status::Deprecated)
+            .unwrap();
+        let accept_all =
+            AcceptancePolicy::accept(&["unverified", "basic", "verified", "attested", "certified"]);
+        // Full soft coverage: without deprecation this reaches
+        // "attested" (data + person? only data here -> "verified");
+        // with the deprecated algorithm the label stays "verified"
+        // but the downgrade is recorded. Person present would cap too.
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &agile,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs {
+                artifact_included: true,
+                time_anchored: true,
+                multi_log_quorum: false,
+                downgrades: vec![],
+            },
+            &accept_all,
+        );
+        let out = pipe.run(&f.artifact, Utc::now()).unwrap();
+        assert!(
+            out.report
+                .downgrades
+                .iter()
+                .any(|d| d == "deprecated_algorithm:Ed25519"),
+            "downgrades: {:?}",
+            out.report.downgrades
+        );
+
+        // With a person dimension the cap bites: attested -> verified.
+        let person = ed25519_dalek::SigningKey::from_bytes(&{
+            use rand_core::RngCore as _;
+            let mut seed = [0u8; 32];
+            rand_core::OsRng.fill_bytes(&mut seed);
+            seed
+        });
+        use ed25519_dalek::Signer as _;
+        let mut rich = f.artifact.clone();
+        let input = rich.cosign_input(&DimensionTag::person());
+        rich.co_signatures.push(crate::artifact::CoSignatureBlock {
+            dimension: DimensionTag::person(),
+            algorithm: "Ed25519".into(),
+            signer_cert_ref: "end".into(),
+            signer_pubkey: person.verifying_key().as_bytes().to_vec(),
+            chain_ref: "root".into(),
+            signature: person.sign(&input).to_bytes().to_vec(),
+            timestamp: Utc::now(),
+        });
+        let out = pipe.run(&rich, Utc::now()).unwrap();
+        assert_eq!(out.label.0, "verified", "deprecated caps attested");
+
+        // Retired hard-fails outright.
+        let mut retired = agile.clone();
+        retired
+            .algorithms
+            .set_status("Ed25519", crate::registry::Status::Retired)
+            .unwrap();
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &f.graph,
+            &retired,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs::default(),
+            &accept_all,
+        );
+        assert!(pipe.run(&f.artifact, Utc::now()).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Completes the remaining five SIGNATIF surfaces (TODOs 18-22 of the local plan):

- **JWS ES256** (section 8, Annex E): detached JWS with ECDSA P-256 in the P1363 64-byte r||s JWS encoding (not DER), completing /conf/format-jws algorithm coverage alongside EdDSA.
- **Passport QR barcodes** (section 16, feature barcode): four error-correction levels for the scanning environment, deterministic grids of the passport distribution bytes.
- **Algorithm agility enforcement** (section 20): deprecated algorithms push a deprecated_algorithm downgrade and cap the classification label; retired already hard-fail. Tests walk deprecated-cap and retired-reject.
- **COSE artifact encoding** (section 8, /conf/format-cose co-signature encoding obligation): TrustedArtifact to COSE_Sign1 chain and back, with header-carried dimension/cert/chain refs and self-description hash cross-checks (tamper test).
- **DPP composition** (Annex H): examples/dpp_composition.rs — EU DPP record as payload (pattern 1), data+person convergence, DPP registry as 2-of-3 multi-operator transparency (pattern 3), reaching the attested label. README documents annexes G and H.

68 tests in confium-signatif (plus the barcode feature set); clippy -D warnings clean with and without features; machete clean.
