### PR TITLE
docs(signatif): /conf/post-quantum now implemented — SLH-DSA-128s landed

### DIFF
--- a/crates/confium-signatif/src/conformance.rs
+++ b/crates/confium-signatif/src/conformance.rs
@@ -180,9 +180,9 @@ pub fn conformance_claims() -> Vec<ConformanceClaim> {
         },
         ConformanceClaim {
             class: "/conf/post-quantum",
-            description: "ML-DSA and classical/PQC composite algorithms",
-            status: S::Partial,
-            implemented_in: "confium_composite::pq (feature pq)",
+            description: "ML-DSA-65 and SLH-DSA-128s verification, classical+PQC and PQC-only composites",
+            status: S::Implemented,
+            implemented_in: "confium_composite::pq (features pq, pq-slh)",
         },
     ]
 }
@@ -238,6 +238,6 @@ mod tests {
     fn report_is_serializable() {
         let report = conformance_report();
         assert!(report["claims"].as_array().unwrap().len() == 24);
-        assert!(report["implemented"].as_u64().unwrap() >= 23);
+        assert_eq!(report["implemented"].as_u64().unwrap(), 24);
     }
 }


### PR DESCRIPTION
With SLH-DSA-128s shipped behind pq-slh (PR #233), the post-quantum conformance class flips from partial to implemented: ML-DSA-65 + SLH-DSA-128s verification, classical+PQC transition composites, and PQC-only composites. All 24 /conf classes now report implemented.