### PR TITLE
ci: run the signatif barcode feature set in the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
         run: cargo test --workspace --verbose
 
       - name: Run tests (post-quantum features)
-        run: cargo test -p confium-composite --features pq --verbose && cargo test -p confium-composite --features pq-slh --verbose
+        run: cargo test -p confium-composite --features pq --verbose && cargo test -p confium-composite --features pq-slh --verbose && cargo test -p confium-signatif --features barcode --verbose
 
   # ============================================================================
   # C++ Binding Tests


### PR DESCRIPTION
The passport QR-barcode feature is tested locally but was missed from the CI matrix when its PR was split; run it alongside the post-quantum feature sets.