### PR TITLE
feat(composite): SLH-DSA-SHA2-128s — stateless hash-based post-quantum (FIPS 205)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,8 +214,8 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --verbose
 
-      - name: Run tests (post-quantum feature)
-        run: cargo test -p confium-composite --features pq --verbose
+      - name: Run tests (post-quantum features)
+        run: cargo test -p confium-composite --features pq --verbose && cargo test -p confium-composite --features pq-slh --verbose
 
   # ============================================================================
   # C++ Binding Tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,6 +1035,7 @@ dependencies = [
  "confium-transparency",
  "ed25519-dalek",
  "hex",
+ "hybrid-array",
  "ml-dsa",
  "p256",
  "proptest",
@@ -1042,6 +1043,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "slh-dsa",
  "thiserror 1.0.69",
 ]
 
@@ -5301,6 +5303,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+]
+
+[[package]]
 name = "shake"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5422,6 +5434,25 @@ dependencies = [
  "libc",
  "log",
  "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "slh-dsa"
+version = "0.2.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "371c02fe34044d8866ddf7cb0e8204a87ef31a39f0408bed41c4253ea9dd61ed"
+dependencies = [
+ "const-oid 0.10.2",
+ "digest 0.11.3",
+ "hmac 0.13.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sha2 0.11.0",
+ "sha3",
+ "signature 3.0.0",
+ "typenum",
+ "zerocopy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,6 +192,7 @@ x509-cert = { version = "0.2", features = ["builder"] }
 der = "0.7"
 spki = "0.7"
 ml-dsa = { version = "0.1", features = ["rand_core"] }
+slh-dsa = { version = "=0.2.0-rc.5" }
 p256 = { version = "0.14", features = ["ecdsa", "pem", "arithmetic"] }
 p384 = "0.14"
 ecdsa = "0.17"

--- a/crates/confium-composite/Cargo.toml
+++ b/crates/confium-composite/Cargo.toml
@@ -20,6 +20,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 pq = ["dep:ml-dsa"]
+pq-slh = ["dep:slh-dsa", "dep:hybrid-array"]
 default = []
 # Wycheproof adversarial test vector integration. Off by default —
 # the vectors are 6 MB of JSON that callers download from
@@ -28,6 +29,8 @@ wycheproof = ["dep:hex"]
 
 [dependencies]
 ml-dsa = { workspace = true, optional = true }
+slh-dsa = { workspace = true, optional = true }
+hybrid-array = { version = "0.4", optional = true, features = ["extra-sizes"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/confium-composite/src/lib.rs
+++ b/crates/confium-composite/src/lib.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 
 pub mod cache;
 pub mod cose;
-#[cfg(feature = "pq")]
+#[cfg(any(feature = "pq", feature = "pq-slh"))]
 pub mod pq;
 
 #[cfg(test)]
@@ -284,9 +284,34 @@ pub fn mldsa65_verifier(
     crate::pq::verify_mldsa65(public_key, message, signature).map_err(|e| e.to_string())
 }
 
+/// The SLH-DSA-SHA2-128s algorithm identifier (FIPS 205, category 1).
+#[cfg(feature = "pq-slh")]
+pub const SLHDSA128S: &str = "SLH-DSA-128s";
+
+/// Verify a single SLH-DSA-SHA2-128s component (feature `pq-slh`).
+///
+/// # Errors
+///
+/// Human-readable errors for wrong algorithm, malformed inputs, or
+/// verification failure.
+#[cfg(feature = "pq-slh")]
+pub fn slhdsa128s_verifier(
+    algorithm: &str,
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
+) -> Result<(), String> {
+    if algorithm != SLHDSA128S {
+        return Err(format!("not SLH-DSA-128s: {algorithm}"));
+    }
+    crate::pq::verify_slhdsa128s(public_key, message, signature)
+}
+
 /// Transition composite verifier: Ed25519 + ECDSA-P256 + ML-DSA-65 in
 /// one dispatch closure — the classical+PQC AND-composition of
-/// SIGNATIF §9.4 during the migration's composite phase.
+/// SIGNATIF §9.4 during the migration's composite phase. With the
+/// `pq-slh` feature it additionally accepts SLH-DSA-128s, enabling
+/// PQC-only composites (two post-quantum algorithms AND-composed).
 ///
 /// # Errors
 ///
@@ -302,6 +327,8 @@ pub fn transition_verifier(
         ED25519 => ed25519_verifier(algorithm, public_key, message, signature),
         ECDSA_P256 => p256_verifier(algorithm, public_key, message, signature),
         MLDSA65 => mldsa65_verifier(algorithm, public_key, message, signature),
+        #[cfg(feature = "pq-slh")]
+        SLHDSA128S => slhdsa128s_verifier(algorithm, public_key, message, signature),
         other => Err(format!("unsupported algorithm: {other}")),
     }
 }

--- a/crates/confium-composite/src/pq.rs
+++ b/crates/confium-composite/src/pq.rs
@@ -16,190 +16,344 @@
 //! | ML-DSA-65     | 1952 B    | 3309 B    |
 //! | ML-DSA-87     | 2592 B    | 4627 B    |
 
-use ml_dsa::MlDsa65;
-use ml_dsa::Signature as MlDsa65Signature;
-use ml_dsa::SigningKey as MlDsa65SigningKey;
-use ml_dsa::VerifyingKey as MlDsa65VerifyingKey;
+#[cfg(feature = "pq")]
+mod mldsa {
+    use ml_dsa::MlDsa65;
+    use ml_dsa::Signature as MlDsa65Signature;
+    use ml_dsa::SigningKey as MlDsa65SigningKey;
+    use ml_dsa::VerifyingKey as MlDsa65VerifyingKey;
 
-/// Minimum security strength: signatures below ML-DSA-44 are not
-/// accepted (SIGNATIF `minimum-security-parameters`: 128 bits).
-pub const MIN_SECURITY_STRENGTH_BITS: u32 = 128;
+    /// Minimum security strength: signatures below ML-DSA-44 are not
+    /// accepted (SIGNATIF `minimum-security-parameters`: 128 bits).
+    pub const MIN_SECURITY_STRENGTH_BITS: u32 = 128;
 
-/// Errors from the post-quantum verifier.
-#[derive(Debug, thiserror::Error)]
-pub enum PqError {
-    /// The public key bytes are not a valid ML-DSA-65 key.
-    #[error("invalid ML-DSA-65 public key: expected 1952 bytes, got {0}")]
-    InvalidPublicKey(usize),
-    /// The signature bytes are not a valid ML-DSA-65 signature.
-    #[error("invalid ML-DSA-65 signature: expected 3309 bytes, got {0}")]
-    InvalidSignature(usize),
-    /// The signature did not verify.
-    #[error("ML-DSA-65 signature verification failed")]
-    VerificationFailed,
-}
-
-/// The ML-DSA-65 public-key size in bytes.
-pub const MLDSA65_PUBLIC_KEY_LEN: usize = 1952;
-/// The ML-DSA-65 signature size in bytes.
-pub const MLDSA65_SIGNATURE_LEN: usize = 3309;
-
-/// Verify an ML-DSA-65 signature.
-///
-/// `public_key` is the raw ML-DSA-65 public key (1952 bytes),
-/// `message` the signed content, `signature` the raw signature
-/// (3309 bytes).
-///
-/// # Errors
-///
-/// Returns a human-readable error for wrong sizes and verification
-/// failures. (The `String` error type predates the placeholder
-/// removal and is kept for 0.4.x semver compatibility; the structured
-/// variant is [`verify_mldsa65_detailed`].)
-pub fn verify_mldsa65(public_key: &[u8], message: &[u8], signature: &[u8]) -> Result<(), String> {
-    verify_mldsa65_detailed(public_key, message, signature).map_err(|e| e.to_string())
-}
-
-/// Verify an ML-DSA-65 signature with structured errors.
-///
-/// # Errors
-///
-/// Size errors for malformed inputs;
-/// [`PqError::VerificationFailed`] when the signature does not verify.
-pub fn verify_mldsa65_detailed(
-    public_key: &[u8],
-    message: &[u8],
-    signature: &[u8],
-) -> Result<(), PqError> {
-    if public_key.len() != MLDSA65_PUBLIC_KEY_LEN {
-        return Err(PqError::InvalidPublicKey(public_key.len()));
+    /// Errors from the post-quantum verifier.
+    #[derive(Debug, thiserror::Error)]
+    pub enum PqError {
+        /// The public key bytes are not a valid ML-DSA-65 key.
+        #[error("invalid ML-DSA-65 public key: expected 1952 bytes, got {0}")]
+        InvalidPublicKey(usize),
+        /// The signature bytes are not a valid ML-DSA-65 signature.
+        #[error("invalid ML-DSA-65 signature: expected 3309 bytes, got {0}")]
+        InvalidSignature(usize),
+        /// The signature did not verify.
+        #[error("ML-DSA-65 signature verification failed")]
+        VerificationFailed,
     }
-    if signature.len() != MLDSA65_SIGNATURE_LEN {
-        return Err(PqError::InvalidSignature(signature.len()));
-    }
-    let encoded_vk: ml_dsa::EncodedVerifyingKey<MlDsa65> = public_key
-        .try_into()
-        .map_err(|_| PqError::InvalidPublicKey(public_key.len()))?;
-    let vk = MlDsa65VerifyingKey::<MlDsa65>::decode(&encoded_vk);
-    let encoded_sig: ml_dsa::EncodedSignature<MlDsa65> = signature
-        .try_into()
-        .map_err(|_| PqError::InvalidSignature(signature.len()))?;
-    let sig = MlDsa65Signature::<MlDsa65>::decode(&encoded_sig)
-        .ok_or(PqError::InvalidSignature(signature.len()))?;
-    use ml_dsa::signature::Verifier as _;
-    vk.verify(message, &sig)
-        .map_err(|_| PqError::VerificationFailed)
-}
 
-/// An ML-DSA-65 keypair for signing and verification.
-#[derive(Debug, Clone)]
-pub struct MlDsa65Keypair {
-    /// The raw public key (1952 bytes).
-    pub public_key: Vec<u8>,
-    signing: MlDsa65SigningKey<MlDsa65>,
-}
+    /// The ML-DSA-65 public-key size in bytes.
+    pub const MLDSA65_PUBLIC_KEY_LEN: usize = 1952;
+    /// The ML-DSA-65 signature size in bytes.
+    pub const MLDSA65_SIGNATURE_LEN: usize = 3309;
 
-impl MlDsa65Keypair {
-    /// Generate a fresh keypair from the OS RNG.
+    /// Verify an ML-DSA-65 signature.
+    ///
+    /// `public_key` is the raw ML-DSA-65 public key (1952 bytes),
+    /// `message` the signed content, `signature` the raw signature
+    /// (3309 bytes).
     ///
     /// # Errors
     ///
-    /// Never fails in practice; the error type keeps the API future
-    /// proof.
-    pub fn generate() -> Self {
-        use rand_core::RngCore as _;
-        let mut seed = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut seed);
-        let signing = MlDsa65SigningKey::<MlDsa65>::from_seed(&seed.into());
-        use ml_dsa::signature::Keypair as _;
-        let public_key = signing.verifying_key().encode().to_vec();
-        Self {
-            public_key,
-            signing,
+    /// Returns a human-readable error for wrong sizes and verification
+    /// failures. (The `String` error type predates the placeholder
+    /// removal and is kept for 0.4.x semver compatibility; the structured
+    /// variant is [`verify_mldsa65_detailed`].)
+    pub fn verify_mldsa65(
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), String> {
+        verify_mldsa65_detailed(public_key, message, signature).map_err(|e| e.to_string())
+    }
+
+    /// Verify an ML-DSA-65 signature with structured errors.
+    ///
+    /// # Errors
+    ///
+    /// Size errors for malformed inputs;
+    /// [`PqError::VerificationFailed`] when the signature does not verify.
+    pub fn verify_mldsa65_detailed(
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), PqError> {
+        if public_key.len() != MLDSA65_PUBLIC_KEY_LEN {
+            return Err(PqError::InvalidPublicKey(public_key.len()));
+        }
+        if signature.len() != MLDSA65_SIGNATURE_LEN {
+            return Err(PqError::InvalidSignature(signature.len()));
+        }
+        let encoded_vk: ml_dsa::EncodedVerifyingKey<MlDsa65> = public_key
+            .try_into()
+            .map_err(|_| PqError::InvalidPublicKey(public_key.len()))?;
+        let vk = MlDsa65VerifyingKey::<MlDsa65>::decode(&encoded_vk);
+        let encoded_sig: ml_dsa::EncodedSignature<MlDsa65> = signature
+            .try_into()
+            .map_err(|_| PqError::InvalidSignature(signature.len()))?;
+        let sig = MlDsa65Signature::<MlDsa65>::decode(&encoded_sig)
+            .ok_or(PqError::InvalidSignature(signature.len()))?;
+        use ml_dsa::signature::Verifier as _;
+        vk.verify(message, &sig)
+            .map_err(|_| PqError::VerificationFailed)
+    }
+
+    /// An ML-DSA-65 keypair for signing and verification.
+    #[derive(Debug, Clone)]
+    pub struct MlDsa65Keypair {
+        /// The raw public key (1952 bytes).
+        pub public_key: Vec<u8>,
+        signing: MlDsa65SigningKey<MlDsa65>,
+    }
+
+    impl MlDsa65Keypair {
+        /// Generate a fresh keypair from the OS RNG.
+        ///
+        /// # Errors
+        ///
+        /// Never fails in practice; the error type keeps the API future
+        /// proof.
+        pub fn generate() -> Self {
+            use rand_core::RngCore as _;
+            let mut seed = [0u8; 32];
+            rand_core::OsRng.fill_bytes(&mut seed);
+            let signing = MlDsa65SigningKey::<MlDsa65>::from_seed(&seed.into());
+            use ml_dsa::signature::Keypair as _;
+            let public_key = signing.verifying_key().encode().to_vec();
+            Self {
+                public_key,
+                signing,
+            }
+        }
+
+        /// Sign a message.
+        pub fn sign(&self, message: &[u8]) -> Vec<u8> {
+            use ml_dsa::signature::Signer as _;
+            self.signing.sign(message).encode().to_vec()
+        }
+
+        /// Verify a signature produced by this keypair.
+        ///
+        /// # Errors
+        ///
+        /// Propagates verification errors.
+        pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), PqError> {
+            verify_mldsa65_detailed(&self.public_key, message, signature)
         }
     }
 
-    /// Sign a message.
-    pub fn sign(&self, message: &[u8]) -> Vec<u8> {
-        use ml_dsa::signature::Signer as _;
-        self.signing.sign(message).encode().to_vec()
+    #[cfg(all(test, feature = "pq"))]
+    mod tests {
+
+        use super::*;
+
+        #[test]
+        fn generate_sign_verify_round_trip() {
+            let kp = MlDsa65Keypair::generate();
+            assert_eq!(kp.public_key.len(), MLDSA65_PUBLIC_KEY_LEN);
+            let msg = b"confium signatif pq transition";
+            let sig = kp.sign(msg);
+            assert_eq!(sig.len(), MLDSA65_SIGNATURE_LEN);
+            assert!(kp.verify(msg, &sig).is_ok());
+            assert!(kp.verify(b"tampered", &sig).is_err());
+            let mut bad = sig.clone();
+            bad[10] ^= 1;
+            assert!(kp.verify(msg, &bad).is_err());
+        }
+
+        #[test]
+        fn size_errors_are_precise() {
+            let err = verify_mldsa65(&[0u8; 10], b"m", &[0u8; 3309]).unwrap_err();
+            assert!(err.to_string().contains("public key"));
+            let err = verify_mldsa65(&[0u8; 1952], b"m", &[0u8; 10]).unwrap_err();
+            assert!(err.to_string().contains("signature"));
+        }
+
+        #[test]
+        fn minimum_strength_documented() {
+            assert_eq!(MIN_SECURITY_STRENGTH_BITS, 128);
+        }
+
+        #[test]
+        fn transition_composite_and_semantics() {
+            use crate::{ComponentSignature, CompositeSignature, MLDSA65, transition_verifier};
+
+            let msg = b"supply-chain provenance record";
+            use rand_core::RngCore as _;
+            let mut ed_seed = [0u8; 32];
+            rand_core::OsRng.fill_bytes(&mut ed_seed);
+            let ed = ed25519_dalek::SigningKey::from_bytes(&ed_seed);
+            use ed25519_dalek::Signer as _;
+            let pq_kp = MlDsa65Keypair::generate();
+
+            let composite = CompositeSignature::new(vec![
+                ComponentSignature {
+                    algorithm: "Ed25519".into(),
+                    public_key: ed.verifying_key().as_bytes().to_vec(),
+                    signature: ed.sign(msg).to_bytes().to_vec(),
+                },
+                ComponentSignature {
+                    algorithm: MLDSA65.into(),
+                    public_key: pq_kp.public_key.clone(),
+                    signature: pq_kp.sign(msg),
+                },
+            ]);
+            let ok = composite
+                .verify(msg.as_slice(), transition_verifier)
+                .unwrap();
+            assert!(ok.all_verified, "components: {:?}", ok.per_component);
+
+            // AND semantics: breaking one component breaks the composite.
+            let mut broken = composite.clone();
+            broken.components[1].signature[100] ^= 1;
+            let bad = broken.verify(msg.as_slice(), transition_verifier).unwrap();
+            assert!(!bad.all_verified);
+        }
+    }
+}
+
+#[cfg(feature = "pq")]
+pub use mldsa::*;
+// ============================================================================
+// SLH-DSA (FIPS 205) — feature `pq-slh`
+// ============================================================================
+
+#[cfg(feature = "pq-slh")]
+mod slh {
+    use slh_dsa::Sha2_128s;
+    use slh_dsa::Signature as SlhSignature;
+    use slh_dsa::SigningKey as SlhSigningKey;
+    use slh_dsa::VerifyingKey as SlhVerifyingKey;
+
+    /// The SLH-DSA-SHA2-128s public-key size in bytes.
+    pub const SLHDSA128S_PUBLIC_KEY_LEN: usize = 32;
+    /// The SLH-DSA-SHA2-128s signature size in bytes.
+    pub const SLHDSA128S_SIGNATURE_LEN: usize = 7856;
+
+    /// Errors from the SLH-DSA verifier.
+    #[derive(Debug, thiserror::Error)]
+    pub enum SlhError {
+        /// Malformed public key.
+        #[error("invalid SLH-DSA-128s public key: expected 32 bytes, got {0}")]
+        InvalidPublicKey(usize),
+        /// Malformed signature.
+        #[error("invalid SLH-DSA-128s signature: expected 7856 bytes, got {0}")]
+        InvalidSignature(usize),
+        /// The signature did not verify.
+        #[error("SLH-DSA-128s signature verification failed")]
+        VerificationFailed,
     }
 
-    /// Verify a signature produced by this keypair.
+    /// Verify an SLH-DSA-SHA2-128s signature with structured errors.
     ///
     /// # Errors
     ///
-    /// Propagates verification errors.
-    pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), PqError> {
-        verify_mldsa65_detailed(&self.public_key, message, signature)
+    /// Size errors for malformed inputs; verification failure otherwise.
+    pub fn verify_slhdsa128s_detailed(
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), SlhError> {
+        if public_key.len() != SLHDSA128S_PUBLIC_KEY_LEN {
+            return Err(SlhError::InvalidPublicKey(public_key.len()));
+        }
+        if signature.len() != SLHDSA128S_SIGNATURE_LEN {
+            return Err(SlhError::InvalidSignature(signature.len()));
+        }
+        let bytes: [u8; SLHDSA128S_PUBLIC_KEY_LEN] = public_key.try_into().expect("32 bytes");
+        let vk: SlhVerifyingKey<Sha2_128s> =
+            SlhVerifyingKey::from(hybrid_array::Array::from(bytes));
+        let sig = SlhSignature::<Sha2_128s>::try_from(signature)
+            .map_err(|_| SlhError::InvalidSignature(signature.len()))?;
+        use slh_dsa::signature::Verifier as _;
+        vk.verify(message, &sig)
+            .map_err(|_| SlhError::VerificationFailed)
+    }
+
+    /// Verify an SLH-DSA-SHA2-128s signature (`String` errors, matching
+    /// the ML-DSA convention for 0.4.x).
+    ///
+    /// # Errors
+    ///
+    /// Human-readable errors for malformed inputs and failures.
+    pub fn verify_slhdsa128s(
+        public_key: &[u8],
+        message: &[u8],
+        signature: &[u8],
+    ) -> Result<(), String> {
+        verify_slhdsa128s_detailed(public_key, message, signature).map_err(|e| e.to_string())
+    }
+
+    /// An SLH-DSA-SHA2-128s keypair. Generated from three seed values
+    /// (sk_seed, sk_prf, pk_seed), so no RNG-version coupling leaks into
+    /// the public API.
+    #[derive(Debug, Clone)]
+    pub struct SlhDsa128sKeypair {
+        /// The raw public key (32 bytes).
+        pub public_key: Vec<u8>,
+        signing: SlhSigningKey<Sha2_128s>,
+    }
+
+    impl SlhDsa128sKeypair {
+        /// Generate a fresh keypair from the OS RNG.
+        pub fn generate() -> Self {
+            use rand_core::RngCore as _;
+            let mut sk_seed = [0u8; 16];
+            let mut sk_prf = [0u8; 16];
+            let mut pk_seed = [0u8; 16];
+            rand_core::OsRng.fill_bytes(&mut sk_seed);
+            rand_core::OsRng.fill_bytes(&mut sk_prf);
+            rand_core::OsRng.fill_bytes(&mut pk_seed);
+            let signing =
+                SlhSigningKey::<Sha2_128s>::slh_keygen_internal(&sk_seed, &sk_prf, &pk_seed);
+            use slh_dsa::signature::Keypair as _;
+            let public_key = signing.verifying_key().to_vec();
+            Self {
+                public_key,
+                signing,
+            }
+        }
+
+        /// Sign a message (deterministic).
+        pub fn sign(&self, message: &[u8]) -> Vec<u8> {
+            use slh_dsa::signature::Signer as _;
+            self.signing.sign(message).to_vec()
+        }
+
+        /// Verify a signature produced by this keypair.
+        ///
+        /// # Errors
+        ///
+        /// Propagates verification errors.
+        pub fn verify(&self, message: &[u8], signature: &[u8]) -> Result<(), SlhError> {
+            verify_slhdsa128s_detailed(&self.public_key, message, signature)
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn round_trip_and_tamper() {
+            let kp = SlhDsa128sKeypair::generate();
+            assert_eq!(kp.public_key.len(), SLHDSA128S_PUBLIC_KEY_LEN);
+            let msg = b"post-quantum stateless hash-based";
+            let sig = kp.sign(msg);
+            assert_eq!(sig.len(), SLHDSA128S_SIGNATURE_LEN);
+            assert!(kp.verify(msg, &sig).is_ok());
+            assert!(kp.verify(b"other", &sig).is_err());
+            let mut bad = sig.clone();
+            bad[100] ^= 1;
+            assert!(kp.verify(msg, &bad).is_err());
+        }
+
+        #[test]
+        fn size_errors() {
+            assert!(verify_slhdsa128s(&[0u8; 31], b"m", &[0u8; 7856]).is_err());
+            assert!(verify_slhdsa128s(&[0u8; 32], b"m", &[0u8; 10]).is_err());
+        }
     }
 }
 
-#[cfg(all(test, feature = "pq"))]
-mod tests {
-
-    use super::*;
-
-    #[test]
-    fn generate_sign_verify_round_trip() {
-        let kp = MlDsa65Keypair::generate();
-        assert_eq!(kp.public_key.len(), MLDSA65_PUBLIC_KEY_LEN);
-        let msg = b"confium signatif pq transition";
-        let sig = kp.sign(msg);
-        assert_eq!(sig.len(), MLDSA65_SIGNATURE_LEN);
-        assert!(kp.verify(msg, &sig).is_ok());
-        assert!(kp.verify(b"tampered", &sig).is_err());
-        let mut bad = sig.clone();
-        bad[10] ^= 1;
-        assert!(kp.verify(msg, &bad).is_err());
-    }
-
-    #[test]
-    fn size_errors_are_precise() {
-        let err = verify_mldsa65(&[0u8; 10], b"m", &[0u8; 3309]).unwrap_err();
-        assert!(err.to_string().contains("public key"));
-        let err = verify_mldsa65(&[0u8; 1952], b"m", &[0u8; 10]).unwrap_err();
-        assert!(err.to_string().contains("signature"));
-    }
-
-    #[test]
-    fn minimum_strength_documented() {
-        assert_eq!(MIN_SECURITY_STRENGTH_BITS, 128);
-    }
-
-    #[test]
-    fn transition_composite_and_semantics() {
-        use crate::{ComponentSignature, CompositeSignature, MLDSA65, transition_verifier};
-
-        let msg = b"supply-chain provenance record";
-        use rand_core::RngCore as _;
-        let mut ed_seed = [0u8; 32];
-        rand_core::OsRng.fill_bytes(&mut ed_seed);
-        let ed = ed25519_dalek::SigningKey::from_bytes(&ed_seed);
-        use ed25519_dalek::Signer as _;
-        let pq_kp = MlDsa65Keypair::generate();
-
-        let composite = CompositeSignature::new(vec![
-            ComponentSignature {
-                algorithm: "Ed25519".into(),
-                public_key: ed.verifying_key().as_bytes().to_vec(),
-                signature: ed.sign(msg).to_bytes().to_vec(),
-            },
-            ComponentSignature {
-                algorithm: MLDSA65.into(),
-                public_key: pq_kp.public_key.clone(),
-                signature: pq_kp.sign(msg),
-            },
-        ]);
-        let ok = composite
-            .verify(msg.as_slice(), transition_verifier)
-            .unwrap();
-        assert!(ok.all_verified, "components: {:?}", ok.per_component);
-
-        // AND semantics: breaking one component breaks the composite.
-        let mut broken = composite.clone();
-        broken.components[1].signature[100] ^= 1;
-        let bad = broken.verify(msg.as_slice(), transition_verifier).unwrap();
-        assert!(!bad.all_verified);
-    }
-}
+#[cfg(feature = "pq-slh")]
+pub use slh::*;


### PR DESCRIPTION
## What

SLH-DSA-SHA2-128s (FIPS 205, stateless hash-based) through the RustCrypto slh-dsa crate, feature pq-slh — the second post-quantum family, completing the algorithm registry coverage alongside ML-DSA-65:

- pq::verify_slhdsa128s(_detailed): size-validated verification (32-byte keys, 7856-byte signatures)
- pq::SlhDsa128sKeypair: seed-based keygen (sk_seed/sk_prf/pk_seed from the OS RNG — decoupled from RNG crate versions), deterministic signing
- lib: SLHDSA128S constant, slhdsa128s_verifier, and the transition verifier gains an SLH-DSA arm — enabling PQC-only composites (two post-quantum algorithms AND-composed, SIGNATIF 9.4)
- CI runs the pq-slh feature set in the matrix

The ML-DSA half is unchanged behind pq; the features are independent. The slh-dsa dependency is pinned to its 0.2.0-rc.5 release candidate (tracked in TODO.signatif/17 for the stable-release follow-up).