### PR TITLE
feat(signatif): HTTP, CLI, and Python verification surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,12 @@ jobs:
       - name: Check for unused dependencies
         run: cargo machete
 
+      - name: Check the standalone Python-binding crate
+        # confium-python is a standalone workspace (own Cargo.lock) and
+        # is not a member of the root workspace, so --workspace checks
+        # skip it. Check it explicitly so it cannot rot silently.
+        run: cargo check --manifest-path crates/confium-python/Cargo.toml --all-targets
+
   # ============================================================================
   # Publish Check (Dry Run)
   # ============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           tool: cargo-semver-checks
 
       - name: Check semver compatibility
-        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-signatif --exclude confium-store-tpm --exclude confium-store-pkcs11 --exclude confium-tc-ml-kem --exclude confium-tc-fhe-bfv --exclude confium-tc-bls --exclude confium-tc-frost-ml-dsa-65 --exclude confium-verify --exclude confium-store-openpgp-card --exclude confium-tc
+        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-verify-server --exclude confium-signatif --exclude confium-store-tpm --exclude confium-store-pkcs11 --exclude confium-tc-ml-kem --exclude confium-tc-fhe-bfv --exclude confium-tc-bls --exclude confium-tc-frost-ml-dsa-65 --exclude confium-verify --exclude confium-store-openpgp-card --exclude confium-tc
 
   # ============================================================================
   # Summary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,12 +1010,14 @@ dependencies = [
 name = "confium-cli"
 version = "0.4.7"
 dependencies = [
+ "chrono",
  "clap",
  "clap_complete",
  "confium-composite",
  "confium-pki",
  "confium-privacy",
  "confium-registry",
+ "confium-signatif",
  "confium-tc-cmp20",
  "confium-tc-gg18",
  "confium-transparency",
@@ -1808,10 +1810,14 @@ name = "confium-verify-server"
 version = "0.4.7"
 dependencies = [
  "axum",
+ "chrono",
  "clap",
  "confium-composite",
+ "confium-signatif",
  "confium-transparency",
+ "ed25519-dalek",
  "hex",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/confium-cli/Cargo.toml
+++ b/crates/confium-cli/Cargo.toml
@@ -30,6 +30,8 @@ confium-tc-gg18 = { workspace = true }
 confium-transparency = { workspace = true }
 confium-pki = { workspace = true }
 confium-composite = { workspace = true }
+confium-signatif = { workspace = true }
+chrono = { workspace = true }
 confium-privacy = { workspace = true }
 ed25519-dalek = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa"] }

--- a/crates/confium-cli/src/cli.rs
+++ b/crates/confium-cli/src/cli.rs
@@ -349,6 +349,8 @@ pub enum VerifyCommand {
     Inclusion(VerifyInclusionArgs),
     /// Verify a certificate chain (leaf + intermediates + anchor).
     CertChain(VerifyCertChainArgs),
+    /// Verify a SIGNATIF trusted artifact through the full pipeline.
+    Signatif(VerifySignatifArgs),
 }
 
 #[derive(Args, Debug)]
@@ -375,6 +377,35 @@ pub struct VerifyInclusionArgs {
     /// Entry JSON file (the leaf being proven).
     #[arg(long)]
     pub entry: std::path::PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct VerifySignatifArgs {
+    /// Trusted artifact JSON file.
+    #[arg(long)]
+    pub artifact: std::path::PathBuf,
+    /// Trust anchor bundle JSON file.
+    #[arg(long)]
+    pub bundle: std::path::PathBuf,
+    /// Trust graph JSON file.
+    #[arg(long)]
+    pub graph: std::path::PathBuf,
+    /// Scheme registry JSON file (omit for the default registry).
+    #[arg(long)]
+    pub registry: Option<std::path::PathBuf>,
+    /// Comma-separated accepted classification labels.
+    #[arg(long, value_delimiter = ',')]
+    pub accept: Vec<String>,
+    /// Transparency inclusion was verified for this artifact.
+    #[arg(long, default_value_t = false)]
+    pub transparency: bool,
+    /// An external time anchor was verified for this artifact.
+    #[arg(long, default_value_t = false)]
+    pub time: bool,
+    /// Externally-attested time (RFC 3339) from a verified time
+    /// authority attestation.
+    #[arg(long)]
+    pub time_attested_at: Option<String>,
 }
 
 #[derive(Args, Debug)]

--- a/crates/confium-cli/src/commands/verify.rs
+++ b/crates/confium-cli/src/commands/verify.rs
@@ -1,6 +1,9 @@
 //! `confium verify` — verification umbrella subcommands.
 
-use crate::cli::{VerifyCertChainArgs, VerifyCommand, VerifyCompositeArgs, VerifyInclusionArgs};
+use crate::cli::{
+    VerifyCertChainArgs, VerifyCommand, VerifyCompositeArgs, VerifyInclusionArgs,
+    VerifySignatifArgs,
+};
 use confium_pki::{Certificate, path::CertPath};
 
 pub fn run(cmd: VerifyCommand) {
@@ -12,6 +15,7 @@ pub fn run(cmd: VerifyCommand) {
         VerifyCommand::Composite(args) => verify_composite(args),
         VerifyCommand::Inclusion(args) => verify_inclusion(args),
         VerifyCommand::CertChain(args) => verify_cert_chain(args),
+        VerifyCommand::Signatif(args) => verify_signatif(args),
     };
     if let Err(e) = result {
         eprintln!("confium verify: {e}");
@@ -160,4 +164,87 @@ fn print_version() {
     println!("  docs:    https://www.confium.org/verify/");
     println!("  specs:   https://www.confium.org/specs/PRODUCTS");
     println!("  quickstart: https://www.confium.org/verify/quickstart/");
+}
+
+fn verify_signatif(args: VerifySignatifArgs) -> Result<(), String> {
+    let read_json = |path: &std::path::PathBuf| -> Result<serde_json::Value, String> {
+        let bytes = std::fs::read(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+        serde_json::from_slice(&bytes).map_err(|e| format!("parse {}: {e}", path.display()))
+    };
+    let artifact: confium_signatif::artifact::TrustedArtifact = {
+        let v = read_json(&args.artifact)?;
+        serde_json::from_value(v).map_err(|e| format!("artifact: {e}"))?
+    };
+    let bundle: confium_signatif::bundle::TrustAnchorBundle = {
+        let v = read_json(&args.bundle)?;
+        serde_json::from_value(v).map_err(|e| format!("bundle: {e}"))?
+    };
+    let graph: confium_signatif::graph::TrustGraph = {
+        let v = read_json(&args.graph)?;
+        serde_json::from_value(v).map_err(|e| format!("graph: {e}"))?
+    };
+    let registry: confium_signatif::registry::Registry = match &args.registry {
+        Some(path) => {
+            let v = read_json(path)?;
+            serde_json::from_value(v).map_err(|e| format!("registry: {e}"))?
+        }
+        None => confium_signatif::registry::Registry::with_initial_values(),
+    };
+    let time_attested_at = match &args.time_attested_at {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| format!("time_attested_at: {e}"))?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let acceptance = confium_signatif::coverage::AcceptancePolicy {
+        accepted_labels: args.accept,
+    };
+    let no_revocations = confium_signatif::revocation::NoRevocations;
+    let verifier = CliVerifier;
+    let pipe = confium_signatif::pipeline::Pipeline::new(
+        &bundle,
+        &graph,
+        &registry,
+        &verifier,
+        &no_revocations,
+        confium_signatif::pipeline::TransparencyInputs {
+            artifact_included: args.transparency,
+            time_anchored: args.time,
+            time_attested_at,
+            multi_log_quorum: false,
+            downgrades: vec![],
+        },
+        &acceptance,
+    );
+    let outcome = pipe
+        .run(&artifact, chrono::Utc::now())
+        .map_err(|e| format!("{e}"))?;
+    let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "label": outcome.label.0,
+            "accept": accept,
+            "coverage": outcome.report,
+        }))
+        .map_err(|e| format!("encode: {e}"))?
+    );
+    if !accept {
+        std::process::exit(2);
+    }
+    Ok(())
+}
+
+/// The CLI verifier fleet: Ed25519 and ECDSA-P256, matching the
+/// classical algorithms in the default registry.
+struct CliVerifier;
+
+impl confium_signatif::graph::SignatureVerifier for CliVerifier {
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+        confium_composite::ed25519_verifier("Ed25519", public_key, message, signature).is_ok()
+            || confium_composite::p256_verifier("ECDSA-P256", public_key, message, signature)
+                .is_ok()
+    }
 }

--- a/crates/confium-python/Cargo.lock
+++ b/crates/confium-python/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64ct"
@@ -36,6 +36,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -75,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "confium-attributes"
 version = "0.4.7"
 dependencies = [
@@ -87,10 +102,10 @@ version = "0.4.7"
 dependencies = [
  "ed25519-dalek",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
 ]
 
@@ -99,6 +114,8 @@ name = "confium-deployment"
 version = "0.4.7"
 dependencies = [
  "chrono",
+ "confium-signatif",
+ "hex",
  "serde",
  "serde_json",
  "thiserror",
@@ -111,10 +128,10 @@ version = "0.4.7"
 dependencies = [
  "chrono",
  "data-encoding",
- "der",
+ "der 0.7.10",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror",
  "x509-cert",
 ]
@@ -128,6 +145,7 @@ dependencies = [
  "confium-composite",
  "confium-deployment",
  "confium-pki",
+ "confium-signatif",
  "confium-tc-cmp20",
  "confium-tc-elgamal-p256",
  "confium-tc-frost-p256",
@@ -138,8 +156,26 @@ dependencies = [
  "p256",
  "pyo3",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
+]
+
+[[package]]
+name = "confium-signatif"
+version = "0.4.7"
+dependencies = [
+ "base64ct",
+ "chrono",
+ "confium-composite",
+ "confium-pki",
+ "ed25519-dalek",
+ "hex",
+ "p256",
+ "rand_core 0.6.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror",
 ]
 
 [[package]]
@@ -148,15 +184,15 @@ version = "0.4.7"
 dependencies = [
  "chrono",
  "confium-tc-core",
- "hmac",
+ "hmac 0.12.1",
  "inventory",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "snafu",
  "thiserror",
  "zeroize",
@@ -169,11 +205,12 @@ dependencies = [
  "confium-tc",
  "crypto-bigint",
  "elliptic-curve",
+ "getrandom 0.4.3",
  "inventory",
  "num-bigint",
  "p256",
  "rand",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -182,14 +219,15 @@ name = "confium-tc-core"
 version = "0.4.7"
 dependencies = [
  "chrono",
+ "getrandom 0.4.3",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "inventory",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "snafu",
  "subtle",
  "thiserror",
@@ -200,6 +238,7 @@ dependencies = [
 name = "confium-tc-elgamal-p256"
 version = "0.4.7"
 dependencies = [
+ "getrandom 0.4.3",
  "p256",
  "serde",
  "thiserror",
@@ -211,8 +250,8 @@ name = "confium-tc-frost-p256"
 version = "0.4.7"
 dependencies = [
  "elliptic-curve",
+ "getrandom 0.4.3",
  "p256",
- "rand_core",
  "thiserror",
  "zeroize",
 ]
@@ -224,9 +263,10 @@ dependencies = [
  "confium-tc",
  "crypto-bigint",
  "elliptic-curve",
+ "getrandom 0.4.3",
  "inventory",
  "p256",
- "sha2",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -238,7 +278,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "thiserror",
 ]
@@ -250,10 +290,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -265,13 +317,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
- "generic-array",
- "rand_core",
+ "libc",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -287,15 +352,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "getrandom 0.4.3",
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+ "subtle",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -325,10 +411,21 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -349,25 +446,37 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "der",
- "digest",
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature",
- "spki",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -376,8 +485,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -388,28 +497,29 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
  "ff",
- "generic-array",
  "group",
- "pem-rfc7468",
- "pkcs8",
- "rand_core",
+ "hybrid-array",
+ "pem-rfc7468 1.0.0",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
  "sec1",
  "serdect",
  "subtle",
@@ -424,11 +534,11 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -482,7 +592,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -497,13 +606,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "group"
-version = "0.13.0"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -531,7 +652,27 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "subtle",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -667,15 +808,16 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "p256"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+checksum = "d2c9239b2dbc807adbbe147e8cf72ea7450c3a0aabe62cb8e75ff4ec22e1f72a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primefield",
  "primeorder",
  "serdect",
- "sha2",
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -683,6 +825,15 @@ name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -699,8 +850,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -719,13 +880,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "primeorder"
-version = "0.13.6"
+name = "primefield"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.2",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
 dependencies = [
  "elliptic-curve",
+ "once_cell",
+ "primefield",
  "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -810,6 +988,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,7 +1001,7 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -827,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -836,17 +1020,23 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
+name = "rand_core"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac",
- "subtle",
+ "crypto-bigint",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -866,14 +1056,14 @@ checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der",
- "generic-array",
- "pkcs8",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
  "serdect",
  "subtle",
  "zeroize",
@@ -939,9 +1129,9 @@ dependencies = [
 
 [[package]]
 name = "serdect"
-version = "0.2.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
  "base16ct",
  "serde",
@@ -954,8 +1144,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -965,8 +1155,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -981,8 +1182,17 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1019,7 +1229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -1282,16 +1502,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
- "der",
+ "const-oid 0.9.6",
+ "der 0.7.10",
  "sha1",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "tls_codec",
 ]
 

--- a/crates/confium-python/Cargo.toml
+++ b/crates/confium-python/Cargo.toml
@@ -23,6 +23,7 @@ confium-pki = { path = "../confium-pki", version = "0.4.0", features = ["cms"] }
 confium-attributes = { path = "../confium-attributes", version = "0.4.0" }
 confium-deployment = { path = "../confium-deployment", version = "0.4.0" }
 confium-tc-cmp20 = { path = "../confium-tc-cmp20", version = "0.4.0" }
+confium-signatif = { path = "../confium-signatif", version = "0.4.0" }
 confium-tc-elgamal-p256 = { path = "../confium-tc-elgamal-p256", version = "0.4.0" }
 confium-tc-frost-p256 = { path = "../confium-tc-frost-p256", version = "0.4.0" }
 confium-tc-gg18 = { path = "../confium-tc-gg18", version = "0.4.0" }
@@ -33,7 +34,7 @@ subtle = "2"
 chrono = "0.4"
 hex = "0.4"
 ed25519-dalek = "2"
-p256 = { workspace = true }
+p256 = { version = "0.14", features = ["ecdsa", "pem", "arithmetic"] }
 
 [package.metadata.maturin]
 python-source = "python"

--- a/crates/confium-python/src/composite.rs
+++ b/crates/confium-python/src/composite.rs
@@ -147,9 +147,13 @@ impl CompositeSignature {
                 pk_bytes.len()
             )));
         }
-        let signing = p256::ecdsa::SigningKey::from_bytes(pk_bytes.into()).map_err(|e| {
-            pyo3::exceptions::PyValueError::new_err(format!("invalid P-256 key: {e}"))
-        })?;
+        let pk_array: [u8; 32] = pk_bytes
+            .try_into()
+            .map_err(|_| pyo3::exceptions::PyValueError::new_err("P-256 private key must be 32 bytes"))?;
+        let signing = p256::ecdsa::SigningKey::from_bytes(&pk_array.into())
+            .map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!("invalid P-256 key: {e}"))
+            })?;
         let msg = message.as_bytes().to_vec();
         let component = py
             .allow_threads(move || confium_composite::build_p256_component(&signing, &msg))

--- a/crates/confium-python/src/lib.rs
+++ b/crates/confium-python/src/lib.rs
@@ -28,6 +28,7 @@ pub mod deployment;
 pub mod ers;
 pub mod ots;
 pub mod pki;
+pub mod signatif;
 pub mod tc;
 pub mod transparency;
 pub mod version;
@@ -47,6 +48,7 @@ fn confium(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     ers::register_module(py, m)?;
     ots::register_module(py, m)?;
     pki::register_module(py, m)?;
+    signatif::register_module(py, m)?;
     tc::register_module(py, m)?;
     transparency::register_module(py, m)?;
     xmldsig::register_module(py, m)?;

--- a/crates/confium-python/src/signatif.rs
+++ b/crates/confium-python/src/signatif.rs
@@ -187,7 +187,6 @@ fn pythonize_dict(d: &Bound<'_, PyDict>) -> PyResult<serde_json::Value> {
 }
 
 fn pyobject_to_json(v: &Bound<'_, pyo3::types::PyAny>) -> PyResult<serde_json::Value> {
-    use pyo3::types::PyAny;
     if v.is_none() {
         return Ok(serde_json::Value::Null);
     }

--- a/crates/confium-python/src/signatif.rs
+++ b/crates/confium-python/src/signatif.rs
@@ -1,0 +1,234 @@
+//! SIGNATIF framework verification.
+//!
+//! Exposes the [`confium_signatif`] verification pipeline to Python:
+//! verify a trusted artifact against a trust anchor bundle, trust
+//! graph, and scheme registry, producing the objective coverage
+//! report, the classification label, and the acceptance decision.
+//!
+//! Python usage:
+//!   ```python
+//!   from confium import signatif
+//!
+//!   result = signatif.verify_trusted_artifact(
+//!       artifact, bundle, graph, registry=None,
+//!       transparency_included=True, time_anchored=True,
+//!       time_attested_at=None, multi_log_quorum=False,
+//!       accepted_labels=["verified"],
+//!   )
+//!   if result["accept"]:
+//!       print(result["label"], result["coverage"]["paths_found"])
+//!   ```
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use confium_signatif::artifact::TrustedArtifact;
+use confium_signatif::bundle::TrustAnchorBundle;
+use confium_signatif::coverage::AcceptancePolicy;
+use confium_signatif::graph::{SignatureVerifier, TrustGraph};
+use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
+use confium_signatif::registry::Registry;
+use confium_signatif::revocation::NoRevocations;
+
+/// The Python-facing verifier fleet: Ed25519 and ECDSA-P256, the
+/// classical algorithms of the default registry.
+struct PyVerifier;
+
+impl SignatureVerifier for PyVerifier {
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+        confium_composite::ed25519_verifier("Ed25519", public_key, message, signature).is_ok()
+            || confium_composite::p256_verifier("ECDSA-P256", public_key, message, signature)
+                .is_ok()
+    }
+}
+
+/// Verify a SIGNATIF trusted artifact through the full pipeline.
+///
+/// Args:
+///     artifact: trusted-artifact dict (as serialized by the Rust
+///         `TrustedArtifact`).
+///     bundle: trust-anchor-bundle dict.
+///     graph: trust-graph dict (nodes + delegation edges).
+///     registry: scheme registry dict; defaults to the initial values.
+///     transparency_included: transparency inclusion was verified.
+///     time_anchored: an external time anchor was verified.
+///     time_attested_at: RFC 3339 time from a verified time authority.
+///     multi_log_quorum: the M-of-K multi-log quorum was met.
+///     accepted_labels: classification labels this verifier accepts.
+///
+/// Returns a dict with `coverage`, `label`, and `accept`.
+#[pyfunction]
+#[pyo3(signature = (
+    artifact,
+    bundle,
+    graph,
+    registry = None,
+    transparency_included = false,
+    time_anchored = false,
+    time_attested_at = None,
+    multi_log_quorum = false,
+    accepted_labels = None,
+))]
+pub fn verify_trusted_artifact(
+    py: Python<'_>,
+    artifact: &Bound<'_, PyDict>,
+    bundle: &Bound<'_, PyDict>,
+    graph: &Bound<'_, PyDict>,
+    registry: Option<&Bound<'_, PyDict>>,
+    transparency_included: bool,
+    time_anchored: bool,
+    time_attested_at: Option<String>,
+    multi_log_quorum: bool,
+    accepted_labels: Option<Vec<String>>,
+) -> PyResult<PyObject> {
+    let to_value = |d: &Bound<'_, PyDict>| -> PyResult<serde_json::Value> {
+        pythonize_dict(d)
+    };
+    let artifact_v = to_value(artifact)?;
+    let bundle_v = to_value(bundle)?;
+    let graph_v = to_value(graph)?;
+
+    let artifact: TrustedArtifact = serde_json::from_value(artifact_v)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("artifact: {e}")))?;
+    let bundle: TrustAnchorBundle = serde_json::from_value(bundle_v)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("bundle: {e}")))?;
+    let graph: TrustGraph = serde_json::from_value(graph_v)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("graph: {e}")))?;
+    let registry: Registry = match registry {
+        Some(d) => serde_json::from_value(pythonize_dict(d)?)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("registry: {e}")))?,
+        None => Registry::with_initial_values(),
+    };
+    let time_attested_at = match &time_attested_at {
+        None => None,
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("time_attested_at: {e}")))?
+                .with_timezone(&chrono::Utc),
+        ),
+    };
+    let acceptance = AcceptancePolicy {
+        accepted_labels: accepted_labels.unwrap_or_default(),
+    };
+    let no_revocations = NoRevocations;
+    let pipe = Pipeline::new(
+        &bundle,
+        &graph,
+        &registry,
+        &PyVerifier,
+        &no_revocations,
+        TransparencyInputs {
+            artifact_included: transparency_included,
+            time_anchored,
+            time_attested_at,
+            multi_log_quorum,
+            downgrades: vec![],
+        },
+        &acceptance,
+    );
+    let outcome = pipe
+        .run(&artifact, chrono::Utc::now())
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?;
+    let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
+    let coverage_json = serde_json::to_value(&outcome.report)
+        .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("encode: {e}")))?;
+    let out = PyDict::new_bound(py);
+    out.set_item("label", outcome.label.0)?;
+    out.set_item("accept", accept)?;
+    out.set_item("coverage", json_to_py(py, &coverage_json)?)?;
+    Ok(out.into())
+}
+
+/// JSON value -> Python object.
+fn json_to_py(py: Python<'_>, v: &serde_json::Value) -> PyResult<PyObject> {
+    use pyo3::types::PyList;
+    let out: PyObject = match v {
+        serde_json::Value::Null => py.None().into(),
+        serde_json::Value::Bool(b) => b.to_object(py),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                i.to_object(py)
+            } else {
+n.as_f64().unwrap_or_default().to_object(py)
+            }
+        }
+        serde_json::Value::String(s) => s.to_object(py),
+        serde_json::Value::Array(arr) => {
+            let list = PyList::empty_bound(py);
+            for item in arr {
+                list.append(json_to_py(py, item)?)?;
+            }
+            list.into_any().unbind().into()
+        }
+        serde_json::Value::Object(map) => {
+            let dict = PyDict::new_bound(py);
+            for (k, val) in map {
+                dict.set_item(k, json_to_py(py, val)?)?;
+            }
+            dict.into_any().unbind().into()
+        }
+    };
+    Ok(out)
+}
+
+/// Best-effort dict -> JSON conversion via serde round-trip through a
+/// string, avoiding a pythonize dependency.
+fn pythonize_dict(d: &Bound<'_, PyDict>) -> PyResult<serde_json::Value> {
+    // Walk key-value pairs directly.
+    let mut map = serde_json::Map::new();
+    for (k, v) in d.iter() {
+        let key: String = k
+            .extract()
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("key: {e}")))?;
+        let value = pyobject_to_json(&v)?;
+        map.insert(key, value);
+    }
+    Ok(serde_json::Value::Object(map))
+}
+
+fn pyobject_to_json(v: &Bound<'_, pyo3::types::PyAny>) -> PyResult<serde_json::Value> {
+    use pyo3::types::PyAny;
+    if v.is_none() {
+        return Ok(serde_json::Value::Null);
+    }
+    if let Ok(b) = v.extract::<bool>() {
+        return Ok(serde_json::Value::Bool(b));
+    }
+    if let Ok(i) = v.extract::<i64>() {
+        return Ok(serde_json::Value::from(i));
+    }
+    if let Ok(f) = v.extract::<f64>() {
+        return Ok(serde_json::Value::from(f));
+    }
+    if let Ok(s) = v.extract::<String>() {
+        return Ok(serde_json::Value::String(s));
+    }
+    if let Ok(list) = v.downcast::<pyo3::types::PyList>() {
+        let mut arr = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            arr.push(pyobject_to_json(&item)?);
+        }
+        return Ok(serde_json::Value::Array(arr));
+    }
+    if let Ok(dict) = v.downcast::<PyDict>() {
+        let mut map = serde_json::Map::new();
+        for (k, val) in dict.iter() {
+            let key: String = k
+                .extract()
+                .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("key: {e}")))?;
+            map.insert(key, pyobject_to_json(&val)?);
+        }
+        return Ok(serde_json::Value::Object(map));
+    }
+    Err(pyo3::exceptions::PyValueError::new_err(
+        "unsupported value type in framework object",
+    ))
+}
+
+/// Register the `confium.signatif` submodule.
+pub fn register_module(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let sub = PyModule::new_bound(py, "signatif")?;
+    sub.add_function(wrap_pyfunction!(verify_trusted_artifact, &sub)?)?;
+    m.add_submodule(&sub)
+}
+

--- a/crates/confium-python/tests/test_signatif.py
+++ b/crates/confium-python/tests/test_signatif.py
@@ -1,0 +1,39 @@
+"""confium.signatif — the SIGNATIF verification pipeline from Python."""
+
+import secrets
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+confium = pytest.importorskip("confium")
+from confium import signatif  # noqa: E402
+
+now = datetime.now(timezone.utc)
+
+
+def test_module_exposes_the_pipeline():
+    assert callable(signatif.verify_trusted_artifact)
+
+
+def test_malformed_artifact_raises():
+    with pytest.raises(ValueError):
+        signatif.verify_trusted_artifact(
+            {"not": "an artifact"},
+            {"not": "a bundle"},
+            {"not": "a graph"},
+        )
+
+
+def test_rejects_missing_required_inputs():
+    with pytest.raises(TypeError):
+        signatif.verify_trusted_artifact()
+
+
+def test_default_registry_used_when_omitted():
+    # A malformed graph must error on the graph, not the registry.
+    with pytest.raises(ValueError, match="graph"):
+        signatif.verify_trusted_artifact(
+            {"artifact_id": "x"},
+            {"bundle_version": "1"},
+            {"nodes": "not-a-map"},
+        )

--- a/crates/confium-verify-server/Cargo.toml
+++ b/crates/confium-verify-server/Cargo.toml
@@ -17,6 +17,8 @@ path = "src/main.rs"
 
 [dependencies]
 confium-composite = { workspace = true }
+chrono = { workspace = true }
+confium-signatif = { workspace = true }
 confium-transparency = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -27,3 +29,9 @@ clap = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
+rand_core = { workspace = true }
+tower = { workspace = true }

--- a/crates/confium-verify-server/src/handlers.rs
+++ b/crates/confium-verify-server/src/handlers.rs
@@ -8,6 +8,8 @@ use serde::{Deserialize, Serialize};
 use confium_composite::{
     ComponentSignature, CompositeSignature, ECDSA_P256, ED25519, ed25519_verifier, p256_verifier,
 };
+use confium_signatif::graph::{SignatureVerifier, TrustGraph};
+use confium_signatif::{artifact::TrustedArtifact, bundle::TrustAnchorBundle, registry::Registry};
 use confium_transparency::entry::MerkleEntry;
 use confium_transparency::merkle::{Hash, InclusionProof, MerkleTree, ProofStep, Side};
 
@@ -204,6 +206,7 @@ mod tests {
     fn app() -> axum::Router {
         axum::Router::new()
             .route("/verify/composite", axum::routing::post(verify_composite))
+            .route("/verify/signatif", axum::routing::post(verify_signatif))
             .route("/verify/inclusion", axum::routing::post(verify_inclusion))
             .route("/healthz", axum::routing::get(healthz))
             .with_state(AppState)
@@ -316,5 +319,163 @@ mod tests {
     fn decode_hash_validates_length() {
         assert!(decode_hash("00").is_err());
         assert!(decode_hash(&"ab".repeat(32)).is_ok());
+    }
+}
+
+/// Request: verify a SIGNATIF trusted artifact through the full
+/// pipeline. The four framework objects arrive as embedded JSON.
+#[derive(Debug, Deserialize)]
+pub struct VerifySignatifRequest {
+    /// The trusted artifact.
+    pub artifact: serde_json::Value,
+    /// The trust anchor bundle.
+    pub bundle: serde_json::Value,
+    /// The trust graph.
+    pub graph: serde_json::Value,
+    /// The scheme registry; defaults to the initial values when absent.
+    #[serde(default)]
+    pub registry: Option<serde_json::Value>,
+    /// Verification options (transparency/time inputs, accepted
+    /// labels); defaults when absent.
+    #[serde(default)]
+    pub options: VerifySignatifOptions,
+}
+
+/// Options for the pipeline run.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct VerifySignatifOptions {
+    /// Transparency inclusion was verified for this artifact.
+    #[serde(default)]
+    pub transparency_included: bool,
+    /// An external time anchor was verified.
+    #[serde(default)]
+    pub time_anchored: bool,
+    /// Externally-attested time (RFC 3339).
+    #[serde(default)]
+    pub time_attested_at: Option<String>,
+    /// Multi-log quorum met.
+    #[serde(default)]
+    pub multi_log_quorum: bool,
+    /// Accepted classification labels (empty = reject everything).
+    #[serde(default)]
+    pub accepted_labels: Vec<String>,
+}
+
+/// Response: the graduated verification outcome.
+#[derive(Debug, Serialize)]
+pub struct VerifySignatifResponse {
+    /// The scheme's classification label.
+    pub label: String,
+    /// The verifier's acceptance decision.
+    pub accept: bool,
+    /// The objective coverage report.
+    pub coverage: confium_signatif::coverage::CoverageReport,
+}
+
+/// The server's verifier fleet: the classical algorithms of the
+/// default registry.
+struct ServerVerifier;
+
+impl SignatureVerifier for ServerVerifier {
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+        ed25519_verifier(ED25519, public_key, message, signature).is_ok()
+            || p256_verifier(ECDSA_P256, public_key, message, signature).is_ok()
+    }
+}
+
+/// POST /verify/signatif
+pub async fn verify_signatif(
+    State(_state): State<AppState>,
+    Json(req): Json<VerifySignatifRequest>,
+) -> (StatusCode, Json<serde_json::Value>) {
+    let respond = |status: StatusCode, body: serde_json::Value| (status, Json(body));
+    let artifact: TrustedArtifact = match serde_json::from_value(req.artifact) {
+        Ok(a) => a,
+        Err(e) => {
+            return respond(
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({"error": format!("artifact: {e}")}),
+            );
+        }
+    };
+    let bundle: TrustAnchorBundle = match serde_json::from_value(req.bundle) {
+        Ok(b) => b,
+        Err(e) => {
+            return respond(
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({"error": format!("bundle: {e}")}),
+            );
+        }
+    };
+    let graph: TrustGraph = match serde_json::from_value(req.graph) {
+        Ok(g) => g,
+        Err(e) => {
+            return respond(
+                StatusCode::BAD_REQUEST,
+                serde_json::json!({"error": format!("graph: {e}")}),
+            );
+        }
+    };
+    let registry: Registry = match req.registry {
+        Some(v) => match serde_json::from_value(v) {
+            Ok(r) => r,
+            Err(e) => {
+                return respond(
+                    StatusCode::BAD_REQUEST,
+                    serde_json::json!({"error": format!("registry: {e}")}),
+                );
+            }
+        },
+        None => Registry::with_initial_values(),
+    };
+    let time_attested_at = match &req.options.time_attested_at {
+        None => None,
+        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+            Ok(t) => Some(t.with_timezone(&chrono::Utc)),
+            Err(e) => {
+                return respond(
+                    StatusCode::BAD_REQUEST,
+                    serde_json::json!({"error": format!("time_attested_at: {e}")}),
+                );
+            }
+        },
+    };
+    let no_revocations = confium_signatif::revocation::NoRevocations;
+    let acceptance = confium_signatif::coverage::AcceptancePolicy {
+        accepted_labels: req.options.accepted_labels,
+    };
+    let pipe = confium_signatif::pipeline::Pipeline::new(
+        &bundle,
+        &graph,
+        &registry,
+        &ServerVerifier,
+        &no_revocations,
+        confium_signatif::pipeline::TransparencyInputs {
+            artifact_included: req.options.transparency_included,
+            time_anchored: req.options.time_anchored,
+            time_attested_at,
+            multi_log_quorum: req.options.multi_log_quorum,
+            downgrades: vec![],
+        },
+        &acceptance,
+    );
+    match pipe.run(&artifact, chrono::Utc::now()) {
+        Ok(outcome) => {
+            let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
+            respond(
+                StatusCode::OK,
+                serde_json::to_value(VerifySignatifResponse {
+                    label: outcome.label.0,
+                    accept,
+                    coverage: outcome.report,
+                })
+                .unwrap_or_default(),
+            )
+        }
+        Err(e) => respond(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            serde_json::json!({"error": format!("{e}"), "label": "rejected"}),
+        ),
     }
 }

--- a/crates/confium-verify-server/src/lib.rs
+++ b/crates/confium-verify-server/src/lib.rs
@@ -1,0 +1,26 @@
+//! Library surface for the HTTP verification service: exposes the
+//! handlers and the canonical router so integrators (and tests) can
+//! mount the same routes as the binary.
+
+pub mod handlers;
+
+pub use handlers::{AppState, VerifySignatifRequest};
+
+/// The canonical router, shared by the binary and tests.
+pub fn router() -> axum::Router {
+    axum::Router::new()
+        .route(
+            "/verify/composite",
+            axum::routing::post(handlers::verify_composite),
+        )
+        .route(
+            "/verify/signatif",
+            axum::routing::post(handlers::verify_signatif),
+        )
+        .route(
+            "/verify/inclusion",
+            axum::routing::post(handlers::verify_inclusion),
+        )
+        .route("/healthz", axum::routing::get(handlers::healthz))
+        .with_state(AppState)
+}

--- a/crates/confium-verify-server/src/main.rs
+++ b/crates/confium-verify-server/src/main.rs
@@ -1,10 +1,7 @@
 //! `confium-verify-server` — HTTP service for verifying threshold
 //! signatures and transparency log inclusion proofs.
 
-mod handlers;
-
 use clap::Parser;
-use handlers::AppState;
 
 /// Command-line arguments.
 #[derive(Parser, Debug)]
@@ -24,17 +21,7 @@ struct Args {
 }
 
 fn build_router() -> axum::Router {
-    axum::Router::new()
-        .route(
-            "/verify/composite",
-            axum::routing::post(handlers::verify_composite),
-        )
-        .route(
-            "/verify/inclusion",
-            axum::routing::post(handlers::verify_inclusion),
-        )
-        .route("/healthz", axum::routing::get(handlers::healthz))
-        .with_state(AppState)
+    confium_verify_server::router()
 }
 
 #[tokio::main]

--- a/crates/confium-verify-server/tests/signatif_endpoint.rs
+++ b/crates/confium-verify-server/tests/signatif_endpoint.rs
@@ -1,0 +1,142 @@
+//! POST /verify/signatif — the full SIGNATIF pipeline over HTTP.
+
+use tower::ServiceExt;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use ed25519_dalek::Signer;
+use rand_core::RngCore;
+
+use confium_signatif::artifact::TrustedArtifact;
+use confium_signatif::bundle::TrustAnchorBundle;
+use confium_signatif::graph::{AuthorityKind, AuthorityNode, DelegationEdge, TrustGraph};
+use confium_signatif::registry::{DimensionTag, Registry};
+
+fn generate_key() -> ed25519_dalek::SigningKey {
+    let mut seed = [0u8; 32];
+    rand_core::OsRng.fill_bytes(&mut seed);
+    ed25519_dalek::SigningKey::from_bytes(&seed)
+}
+
+fn fixture() -> serde_json::Value {
+    let registry = Registry::with_initial_values();
+    let root_sk = generate_key();
+    let end_sk = generate_key();
+    let root = AuthorityNode {
+        id: "root".into(),
+        kind: AuthorityKind::Root,
+        public_key: root_sk.verifying_key().as_bytes().to_vec(),
+        quorum: None,
+        scope: confium_signatif::scope::ScopeDimensions::unconstrained(),
+    };
+    let end = AuthorityNode {
+        id: "end".into(),
+        kind: AuthorityKind::EndCertificate,
+        public_key: end_sk.verifying_key().as_bytes().to_vec(),
+        quorum: None,
+        scope: confium_signatif::scope::ScopeDimensions::unconstrained(),
+    };
+    let mut graph = TrustGraph::new();
+    graph.add_node(root.clone());
+    graph.add_node(end.clone());
+    graph
+        .add_delegation(DelegationEdge {
+            parent: "root".into(),
+            child: "end".into(),
+            signature: root_sk
+                .sign(&end.binding_bytes().unwrap())
+                .to_bytes()
+                .to_vec(),
+        })
+        .unwrap();
+    let mut bundle = TrustAnchorBundle {
+        bundle_version: "1".into(),
+        valid_from: chrono::Utc::now() - chrono::Duration::hours(1),
+        valid_until: chrono::Utc::now() + chrono::Duration::days(30),
+        roots: vec![confium_signatif::bundle::AnchorRoot {
+            name: "root".into(),
+            aggregate_key: root.public_key.clone(),
+            fingerprint: hex::encode(&root.public_key),
+            quorum: None,
+        }],
+        transparency_logs: vec![],
+        update_log: None,
+        bundle_signature: vec![],
+    };
+    let msg = bundle.signing_bytes().unwrap();
+    bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
+    let mut artifact = TrustedArtifact::new(
+        confium_signatif::artifact::ArtifactVersion { major: 1, minor: 0 },
+        "http-1",
+        serde_json::json!({"dose": 500}),
+        None,
+    )
+    .unwrap();
+    artifact
+        .sign(
+            DimensionTag::data(),
+            "Ed25519",
+            "end",
+            end_sk.verifying_key().as_bytes().to_vec(),
+            "root",
+            &|m| end_sk.sign(m).to_bytes().to_vec(),
+            &registry,
+        )
+        .unwrap();
+    serde_json::json!({
+        "artifact": artifact,
+        "bundle": bundle,
+        "graph": graph,
+        "options": {
+            "transparency_included": true,
+            "time_anchored": true,
+            "time_attested_at": chrono::Utc::now().to_rfc3339(),
+            "accepted_labels": ["basic", "verified"],
+        },
+    })
+}
+
+#[tokio::test]
+async fn verifies_artifact_and_returns_graduated_outcome() {
+    let app = confium_verify_server::router();
+    let body = serde_json::to_string(&fixture()).unwrap();
+    let response = app
+        .oneshot(
+            Request::post("/verify/signatif")
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let out: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(out["label"], "verified");
+    assert_eq!(out["accept"], true);
+    assert_eq!(out["coverage"]["dimensions_verified"][0], "data");
+}
+
+#[tokio::test]
+async fn tampered_artifact_is_rejected_with_422() {
+    let app = confium_verify_server::router();
+    let mut body = fixture();
+    body["artifact"]["payload"]["dose"] = serde_json::json!(999);
+    let response = app
+        .oneshot(
+            Request::post("/verify/signatif")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let out: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(out["label"], "rejected");
+}


### PR DESCRIPTION
## What

The framework pipeline on the last three adoption surfaces (TODOs 30-32 of the local plan), completing the coverage matrix: **Rust (library + facade), browser (wasm), HTTP, CLI, Python**.

- **confium-verify-server**: `POST /verify/signatif` runs the full pipeline over HTTP. The four framework objects arrive as embedded JSON; options carry transparency/time inputs and accepted labels; the response is `{label, accept, coverage}`. Hard failures return 422 with `label: rejected` (endpoint tests: graduated outcome + tamper rejection). The server gained a library surface (`lib.rs` router) shared by the binary and tests.
- **confium-cli**: `confium verify signatif --artifact --bundle --graph [--registry] [--accept l1,l2] [--transparency] [--time] [--time-attested-at RFC3339]` prints the coverage report and decision, exit 2 on rejection. Ed25519 + ECDSA-P256 fleet.
- **confium-python**: `from confium import signatif` — `signatif.verify_trusted_artifact(artifact, bundle, graph, registry=None, ...)` returning `{coverage, label, accept}`, with dict-to-JSON bridging (no pythonize dep). Pytest suite added.

## Repairs found along the way

- The standalone `confium-python` crate was **latently broken** by the p256 0.13->0.14 migration: it is not a root-workspace member, so `--workspace` checks never reached it, and its `p256 = { workspace = true }` line could not resolve. Fixed (explicit p256 0.14 pin + the `SigningKey::from_bytes` API change), and **CI now checks the crate explicitly** (`cargo check --manifest-path crates/confium-python/Cargo.toml --all-targets` in the machete job) so standalone crates cannot rot silently again.
