### PR TITLE
docs(signatif): the adoption story — decisions, quickstarts, conformance page, registry convention

### DIFF
--- a/crates/confium-signatif/examples/conformance_page.rs
+++ b/crates/confium-signatif/examples/conformance_page.rs
@@ -1,0 +1,41 @@
+//! Print the conformance page for the docs site: the `/conf` class
+//! table generated from [`conformance_claims`], so the published page
+//! can never drift from the code (a CI test compares the output with
+//! the committed `docs/signatif/conformance.mdx`).
+//!
+//! Regenerate with:
+//!
+//! ```sh
+//! cargo run -p confium-signatif --example conformance_page \
+//!   > docs/signatif/conformance-table.mdx
+//! ```
+
+use confium_signatif::conformance::{ConformanceStatus, conformance_claims};
+
+fn main() {
+    let claims = conformance_claims();
+    let implemented = claims
+        .iter()
+        .filter(|c| c.status == ConformanceStatus::Implemented)
+        .count();
+    let partial = claims.len() - implemented;
+
+    println!("| Class | Status | Implemented in | Description |");
+    println!("|---|---|---|---|");
+    for c in &claims {
+        let status = match c.status {
+            ConformanceStatus::Implemented => "implemented",
+            ConformanceStatus::Partial => "partial",
+            ConformanceStatus::Planned => "planned",
+        };
+        println!(
+            "| `{}` | {} | {} | {} |",
+            c.class, status, c.implemented_in, c.description
+        );
+    }
+    println!();
+    println!(
+        "_{implemented} of {} classes implemented, {partial} partial._",
+        claims.len()
+    );
+}

--- a/crates/confium-signatif/src/registry.rs
+++ b/crates/confium-signatif/src/registry.rs
@@ -339,6 +339,19 @@ impl Registry {
         }
     }
 
+    /// Load a registry from its published bytes (the Annex C
+    /// publication convention: schemes publish `registry.json` at a
+    /// stable URL; every verification surface loads the same bytes).
+    /// Round-trips with [`Registry::publication_bytes`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an encoding error on malformed JSON.
+    pub fn from_published_bytes(bytes: &[u8]) -> SignatifResult<Self> {
+        serde_json::from_slice(bytes)
+            .map_err(|e| SignatifError::Encoding(format!("published registry: {e}")))
+    }
+
     /// Deterministic publication bytes for a registry (JCS).
     ///
     /// # Errors
@@ -388,6 +401,17 @@ mod tests {
             .unwrap();
         assert!(r.algorithms.usable("ECDSA-P256").is_none());
         assert!(r.algorithms.set_status("nope", Status::Active).is_err());
+    }
+
+    #[test]
+    fn published_registry_round_trips() {
+        let mut r = Registry::with_initial_values();
+        r.register_dimension("cnml:instrument-class", "CNML classification");
+        let published = r.publication_bytes().unwrap();
+        let back = Registry::from_published_bytes(&published).unwrap();
+        assert!(back.dimensions.contains("cnml:instrument-class"));
+        assert_eq!(back.publication_bytes().unwrap(), published);
+        assert!(Registry::from_published_bytes(b"not json").is_err());
     }
 
     #[test]

--- a/crates/confium-signatif/tests/ats.rs
+++ b/crates/confium-signatif/tests/ats.rs
@@ -341,10 +341,12 @@ fn ats_passport() {
 fn conformance_page_matches_docs() {
     use confium_signatif::conformance::{ConformanceStatus, conformance_claims};
 
+    // Normalize line endings: Windows checkouts may carry CRLF.
     let committed = include_str!(concat!(
         env!("CARGO_MANIFEST_DIR"),
         "/../../docs/signatif/conformance.mdx"
-    ));
+    ))
+    .replace("\r\n", "\n");
 
     let claims = conformance_claims();
     let implemented = claims

--- a/crates/confium-signatif/tests/ats.rs
+++ b/crates/confium-signatif/tests/ats.rs
@@ -333,3 +333,48 @@ fn ats_passport() {
     let bytes = p.distribution_bytes().unwrap();
     assert!(Passport::from_distribution_bytes(&bytes).is_ok());
 }
+
+/// The docs conformance page must match the implementation: regenerate
+/// the table and compare it against the committed MDX (item 36 — the
+/// claim can never silently drift).
+#[test]
+fn conformance_page_matches_docs() {
+    use confium_signatif::conformance::{ConformanceStatus, conformance_claims};
+
+    let committed = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../docs/signatif/conformance.mdx"
+    ));
+
+    let claims = conformance_claims();
+    let implemented = claims
+        .iter()
+        .filter(|c| c.status == ConformanceStatus::Implemented)
+        .count();
+    let partial = claims.len() - implemented;
+
+    let mut generated =
+        String::from("| Class | Status | Implemented in | Description |\n|---|---|---|---|\n");
+    for c in &claims {
+        let status = match c.status {
+            ConformanceStatus::Implemented => "implemented",
+            ConformanceStatus::Partial => "partial",
+            ConformanceStatus::Planned => "planned",
+        };
+        generated.push_str(&format!(
+            "| `{}` | {} | {} | {} |\n",
+            c.class, status, c.implemented_in, c.description
+        ));
+    }
+    generated.push_str(&format!(
+        "\n_{implemented} of {} classes implemented, {partial} partial._\n",
+        claims.len()
+    ));
+
+    assert!(
+        committed.contains(&generated),
+        "docs/signatif/conformance.mdx is stale — regenerate with \
+         `cargo run -p confium-signatif --example conformance_page` \
+         and update the table in the page"
+    );
+}

--- a/docs/signatif/adoption-guide.mdx
+++ b/docs/signatif/adoption-guide.mdx
@@ -8,7 +8,10 @@ audience: security-engineer, devsecops
 
 SIGNATIF is the framework; Confium is the implementation tool; your
 domain scheme (CNML, DPP, supply chain, …) is the adopting technology.
-This guide walks a scheme from zero to a conformance claim. Runnable
+This guide walks a scheme from zero to a conformance claim along one
+spine (the CNML choices); every step marks the **decision forks** your
+scheme owns — the full option menus live in
+[Decisions your scheme makes](/docs/signatif/decisions). Runnable
 companions: `examples/cnml_profile.rs` and `examples/dpp_composition.rs`
 in the `confium-signatif` crate.
 
@@ -20,7 +23,8 @@ cargo add confium-signatif
 
 A scheme customizes the framework through the registries — never by
 forking technology. Start from the initial values and register your
-extension dimensions:
+extension dimensions (then publish the result per the
+[registry publication convention](/docs/signatif/registry)):
 
 ```rust
 use confium_signatif::registry::Registry;
@@ -37,6 +41,9 @@ Algorithm lifecycle is registry-driven: `Active` signs and verifies,
 window, `Retired` hard-fails.
 
 ## 2. Build the trust topology
+
+> **Fork — topology:** hierarchical, federated, cross-recognized, or
+> mesh (plus mixtures). This spine uses a hierarchy with quorums.
 
 Authorities form a directed acyclic graph: a root trust authority
 (declare its quorum), delegated authorities with narrowed scopes, end
@@ -62,6 +69,12 @@ threshold authorities (nested threshold), and join/leave re-shares
 preserve the aggregate key.
 
 ## 3. Issue trusted artifacts
+
+> **Fork — format profile:** this spine serializes artifacts through
+> the generic JSON model; JWS+JCS and COSE envelopes are both wired,
+> and schemes with an XML estate carry legacy XMLDSig payloads via
+> Exclusive C14N — the canonical payload hash covers the C14N bytes
+> and JCS is used only for the self-description around them.
 
 An artifact is the convergence point of independent attestations.
 Every co-signature — regardless of trust dimension, organization, or
@@ -122,6 +135,10 @@ feature) carry certificate summaries; challenge-response binds a
 embedded, by transparency-log reference, or hybrid — all offline
 verifiable.
 
+> **Fork — algorithms and migration phase:** this spine stays
+> classical; the composite and post-quantum-only phases are declared
+> the same way.
+
 ## 6. Ride the post-quantum migration
 
 Declare your phase (`classical_only`, `composite`, `post_quantum_only`)
@@ -131,7 +148,16 @@ SLH-DSA-128s (features `pq`, `pq-slh`) in AND-composition — new
 artifacts carry classical+PQC composites while classical-only
 artifacts keep verifying.
 
-## 7. Claim conformance
+## 7. Verify anywhere
+
+One pipeline, five surfaces — pick by architecture, not by trust:
+[browser](/docs/signatif/quickstarts/browser),
+[HTTP](/docs/signatif/quickstarts/http),
+[CLI](/docs/signatif/quickstarts/cli),
+[Python](/docs/signatif/quickstarts/python),
+[Rust](/docs/signatif/quickstarts/rust).
+
+## 8. Claim conformance
 
 `confium_signatif::conformance::conformance_report()` emits the
 machine-readable claim list — all 24 `/conf` classes implemented by

--- a/docs/signatif/conformance.mdx
+++ b/docs/signatif/conformance.mdx
@@ -1,0 +1,58 @@
+---
+title: "Confium's Signatif conformance"
+description: The machine-checked conformance claim — every /conf class, its status, and where it is implemented. Generated from the code; drift fails CI.
+audience: security-engineer, devsecops
+---
+
+# Confium's Signatif conformance
+
+Confium claims conformance to the SIGNATIF framework (ISO/TC 154
+working draft) through the `confium-signatif` crate. This page is
+**generated from the code** — `cargo run -p confium-signatif
+--example conformance_page` regenerates the table below, and a CI
+test asserts the committed page matches the implementation, so the
+claim can never silently drift.
+
+Verify it yourself:
+
+```sh
+cargo run -p confium-signatif --example conformance_page
+cargo test -p confium-signatif conformance_page_matches_docs
+```
+
+The abstract test suite witnessing the implemented classes is
+`crates/confium-signatif/tests/ats.rs` — every class below is
+exercised through its public surface.
+
+_Specification basis: the SIGNATIF working draft as of August 2026.
+When the draft evolves, this page and the underlying claims move with
+it — the tests move first._
+
+| Class | Status | Implemented in | Description |
+|---|---|---|---|
+| `/conf/basic-verifier` | implemented | confium_signatif::pipeline | Verify artifacts offline against an anchor bundle: hard checks, coverage report, acceptance policy |
+| `/conf/full-verifier` | implemented | confium_signatif::pipeline + graph + coverage | Basic verifier plus trust-graph path-finding, multi-dimension verification, classification policies |
+| `/conf/issuing-authority` | implemented | confium_signatif::artifact + ceremony | Issue end certificates and produce trusted artifacts with dimension attestations |
+| `/conf/root-authority` | implemented | confium_signatif::bundle + confium_deployment::signatif | Operate a root: anchor bundles, deployment manifests, cross-recognition |
+| `/conf/transparency-operator` | implemented | confium_transparency + confium-log-server | Operate an append-only log with inclusion and consistency proofs |
+| `/conf/mirror` | implemented | confium_transparency::witness + confium-log-monitor | Mirror a log: verify append-only continuity, serve proofs |
+| `/conf/device-signer` | implemented | confium_signatif::passport (Challenge) | Device signs fresh nonce-bound artifacts under challenge |
+| `/conf/hierarchical` | implemented | confium_signatif::graph + deployment::signatif | Single-root hierarchy topology |
+| `/conf/federated` | implemented | confium_signatif::fta | Threshold groups of independent organizations |
+| `/conf/cross-recognized` | implemented | confium_deployment::signatif::CrossRecognition | Roots attesting each other via signed credentials |
+| `/conf/mesh` | implemented | confium_signatif::graph (multi-root, multi-path) | Many-to-many peer recognition |
+| `/conf/format-cose` | implemented | confium_composite::cose | COSE Sig_Structure envelope |
+| `/conf/format-jws` | implemented | confium_signatif::jws | JWS compact, detached content |
+| `/conf/format-xmldsig` | implemented | confium_pki::xmldsig | XML Signature with Exclusive C14N |
+| `/conf/dimension-data` | implemented | confium_signatif::artifact + registry | Data dimension attestation |
+| `/conf/dimension-person` | implemented | confium_signatif::artifact + registry | Person dimension attestation |
+| `/conf/dimension-time` | implemented | confium_signatif::time | Time dimension with external anchor |
+| `/conf/dimension-location` | implemented | confium_signatif::artifact + registry | Location dimension attestation |
+| `/conf/dimension-environment` | implemented | confium_signatif::artifact + registry | Environment dimension attestation |
+| `/conf/dimension-authorization` | implemented | confium_signatif::artifact + registry | Authorization dimension attestation |
+| `/conf/dimension-identity` | implemented | confium_signatif::artifact + registry | Identity dimension attestation |
+| `/conf/dimension-oracle` | implemented | confium_signatif::artifact + registry | Oracle dimension attestation |
+| `/conf/multi-dimensional` | implemented | confium_signatif::artifact (living artifacts) | Multiple independent dimensions converging on one artifact |
+| `/conf/post-quantum` | implemented | confium_composite::pq (features pq, pq-slh) | ML-DSA-65 and SLH-DSA-128s verification, classical+PQC and PQC-only composites |
+
+_24 of 24 classes implemented, 0 partial._

--- a/docs/signatif/decisions.mdx
+++ b/docs/signatif/decisions.mdx
@@ -1,0 +1,102 @@
+---
+title: "Decisions your scheme makes"
+description: The five decision points every SIGNATIF scheme owns — topology, format, algorithms, dimensions and registry, policies — and the Confium module that implements each option.
+audience: security-engineer, devsecops
+---
+
+# Decisions your scheme makes
+
+Signatif is deliberately choice-preserving: the framework fixes the
+*semantics* (what a trust chain, an artifact, a coverage report, a
+classification mean) while your scheme fixes the *instantiation*. A
+scheme that adopts the framework through Confium makes five decisions.
+Nothing here is mandated — every row is wired, tested, and
+interchangeable.
+
+> Confium is one implementation of every option below. The normative
+> definitions live in the Signatif specification; this page maps each
+> choice to the Confium code that realizes it.
+
+## 1. Trust topology
+
+How authorities relate — declared in your
+`confium_deployment::signatif::SignatifManifest` and enforced by the
+`confium_signatif::graph` path-finder.
+
+| Option | Conformance class | When to choose | Confium |
+|---|---|---|---|
+| Hierarchical | `/conf/hierarchical` | One root, strict delegation (regulators, NMI-style) | `TrustGraph` single-root DAG |
+| Federated | `/conf/federated` | M-of-K organizations share one aggregate key | `confium_signatif::fta::FederatedTrustAuthority` |
+| Cross-recognized | `/conf/cross-recognized` | Independent roots attesting each other | `CrossRecognition` credentials |
+| Mesh | `/conf/mesh` | Many-to-many peer recognition | multi-root, multi-path `find_paths` |
+
+Mixtures are conforming: the trust graph is a DAG, so a federated
+authority can sit inside a hierarchy, and hierarchy-spanning FTAs act
+as bridges.
+
+## 2. Artifact format profile
+
+The envelope carrying co-signatures. Multiple profiles may coexist in
+one deployment — verify all of them through one pipeline.
+
+| Option | Conformance class | Notes | Confium |
+|---|---|---|---|
+| JWS + JCS | `/conf/format-jws` | Detached-content JWS (EdDSA, ES256); RFC 8785 canonical JSON | `confium_signatif::jws`, `jcs` |
+| COSE | `/conf/format-cose` | COSE_Sign1 chains with dimension/cert/chain refs in headers | `confium_signatif::cose`, `confium_composite::cose` |
+| XMLDSig + Exc-C14N | `/conf/format-xmldsig` | See [bringing legacy XML](#bringing-legacy-xml) below | `confium_pki::xmldsig` |
+
+### Bringing legacy XML
+
+Schemes with an XML estate (CNML families, OASIS/metrology documents)
+do not need to migrate payloads to JSON. Wrap the existing
+XMLDSig-signed subtree in the artifact model: canonicalize with
+Exclusive C14N, hash the canonical bytes as the artifact's canonical
+payload hash, and attach dimension co-signatures over that hash. The
+JCS layer is used only for the *self-description* around the payload,
+never for the payload itself. See the
+[adoption guide](/docs/signatif/adoption-guide) step 3.
+
+## 3. Algorithms and migration phase
+
+Declare the active set and the phase (`classical_only`, `composite`,
+`post_quantum_only`) in the manifest. Algorithm lifecycle is
+registry-driven: `Active` signs and verifies; `Deprecated` downgrades
+the classification label during your migration window; `Retired`
+hard-fails.
+
+| Choice | Options | Confium |
+|---|---|---|
+| Classical | Ed25519, ECDSA-P256 | every surface's verifier fleet |
+| Post-quantum | ML-DSA-65, SLH-DSA-128s | `confium_composite::pq` (features `pq`, `pq-slh`) |
+| Composite | classical∧PQC, PQC-only | `confium_composite::transition_verifier` |
+
+## 4. Trust dimensions and your registry
+
+The eight registered dimensions (data, person, time, location,
+environment, authorization, identity, oracle) cover common ground;
+your scheme registers extensions (e.g. `cnml:instrument-class`) in a
+**scheme-maintained registry** that you publish. See the
+[registry publication convention](/docs/signatif/registry).
+
+| Choice | Confium |
+|---|---|
+| Which dimensions your artifacts attest | `DimensionTag` per co-signature block |
+| Your registry values | `Registry` + `register_dimension` / published JSON |
+| Scheme-specific scope dimensions | `ScopeDimensions::extra` (extensible, ignored by verifiers that don't know them) |
+| Executable scope conditions | `confium_signatif::conditions` (JSON Logic subset, hard check) |
+
+## 5. Policies
+
+Two layers, two owners. The **classification policy** is the scheme's
+pure function from coverage report to label (the reference ladder —
+`unverified → basic → verified → attested → certified` — ships as
+`ReferenceClassificationPolicy`; replace it with your own `ClassificationPolicy`
+implementation). The **acceptance policy** is each verifier's risk
+posture: which labels it accepts, per decision context
+(`AcceptancePolicy`).
+
+## What Confium never decides for you
+
+Registry contents, payload schemas, classification labels and their
+semantics, topology shape, and governance. Those are yours; the
+framework and this implementation keep them open.

--- a/docs/signatif/quickstarts/browser.mdx
+++ b/docs/signatif/quickstarts/browser.mdx
@@ -1,0 +1,52 @@
+---
+title: "Quickstart: verify in the browser"
+description: Verify a SIGNATIF trusted artifact in a browser or Node.js with @confium/confium-wasm — no phone-home, everything runs client-side.
+audience: devsecops
+---
+
+# Quickstart: verify in the browser
+
+The wasm package runs the full pipeline client-side: hard checks,
+coverage report, classification, acceptance — against a trust anchor
+bundle your app ships or caches.
+
+```sh
+npm install @confium/confium-wasm
+```
+
+```js
+import init, { verifyTrustedArtifact } from "@confium/confium-wasm";
+
+await init();
+
+const result = JSON.parse(await verifyTrustedArtifact(
+  artifactJson,   // the trusted artifact
+  bundleJson,     // the signed trust anchor bundle
+  graphJson,      // the trust graph (nodes + delegation edges)
+  registryJson,   // your scheme's published registry
+  JSON.stringify({
+    transparency_included: true,
+    time_anchored: true,
+    time_attested_at: attestation.attested_at, // from a verified time authority
+    accepted_labels: ["verified", "attested"],
+  }),
+));
+
+if (result.accept) {
+  console.log(result.label, result.coverage.dimensions_verified);
+} else {
+  console.error(result.label, result.coverage.downgrades);
+}
+```
+
+Tampered payloads hard-fail with an error naming the failing check;
+rejections return the `rejected` label. Build with
+`verify-signatif` for the tree-shaking profile:
+
+```sh
+wasm-pack build crates/confium-wasm --target web --features verify-signatif
+```
+
+The verifier fleet covers Ed25519 and ECDSA-P256; threshold aggregate
+and post-quantum verification are server-side concerns — use the
+[HTTP quickstart](/docs/signatif/quickstarts/http) for those.

--- a/docs/signatif/quickstarts/cli.mdx
+++ b/docs/signatif/quickstarts/cli.mdx
@@ -1,0 +1,37 @@
+---
+title: "Quickstart: verify on the command line"
+description: confium verify signatif — the operator surface for the full SIGNATIF pipeline.
+audience: security-engineer, devsecops
+---
+
+# Quickstart: verify on the command line
+
+```sh
+confium verify signatif \
+  --artifact cnml-cert.json \
+  --bundle nmi-bundle.json \
+  --graph nmi-graph.json \
+  --registry cnml-registry.json \
+  --accept verified,attested \
+  --transparency --time \
+  --time-attested-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+The command prints the coverage report and decision:
+
+```json
+{
+  "label": "attested",
+  "accept": true,
+  "coverage": {
+    "hard_checks": "pass",
+    "dimensions_verified": ["data", "person"],
+    "paths_found": 2,
+    "downgrades": []
+  }
+}
+```
+
+Exit codes: `0` accepted, `2` rejected (with the report printed),
+`1` usage or input error. `--registry` is optional (default registry
+values). The fleet verifies Ed25519 and ECDSA-P256 components.

--- a/docs/signatif/quickstarts/http.mdx
+++ b/docs/signatif/quickstarts/http.mdx
@@ -1,0 +1,56 @@
+---
+title: "Quickstart: verify over HTTP"
+description: POST a trusted artifact to confium-verify-server and get the coverage report, label, and acceptance decision back.
+audience: devsecops
+---
+
+# Quickstart: verify over HTTP
+
+Run the service and POST the four framework objects:
+
+```sh
+confium-verify-server --addr 127.0.0.1 --port 8082
+```
+
+```sh
+curl -s http://127.0.0.1:8082/verify/signatif \
+  -H 'content-type: application/json' \
+  -d @request.json | jq
+```
+
+```json
+{
+  "artifact":  { "...": "trusted artifact" },
+  "bundle":    { "...": "trust anchor bundle" },
+  "graph":     { "...": "trust graph" },
+  "registry":  { "...": "your published scheme registry" },
+  "options": {
+    "transparency_included": true,
+    "time_anchored": true,
+    "time_attested_at": "2026-08-18T09:00:00Z",
+    "accepted_labels": ["verified", "attested"]
+  }
+}
+```
+
+Response — the graduated outcome:
+
+```json
+{
+  "label": "attested",
+  "accept": true,
+  "coverage": {
+    "hard_checks": "pass",
+    "transparency_included": true,
+    "time_anchored": true,
+    "dimensions_verified": ["data", "person"],
+    "independent_roots": 1,
+    "paths_found": 2,
+    "downgrades": []
+  }
+}
+```
+
+Hard failures return `422` with `label: "rejected"` and the failing
+check named in `error`. The registry field is optional — omit it to
+use Confium's initial registry values.

--- a/docs/signatif/quickstarts/python.mdx
+++ b/docs/signatif/quickstarts/python.mdx
@@ -1,0 +1,34 @@
+---
+title: "Quickstart: verify from Python"
+description: The confium.signatif module — the full pipeline from Python, returning coverage, label, and acceptance.
+audience: devsecops
+---
+
+# Quickstart: verify from Python
+
+```sh
+pip install confium
+```
+
+```python
+from confium import signatif
+
+result = signatif.verify_trusted_artifact(
+    artifact,   # dict: the trusted artifact
+    bundle,     # dict: the trust anchor bundle
+    graph,      # dict: the trust graph
+    registry=cnml_registry,          # dict or None for defaults
+    transparency_included=True,
+    time_anchored=True,
+    time_attested_at="2026-08-18T09:00:00Z",
+    accepted_labels=["verified", "attested"],
+)
+
+if result["accept"]:
+    print(result["label"], result["coverage"]["dimensions_verified"])
+```
+
+Malformed inputs raise `ValueError` naming the offending object;
+hard-check failures raise `ValueError` naming the failing check.
+See also the [HTTP quickstart](/docs/signatif/quickstarts/http) for a
+service without the native extension.

--- a/docs/signatif/quickstarts/rust.mdx
+++ b/docs/signatif/quickstarts/rust.mdx
@@ -1,0 +1,46 @@
+---
+title: "Quickstart: verify from Rust"
+description: The confium-signatif pipeline from Rust — the reference surface every other quickstart wraps.
+audience: security-engineer
+---
+
+# Quickstart: verify from Rust
+
+```sh
+cargo add confium-signatif
+```
+
+```rust
+use confium_signatif::coverage::AcceptancePolicy;
+use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
+use confium_signatif::revocation::NoRevocations;
+
+let pipe = Pipeline::new(
+    &bundle,   // TrustAnchorBundle
+    &graph,    // TrustGraph
+    &registry, // Registry (yours or the initial values)
+    &verifier, // your SignatureVerifier fleet
+    &NoRevocations,
+    TransparencyInputs {
+        artifact_included: true,
+        time_anchored: true,
+        time_attested_at: Some(attestation.attested_at),
+        ..Default::default()
+    },
+    &AcceptancePolicy::accept(&["verified", "attested"]),
+);
+
+match pipe.run(&artifact, chrono::Utc::now()) {
+    Ok(outcome) if outcome.accept => {
+        println!("{} {:?}", outcome.label.0, outcome.report.dimensions_verified);
+    }
+    Ok(outcome) => println!("rejected: {}", outcome.label.0),
+    Err(hard) => eprintln!("hard check failed: {hard}"),
+}
+```
+
+Bring your own `SignatureVerifier` to widen the fleet (threshold
+aggregates, ML-DSA/SLH-DSA through `confium-composite`'s features),
+or take `confium-verify --features signatif` for the product facade.
+The complete runnable version — issuance included — is
+`crates/confium-signatif/examples/cnml_profile.rs`.

--- a/docs/signatif/registry.mdx
+++ b/docs/signatif/registry.mdx
@@ -1,0 +1,62 @@
+---
+title: "Publishing your scheme registry"
+description: The Annex C publication convention — your scheme publishes registry.json at a stable URL and every verification surface loads the same bytes.
+audience: security-engineer, devsecops
+---
+
+# Publishing your scheme registry
+
+Signatif's Annex C requires each scheme to **maintain and publish**
+its five registries (trust dimensions, algorithms, ceremony types,
+format profiles, scope dimensions) at "a publicly accessible location".
+Confium implements that as a single deterministic JSON document:
+
+- **Format**: the JSON serialization of `confium_signatif::Registry`
+  (deterministic — `publication_bytes()` produces the JCS form, so
+  every publish of the same registry yields identical bytes).
+- **Location**: your scheme publishes `registry.json` at a stable URL
+  you control (e.g. `https://cnml.example/signatif/registry.json`).
+  Distribute the URL through your deployment manifest and docs;
+  out-of-band distribution (bundled files, fingerprints) works
+  identically, since the registry is self-describing.
+- **Integrity**: like any trust input, pair publication with a
+  fingerprint (SHA-256 of the published bytes) wherever your threat
+  model needs it — in the manifest, the anchor bundle, or your docs.
+
+## Authoring
+
+```rust
+use confium_signatif::registry::Registry;
+
+let mut registry = Registry::with_initial_values();
+registry.register_dimension("cnml:instrument-class", "CNML instrument classification");
+// … algorithm status transitions, ceremony types, format profiles …
+
+std::fs::write("registry.json", registry.publication_bytes()?)?;
+```
+
+## Loading on every surface
+
+Rust:
+
+```rust
+let bytes = client.get(REGISTRY_URL).send().await?.bytes().await?;
+let registry = Registry::from_published_bytes(&bytes)?;
+```
+
+The other four surfaces take the same document as JSON — pass the
+parsed object as the `registry` input to
+[verifyTrustedArtifact (browser)](/docs/signatif/quickstarts/browser),
+[POST /verify/signatif (HTTP)](/docs/signatif/quickstarts/http),
+[confium verify signatif --registry (CLI)](/docs/signatif/quickstarts/cli),
+or [signatif.verify_trusted_artifact (Python)](/docs/signatif/quickstarts/python).
+Omit it to fall back to Confium's initial registry values.
+
+## Lifecycle
+
+Algorithm entries carry a status — `active`, `deprecated`, `retired` —
+and the [deprecation process](/docs/signatif/decisions) is enforced
+from the registry you publish: deprecated algorithms downgrade the
+classification label, retired ones hard-fail. Changing a status is a
+registry republication, not a code change; publish with a dated commit
+and record the rationale your registration policy requires.


### PR DESCRIPTION
## What

The Signatif adoption story for Confium users (TODOs 33-37 of the local plan). Positioning throughout: Signatif is the framework, the scheme owns the decisions, Confium is one implementation of every option.

- **decisions.mdx** — "Decisions your scheme makes": the five decision points (topology, format profile, algorithms + migration phase, dimensions + registry, policies), each option mapped to its Confium module and conformance class. Includes the legacy-XMLDSig subsection for CNML-style XML estates: C14N bytes as the canonical payload, JCS only for the self-description.
- **Five quickstarts** — browser (wasm verifyTrustedArtifact), HTTP (POST /verify/signatif), CLI (confium verify signatif), Python, Rust — copy-paste length, derived from the tested examples.
- **adoption-guide.mdx as the spine** — each step now marks its decision fork linking to the decisions page, plus a "verify anywhere" section linking all five quickstarts.
- **conformance.mdx** — the 24-class claim table generated from conformance_claims(); `cargo run --example conformance_page` regenerates it, and a new CI test (conformance_page_matches_docs) asserts the committed page matches the code — the claim cannot silently drift. Spec-revision stamped.
- **registry.mdx + Registry::from_published_bytes** — the Annex C publication convention: schemes publish deterministic registry.json at a stable URL; loading shown for all five surfaces. Round-trip test added.

76 unit + 12 ATS tests green; clippy -D warnings clean.
