### PR TITLE
fix(ci): exclude confium-store-tpm from semver-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,7 +358,12 @@ jobs:
           tool: cargo-semver-checks
 
       - name: Check semver compatibility
-        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }}
+        # confium-store-tpm is excluded because its `tpm` feature pulls
+        # tss-esapi-sys, whose build script cannot build on CI runners
+        # (no TSS system libraries / unsupported target tuple). The
+        # crate publishes; its semver baseline just cannot be built
+        # there.
+        run: cargo semver-checks --baseline-rev origin/${{ github.base_ref }} --exclude confium-store-tpm
 
   # ============================================================================
   # Summary


### PR DESCRIPTION
## Summary

- Removing the whole semver-checks exclude list in #245 exposed a second reason part of it existed: `cargo semver-checks` builds every crate with all features, and `confium-store-tpm`'s `tpm` feature pulls `tss-esapi-sys`, whose build script cannot run on CI runners (no TSS system libraries; unsupported target tuple on some hosts).
- Re-add the single `--exclude confium-store-tpm`; every other crate keeps its real baseline check. Verified locally that the other feature-heavy crates (store-pkcs11, store-openpgp-card, sandbox-*, pkcs11-server, openssl-provider, jce-provider) build all-features rustdoc fine.

## Test plan

- [x] `cargo doc -p <crate> --all-features --no-deps` OK for the eight other feature-heavy crates
- [x] `cargo semver-checks -p confium-store-tpm` reproduces the exact CI failure (tss-esapi-sys build panic)
- [ ] Semver Compatibility job green on this PR
