### PR TITLE
chore(ci): drop semver-checks exclusions now that every crate is published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,7 @@ jobs:
           tool: cargo-semver-checks
 
       - name: Check semver compatibility
-        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-verify-server --exclude confium-signatif --exclude confium-store-tpm --exclude confium-store-pkcs11 --exclude confium-tc-ml-kem --exclude confium-tc-fhe-bfv --exclude confium-tc-bls --exclude confium-tc-frost-ml-dsa-65 --exclude confium-verify --exclude confium-store-openpgp-card --exclude confium-tc
+        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }}
 
   # ============================================================================
   # Summary


### PR DESCRIPTION
## Summary

- The eleven `--exclude` flags on the `cargo semver-checks` line existed only because those crates had never been published, so no registry baseline existed to check against.
- The v0.5.0 release has now published every crate (all at 0.5.0 on crates.io), so the entire exclude list is removed and every crate gets a real semver baseline.

## Test plan

- [x] Verified each previously excluded crate returns 200 from the crates.io API at version 0.5.0
- [ ] `Semver Compatibility` job green on this PR with the unexcluded command
