### PR TITLE
feat(signatif): scope conditions, time-key freshness, governance verification, adoption guide

### DIFF
--- a/crates/confium-deployment/src/signatif.rs
+++ b/crates/confium-deployment/src/signatif.rs
@@ -141,6 +141,27 @@ impl CrossRecognition {
         });
         Ok(jcs::canonicalize(&v)?.into_bytes())
     }
+
+    /// Verify the attesting root's signature over the credential
+    /// (§19 `mutual-recognition`).
+    ///
+    /// # Errors
+    ///
+    /// Signature errors when the attesting root's key does not verify.
+    pub fn verify(
+        &self,
+        from_root_key: &[u8],
+        verifier: &dyn SignatureVerifier,
+    ) -> SignatifResult<()> {
+        let msg = self.signing_bytes()?;
+        if verifier.verify(from_root_key, &msg, &self.signature) {
+            Ok(())
+        } else {
+            Err(SignatifError::BadSignature {
+                context: format!("cross-recognition {} -> {}", self.from_root, self.to_root),
+            })
+        }
+    }
 }
 
 /// The multi-log attestation policy.
@@ -478,6 +499,34 @@ mod tests {
         m.root_signature = sk.sign(&m.signing_bytes().unwrap()).to_bytes().to_vec();
         m.algorithms.push("ML-DSA-65".into());
         assert!(m.verify_signature(&Ed25519Verifier).is_err());
+    }
+
+    #[test]
+    fn cross_recognition_signature_verifies() {
+        use rand_core::RngCore;
+        let mut seed = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut seed);
+        let root_a = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let mut cred = CrossRecognition {
+            from_root: "root-a".into(),
+            to_root: "root-b".into(),
+            to_fingerprint: "fbb".into(),
+            recognized_scope: ScopeDimensions::unconstrained(),
+            signature: vec![],
+        };
+        cred.signature = root_a
+            .sign(&cred.signing_bytes().unwrap())
+            .to_bytes()
+            .to_vec();
+        assert!(
+            cred.verify(root_a.verifying_key().as_bytes(), &Ed25519Verifier)
+                .is_ok()
+        );
+        cred.to_root = "root-c".into();
+        assert!(
+            cred.verify(root_a.verifying_key().as_bytes(), &Ed25519Verifier)
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/confium-signatif/examples/cnml_profile.rs
+++ b/crates/confium-signatif/examples/cnml_profile.rs
@@ -139,6 +139,7 @@ fn main() {
             endpoint: "https://log.nmi.example".into(),
         }],
         bundle_signature: vec![],
+        update_log: None,
     };
     let bundle_msg = bundle.signing_bytes().unwrap();
     bundle.bundle_signature = root_sk.sign(&bundle_msg).to_bytes().to_vec();
@@ -202,6 +203,7 @@ fn main() {
             TransparencyInputs {
                 artifact_included: transparency,
                 time_anchored,
+                time_attested_at: time_anchored.then(Utc::now),
                 multi_log_quorum: false,
                 downgrades: vec![],
             },
@@ -227,6 +229,7 @@ fn main() {
         TransparencyInputs {
             artifact_included: true,
             time_anchored: true,
+            time_attested_at: None,
             multi_log_quorum: false,
             downgrades: vec![],
         },

--- a/crates/confium-signatif/examples/dpp_composition.rs
+++ b/crates/confium-signatif/examples/dpp_composition.rs
@@ -115,6 +115,7 @@ fn main() {
         }],
         transparency_logs: vec![],
         bundle_signature: vec![],
+        update_log: None,
     };
     let msg = bundle.signing_bytes().unwrap();
     bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
@@ -200,6 +201,7 @@ fn main() {
         TransparencyInputs {
             artifact_included: true,
             time_anchored: true,
+            time_attested_at: Some(Utc::now()),
             multi_log_quorum,
             downgrades: vec![],
         },

--- a/crates/confium-signatif/src/bundle.rs
+++ b/crates/confium-signatif/src/bundle.rs
@@ -51,6 +51,11 @@ pub struct TrustAnchorBundle {
     pub roots: Vec<AnchorRoot>,
     /// Recognized transparency logs and mirrors.
     pub transparency_logs: Vec<AnchorLog>,
+    /// The transparency-log reference recording this bundle update
+    /// (§7: bundle updates shall be recorded in a transparency log).
+    /// Signed as part of the bundle body.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update_log: Option<crate::discovery::LogRef>,
     /// Threshold signature of the issuing root over the canonical
     /// bundle body (all fields except this signature).
     pub bundle_signature: Vec<u8>,
@@ -175,6 +180,7 @@ mod tests {
             }],
             transparency_logs: Vec::new(),
             bundle_signature: Vec::new(),
+            update_log: None,
         };
         bundle.bundle_signature = sk
             .sign(&bundle.signing_bytes().unwrap())
@@ -182,6 +188,37 @@ mod tests {
             .to_vec();
         assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_ok());
         bundle.bundle_signature[3] ^= 1;
+        assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_err());
+    }
+
+    #[test]
+    fn update_log_reference_is_signed_content() {
+        let sk = generate_key();
+        let mut bundle = TrustAnchorBundle {
+            bundle_version: "2026.09".into(),
+            valid_from: Utc::now() - chrono::Duration::hours(1),
+            valid_until: Utc::now() + chrono::Duration::days(30),
+            roots: vec![AnchorRoot {
+                name: "root".into(),
+                aggregate_key: sk.verifying_key().as_bytes().to_vec(),
+                fingerprint: "00".into(),
+                quorum: None,
+            }],
+            transparency_logs: Vec::new(),
+            update_log: Some(crate::discovery::LogRef {
+                log: "nmi-log".into(),
+                sequence: 4242,
+            }),
+            bundle_signature: Vec::new(),
+        };
+        bundle.bundle_signature = sk
+            .sign(&bundle.signing_bytes().unwrap())
+            .to_bytes()
+            .to_vec();
+        assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_ok());
+        // Flipping the log reference breaks the signature: it is
+        // signed content.
+        bundle.update_log.as_mut().unwrap().sequence = 4243;
         assert!(bundle.verify(Utc::now(), &Ed25519Verifier).is_err());
     }
 
@@ -194,6 +231,7 @@ mod tests {
             roots: vec![],
             transparency_logs: vec![],
             bundle_signature: vec![],
+            update_log: None,
         };
         assert!(matches!(
             b.verify(Utc::now(), &AcceptAllVerifier),

--- a/crates/confium-signatif/src/conditions.rs
+++ b/crates/confium-signatif/src/conditions.rs
@@ -1,0 +1,261 @@
+//! Executable scope conditions (SIGNATIF §11 `scope-conditions`).
+//!
+//! A scope may carry **scope conditions** — executable predicates
+//! evaluated at verification time against the content and context of
+//! the artifact. An artifact signed by a key whose scope conditions
+//! are not met fails verification, *regardless of cryptographic
+//! signature validity* — this is one of the pipeline's hard checks.
+//!
+//! The expression language is a deterministic subset of JSON Logic
+//! (the Annex E reference choice): `var` paths over the evaluation
+//! context, numeric/string comparisons, and boolean combinators.
+//! Determinism (§11 `condition-determinism`): the evaluation context
+//! is fully determined by the artifact and its chain — payload,
+//! artifact id, signer reference, dimension, and the signer's
+//! attestation timestamp. No wall-clock, no external state.
+
+use serde_json::Value;
+
+use crate::error::{SignatifError, SignatifResult};
+
+/// The evaluation context for scope conditions: everything the
+/// artifact and its chain determine, and nothing else.
+#[derive(Debug, Clone)]
+pub struct ConditionContext {
+    /// The JSON evaluation root: `payload`, `artifact_id`,
+    /// `signer_cert_ref`, `dimension`, and `attested_at` (RFC 3339).
+    pub root: Value,
+}
+
+impl ConditionContext {
+    /// Build the context from an artifact's facts.
+    ///
+    /// # Errors
+    ///
+    /// Never fails; kept symmetrical with the other constructors.
+    pub fn new(
+        payload: &Value,
+        artifact_id: &str,
+        signer_cert_ref: &str,
+        dimension: &str,
+        attested_at: &str,
+    ) -> Self {
+        Self {
+            root: serde_json::json!({
+                "payload": payload,
+                "artifact_id": artifact_id,
+                "signer_cert_ref": signer_cert_ref,
+                "dimension": dimension,
+                "attested_at": attested_at,
+            }),
+        }
+    }
+}
+
+/// Evaluate one condition expression against a context.
+///
+/// Supported operators (JSON Logic subset):
+/// `{">=": [a, b]}`, `>`, `<=`, `<`, `{"==": [a, b]}`, `!=`,
+/// `{"and": [...]}`, `{"or": [...]}`, `{"!": expr}`, `{"!!": expr}`,
+/// `{"var": "dotted.path"}`. Numbers compare numerically; mixed
+/// number/string compares equal only on identical string forms;
+/// anything else compares by `Value` equality.
+///
+/// # Errors
+///
+/// Encoding errors for malformed expressions (unknown operator, bad
+/// arity, non-string `var` path). Malformed expressions are errors,
+/// not `false` — a condition that cannot be evaluated fails closed.
+pub fn evaluate_condition(expr: &Value, ctx: &ConditionContext) -> SignatifResult<bool> {
+    let obj = expr
+        .as_object()
+        .ok_or_else(|| SignatifError::Encoding("condition must be an object".into()))?;
+    let (op, args) = obj
+        .iter()
+        .next()
+        .ok_or_else(|| SignatifError::Encoding("condition object is empty".into()))?;
+    match op.as_str() {
+        "var" => Err(SignatifError::Encoding(
+            "var is only valid as an operand, not a top-level condition".into(),
+        )),
+        "!" => Ok(!evaluate_condition(args, ctx)?),
+        "!!" => evaluate_condition(args, ctx),
+        "and" => {
+            let list = args
+                .as_array()
+                .ok_or_else(|| SignatifError::Encoding("and expects an array".into()))?;
+            let mut ok = true;
+            for sub in list {
+                ok = ok && evaluate_condition(sub, ctx)?;
+            }
+            Ok(ok)
+        }
+        "or" => {
+            let list = args
+                .as_array()
+                .ok_or_else(|| SignatifError::Encoding("or expects an array".into()))?;
+            let mut ok = false;
+            for sub in list {
+                ok = ok || evaluate_condition(sub, ctx)?;
+            }
+            Ok(ok)
+        }
+        ">=" | ">" | "<=" | "<" | "==" | "!=" => {
+            let list = args
+                .as_array()
+                .ok_or_else(|| SignatifError::Encoding(format!("{op} expects an array")))?;
+            if list.len() != 2 {
+                return Err(SignatifError::Encoding(format!(
+                    "{op} expects two operands"
+                )));
+            }
+            let a = resolve_operand(&list[0], ctx)?;
+            let b = resolve_operand(&list[1], ctx)?;
+            let cmp = compare(&a, &b);
+            Ok(match op.as_str() {
+                ">=" => cmp != std::cmp::Ordering::Less,
+                ">" => cmp == std::cmp::Ordering::Greater,
+                "<=" => cmp != std::cmp::Ordering::Greater,
+                "<" => cmp == std::cmp::Ordering::Less,
+                "==" => cmp == std::cmp::Ordering::Equal,
+                _ => cmp != std::cmp::Ordering::Equal,
+            })
+        }
+        other => Err(SignatifError::Encoding(format!(
+            "unsupported condition operator {other}"
+        ))),
+    }
+}
+
+/// Evaluate every condition; all must hold.
+///
+/// # Errors
+///
+/// Propagates the first malformed or failing condition's error. A
+/// failing condition is an [`SignatifError::HardCheck`].
+pub fn evaluate_all(conditions: &[Value], ctx: &ConditionContext) -> SignatifResult<()> {
+    for (i, expr) in conditions.iter().enumerate() {
+        let ok = evaluate_condition(expr, ctx)?;
+        if !ok {
+            return Err(SignatifError::HardCheck(format!(
+                "scope_condition[{i}] not satisfied"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_operand(v: &Value, ctx: &ConditionContext) -> SignatifResult<Value> {
+    match v {
+        Value::Object(obj) => {
+            if let Some(Value::String(path)) = obj.get("var") {
+                let mut current = &ctx.root;
+                for segment in path.split('.') {
+                    current = current.get(segment).ok_or_else(|| {
+                        SignatifError::Encoding(format!("var path `{path}` not found"))
+                    })?;
+                }
+                Ok(current.clone())
+            } else {
+                // Nested expression.
+                Ok(Value::Bool(evaluate_condition(v, ctx)?))
+            }
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+fn compare(a: &Value, b: &Value) -> std::cmp::Ordering {
+    if let (Some(x), Some(y)) = (a.as_f64(), b.as_f64()) {
+        return x.partial_cmp(&y).unwrap_or(std::cmp::Ordering::Equal);
+    }
+    if let (Some(x), Some(y)) = (a.as_str(), b.as_str()) {
+        return x.cmp(y);
+    }
+    if a == b {
+        std::cmp::Ordering::Equal
+    } else {
+        // Incomparable, unequal values sort greater to make == false
+        // and != true deterministically.
+        std::cmp::Ordering::Greater
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx() -> ConditionContext {
+        ConditionContext::new(
+            &json!({"quantity": 50000, "product": "vaccine-batch-A", "batch": {"id": "LOT-1"}}),
+            "art-1",
+            "end-1",
+            "data",
+            "2026-08-18T00:00:00Z",
+        )
+    }
+
+    #[test]
+    fn value_within_range() {
+        let c = evaluate_condition(&json!({">=": [{"var": "payload.quantity"}, 10000]}), &ctx())
+            .unwrap();
+        assert!(c);
+        let c = evaluate_condition(&json!({"<": [{"var": "payload.quantity"}, 10000]}), &ctx())
+            .unwrap();
+        assert!(!c);
+    }
+
+    #[test]
+    fn nested_paths_and_boolean_combinators() {
+        let c = evaluate_condition(
+            &json!({"and": [
+                {"==": [{"var": "payload.product"}, "vaccine-batch-A"]},
+                {"or": [
+                    {">=": [{"var": "payload.quantity"}, 10000]},
+                    {"==": [{"var": "payload.batch.id"}, "LOT-9"]}
+                ]},
+            ]}),
+            &ctx(),
+        )
+        .unwrap();
+        assert!(c);
+    }
+
+    #[test]
+    fn signer_and_dimension_visible() {
+        let c = evaluate_condition(
+            &json!({"==": [{"var": "signer_cert_ref"}, "end-1"]}),
+            &ctx(),
+        )
+        .unwrap();
+        assert!(c);
+        let c = evaluate_condition(&json!({"==": [{"var": "dimension"}, "data"]}), &ctx()).unwrap();
+        assert!(c);
+    }
+
+    #[test]
+    fn failing_condition_hard_fails() {
+        let expr = serde_json::json!({ ">=": [ {"var": "payload.quantity"}, 999999 ] });
+        let err = evaluate_all(&[expr], &ctx()).unwrap_err();
+        assert!(err.to_string().contains("scope_condition[0]"));
+    }
+
+    #[test]
+    fn malformed_expressions_fail_closed() {
+        assert!(evaluate_condition(&json!("nope"), &ctx()).is_err());
+        assert!(evaluate_condition(&json!({"+": [1, 1]}), &ctx()).is_err());
+        assert!(
+            evaluate_condition(&json!({">=": [{"var": "payload.missing"}, 1]}), &ctx()).is_err()
+        );
+    }
+
+    #[test]
+    fn deterministic_same_context_same_result() {
+        let expr = json!({">=": [{"var": "payload.quantity"}, 1]});
+        assert_eq!(
+            evaluate_condition(&expr, &ctx()).unwrap(),
+            evaluate_condition(&expr, &ctx()).unwrap()
+        );
+    }
+}

--- a/crates/confium-signatif/src/graph.rs
+++ b/crates/confium-signatif/src/graph.rs
@@ -414,6 +414,7 @@ mod tests {
             }],
             transparency_logs: Vec::new(),
             bundle_signature: Vec::new(),
+            update_log: None,
         }
     }
 

--- a/crates/confium-signatif/src/lib.rs
+++ b/crates/confium-signatif/src/lib.rs
@@ -30,6 +30,7 @@
 pub mod artifact;
 pub mod bundle;
 pub mod ceremony;
+pub mod conditions;
 pub mod conformance;
 pub mod cose;
 pub mod coverage;

--- a/crates/confium-signatif/src/pipeline.rs
+++ b/crates/confium-signatif/src/pipeline.rs
@@ -32,6 +32,10 @@ pub struct TransparencyInputs {
     pub multi_log_quorum: bool,
     /// Whether a time-anchor attestation was verified (see [`crate::time`]).
     pub time_anchored: bool,
+    /// The externally-attested time from a verified [`crate::time::
+    /// TimeAttestation`] — the freshness source preferred over the
+    /// signer's self-asserted block timestamps (§8.8).
+    pub time_attested_at: Option<DateTime<Utc>>,
     /// Downgrade reasons the caller's soft checks produced (e.g.
     /// "transparency_missing", "time_anchor_absent").
     pub downgrades: Vec<String>,
@@ -192,7 +196,25 @@ impl<'a> Pipeline<'a> {
             }
         }
 
-        // Hard 4: revocation of every authority on every valid path.
+        // Hard 4: scope conditions — every signer node's executable
+        // conditions are evaluated against the artifact and its chain
+        // (§11): failing conditions hard-fail regardless of signature
+        // validity.
+        for block in &artifact.co_signatures {
+            if let Some(node) = self.graph.node(&block.signer_cert_ref) {
+                let ctx = crate::conditions::ConditionContext::new(
+                    &artifact.payload,
+                    &artifact.artifact_id,
+                    &block.signer_cert_ref,
+                    block.dimension.as_str(),
+                    &block.timestamp.to_rfc3339(),
+                );
+                crate::conditions::evaluate_all(&node.scope.conditions, &ctx)
+                    .map_err(|e| SignatifError::HardCheck(format!("scope_conditions: {e}")))?;
+            }
+        }
+
+        // Hard 5: revocation of every authority on every valid path.
         for block in &artifact.co_signatures {
             let status = self
                 .revocation
@@ -231,14 +253,18 @@ impl<'a> Pipeline<'a> {
         if self.revocation.max_crl_age(now) > DEFAULT_GRACE_PERIOD {
             downgrades.push("crl_stale".into());
         }
-        // Freshness: newest time-dimension attestation inside window?
-        if let Some(newest) = artifact
-            .co_signatures
-            .iter()
-            .filter(|b| b.dimension.as_str() == crate::registry::DimensionTag::TIME)
-            .map(|b| b.timestamp)
-            .max()
-        {
+        // Freshness: the externally-attested time when a verified time
+        // authority attestation exists; otherwise the newest
+        // time-dimension block timestamp.
+        let freshness_source = self.transparency.time_attested_at.or_else(|| {
+            artifact
+                .co_signatures
+                .iter()
+                .filter(|b| b.dimension.as_str() == crate::registry::DimensionTag::TIME)
+                .map(|b| b.timestamp)
+                .max()
+        });
+        if let Some(newest) = freshness_source {
             let age = now.signed_duration_since(newest);
             if age > self.freshness.window + self.freshness.grace {
                 return Err(SignatifError::HardCheck(
@@ -325,6 +351,7 @@ mod tests {
         registry: Registry,
         artifact: TrustedArtifact,
         end_sk: SigningKey,
+        root_sk: SigningKey,
     }
 
     fn build() -> Fixture {
@@ -371,6 +398,7 @@ mod tests {
             }],
             transparency_logs: vec![],
             bundle_signature: vec![],
+            update_log: None,
         };
         // Bundle signature unused by pipeline? It verifies signatures —
         // sign the bundle with the root key so hard check 1 passes.
@@ -405,6 +433,7 @@ mod tests {
             registry,
             artifact,
             end_sk,
+            root_sk,
         }
     }
 
@@ -453,6 +482,7 @@ mod tests {
             TransparencyInputs {
                 artifact_included: transparency,
                 time_anchored: time,
+                time_attested_at: None,
                 multi_log_quorum: false,
                 downgrades: vec![],
             },
@@ -481,6 +511,51 @@ mod tests {
     }
 
     #[test]
+    fn scope_conditions_hard_fail_when_unmet() {
+        let f = build();
+        static NO_REVOCATIONS: NoRevocations = NoRevocations;
+        let accept_all = AcceptancePolicy::accept(&["verified"]);
+        // The end node carries an executable condition on the payload.
+        // The conditions are part of the node binding, so the root's
+        // delegation credential must cover them (four-layer scope
+        // enforcement, layers 1-2).
+        let mut end = f.graph.node("end").unwrap().clone();
+        end.scope.conditions = vec![serde_json::json!({
+            ">=": [ {"var": "payload.v"}, 5 ]
+        })];
+        let root_node = f.graph.node("root").unwrap().clone();
+        use ed25519_dalek::Signer as _;
+        let mut graph = TrustGraph::new();
+        graph.add_node(root_node);
+        graph.add_node(end.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root".into(),
+                child: "end".into(),
+                signature: f
+                    .root_sk
+                    .sign(&end.binding_bytes().unwrap())
+                    .to_bytes()
+                    .to_vec(),
+            })
+            .unwrap();
+        let pipe = Pipeline::new(
+            &f.bundle,
+            &graph,
+            &f.registry,
+            &Ed25519Verifier,
+            &NO_REVOCATIONS,
+            TransparencyInputs::default(),
+            &accept_all,
+        );
+        // payload.v == 1 -> condition unmet -> hard failure even though
+        // every signature and the chain verify. The positive path is
+        // exercised in the conditions module tests.
+        let err = pipe.run(&f.artifact, Utc::now()).unwrap_err();
+        assert!(err.to_string().contains("scope_conditions"), "got {err}");
+    }
+
+    #[test]
     fn deprecated_algorithm_downgrades_and_caps_label() {
         let f = build();
         static NO_REVOCATIONS: NoRevocations = NoRevocations;
@@ -504,6 +579,7 @@ mod tests {
             TransparencyInputs {
                 artifact_included: true,
                 time_anchored: true,
+                time_attested_at: None,
                 multi_log_quorum: false,
                 downgrades: vec![],
             },
@@ -573,6 +649,7 @@ mod tests {
             TransparencyInputs {
                 artifact_included: true,
                 time_anchored: true,
+                time_attested_at: None,
                 multi_log_quorum: false,
                 downgrades: vec![],
             },

--- a/crates/confium-signatif/src/scope.rs
+++ b/crates/confium-signatif/src/scope.rs
@@ -67,6 +67,10 @@ pub struct ScopeDimensions {
     /// Scheme-registered extension dimensions.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub extra: BTreeMap<String, ScopeValue>,
+    /// Executable scope conditions (JSON Logic subset) evaluated at
+    /// verification time against the artifact and its chain (§11).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditions: Vec<serde_json::Value>,
 }
 
 impl ScopeDimensions {

--- a/crates/confium-signatif/tests/ats.rs
+++ b/crates/confium-signatif/tests/ats.rs
@@ -102,6 +102,7 @@ fn build() -> Fixture {
         }],
         transparency_logs: vec![],
         bundle_signature: vec![],
+        update_log: None,
     };
     let msg = bundle.signing_bytes().unwrap();
     bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
@@ -151,6 +152,7 @@ fn ats_verifier_classes() {
         TransparencyInputs {
             artifact_included: true,
             time_anchored: true,
+            time_attested_at: None,
             multi_log_quorum: false,
             downgrades: vec![],
         },

--- a/docs/signatif/adoption-guide.mdx
+++ b/docs/signatif/adoption-guide.mdx
@@ -1,0 +1,140 @@
+---
+title: "Adoption guide: SIGNATIF with Confium"
+description: How a domain scheme such as CNML adopts the SIGNATIF framework by building on Confium — registries, trust topology, artifact issuance, verification pipeline, delivery, and conformance claims.
+audience: security-engineer, devsecops
+---
+
+# Adoption guide: SIGNATIF with Confium
+
+SIGNATIF is the framework; Confium is the implementation tool; your
+domain scheme (CNML, DPP, supply chain, …) is the adopting technology.
+This guide walks a scheme from zero to a conformance claim. Runnable
+companions: `examples/cnml_profile.rs` and `examples/dpp_composition.rs`
+in the `confium-signatif` crate.
+
+```sh
+cargo add confium-signatif
+```
+
+## 1. Declare your scheme profile
+
+A scheme customizes the framework through the registries — never by
+forking technology. Start from the initial values and register your
+extension dimensions:
+
+```rust
+use confium_signatif::registry::Registry;
+
+let mut registry = Registry::with_initial_values();
+registry.register_dimension(
+    "cnml:instrument-class",
+    "CNML instrument classification (mass, volume, length)",
+);
+```
+
+Algorithm lifecycle is registry-driven: `Active` signs and verifies,
+`Deprecated` downgrades the classification label during the migration
+window, `Retired` hard-fails.
+
+## 2. Build the trust topology
+
+Authorities form a directed acyclic graph: a root trust authority
+(declare its quorum), delegated authorities with narrowed scopes, end
+certificates for signing keys. Every delegation is the parent's
+signature over the child's binding — key, quorum, scope, and scope
+conditions — so scope is cryptographically enforced at every link.
+
+```rust
+use confium_signatif::graph::{AuthorityKind, AuthorityNode, TrustGraph};
+```
+
+Declare the whole deployment in a root-signed
+`confium_deployment::signatif::SignatifManifest` — topology profile
+(hierarchical, federated, cross-recognized, mesh), authorities,
+algorithms, migration phase, transparency logs, and the M-of-K
+multi-log policy. Manifest validation rejects cycles, scope widening,
+and inconsistent quorums.
+
+For multi-organization authorities, use
+`confium_signatif::fta::FederatedTrustAuthority` — M-of-K
+organizations share one aggregate key, members may themselves be
+threshold authorities (nested threshold), and join/leave re-shares
+preserve the aggregate key.
+
+## 3. Issue trusted artifacts
+
+An artifact is the convergence point of independent attestations.
+Every co-signature — regardless of trust dimension, organization, or
+root — signs the same canonical payload hash (RFC 8785 JCS), bound to
+the artifact id so blocks cannot be replayed across artifacts.
+
+```rust
+use confium_signatif::artifact::{ArtifactVersion, TrustedArtifact};
+use confium_signatif::registry::DimensionTag;
+
+let mut artifact = TrustedArtifact::new(
+    ArtifactVersion { major: 1, minor: 0 },
+    "cnml-cert-2026-00001",
+    payload,            // your domain schema's JSON
+    Some("https://cnml.example/schema/certificate.json".into()),
+)?;
+artifact.sign(DimensionTag::data(), "Ed25519", /* … */)?;
+artifact.sign(DimensionTag::person(), "Ed25519", /* … */)?; // living artifact
+```
+
+Artifacts are living: dimensions accumulate over time, each attesting
+the *original* canonical bytes. Scope conditions (a deterministic
+JSON Logic subset) ride in the authority's scope and are evaluated at
+verification time — an artifact outside its signer's conditions fails
+hard even with valid signatures.
+
+Envelope formats: JWS detached-content (`jws`), COSE chains (`cose`),
+and X.509 certificates carrying scopes as extensions (`x509`).
+
+## 4. Verify through the pipeline
+
+The verifier holds a signed trust anchor bundle (versioned, validity
+bounded, its updates log-recorded) and runs
+`confium_signatif::pipeline::Pipeline`:
+
+- **Hard checks** short-circuit to the rejected label: format
+  validity and version, every co-signature, chain path-finding with
+  per-link signature and scope-narrowing, scope conditions,
+  revocation.
+- **Soft checks** accumulate into the objective **coverage report**:
+  transparency inclusion, external time anchor, verified dimensions,
+  independent-root count, multi-log quorum, downgrades (including
+  deprecated algorithms).
+- The scheme's **classification policy** (pure function) maps the
+  report to a graduated label; the verifier's **acceptance policy**
+  turns labels into accept/reject decisions.
+
+Revocation uses signed CRLs plus artifact-to-authority-state hash
+bindings; propagation marks every transitively bound artifact
+(reversibly), with forward and reverse queries. Offline verification
+runs on cached CRLs within the grace period.
+
+## 5. Deliver and discover
+
+Machine-readable passports (with QR barcodes under the `barcode`
+feature) carry certificate summaries; challenge-response binds a
+256-bit nonce and freshness window for device signers; chains travel
+embedded, by transparency-log reference, or hybrid — all offline
+verifiable.
+
+## 6. Ride the post-quantum migration
+
+Declare your phase (`classical_only`, `composite`, `post_quantum_only`)
+in the manifest. During the composite phase, `confium-composite`'s
+`transition_verifier` accepts Ed25519 + ECDSA-P256 + ML-DSA-65 +
+SLH-DSA-128s (features `pq`, `pq-slh`) in AND-composition — new
+artifacts carry classical+PQC composites while classical-only
+artifacts keep verifying.
+
+## 7. Claim conformance
+
+`confium_signatif::conformance::conformance_report()` emits the
+machine-readable claim list — all 24 `/conf` classes implemented by
+Confium — witnessed by the abstract test suite
+(`tests/ats.rs`). Your scheme claims conformance by pointing at that
+report plus your own profile tests.


### PR DESCRIPTION
## What

Closes the final normative gaps and ships the adoption runbook:

- **Executable scope conditions** (section 11 + 14 hard checks): deterministic JSON Logic subset over a context built only from the artifact and its chain; conditions travel in the authority scope (X.509 extension, delegation binding) and are evaluated as a pipeline hard check — unmet conditions fail verification regardless of signature validity; malformed expressions fail closed.
- **Time-key freshness** (8.8 + 14): the verified time authority's attested time is the pipeline's freshness source, replacing signer self-asserted timestamps.
- **Governance verification** (7 + 19): anchor bundles carry a signed transparency-log update reference (flipping the sequence breaks the bundle signature); CrossRecognition::verify checks the attesting root's signature.
- **Adoption guide** (docs/signatif/adoption-guide.mdx): the seven-step runbook for a domain scheme (CNML) — registries, topology, issuance, pipeline, delivery, PQC migration, conformance claims.

75 tests in confium-signatif + 22 in confium-deployment; clippy -D warnings clean; both examples run green.
