### PR TITLE
fix(ci): use snake_case inputs for first-interaction v3

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/first-interaction@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: |
+          pr_message: |
             👋 Thanks for opening your first PR on Confium!
 
             A maintainer will review this soon. In the meantime:
@@ -31,7 +31,7 @@ jobs:
             - If this is a non-trivial change, consider linking to a spec or design discussion
 
             We're glad you're here.
-          issue-message: |
+          issue_message: |
             👋 Thanks for your first issue on Confium!
 
             A maintainer will triage this within a few days. If it's urgent, ping us in [Discussions](https://github.com/confium/confium/discussions).


### PR DESCRIPTION
## Summary

- The actions group bump (#210) upgraded actions/first-interaction v1 → v3, which renamed `pr-message`/`issue-message` to `pr_message`/`issue_message` and made them required.
- The welcome job has failed on every PR since ("Input required and not supplied: issue_message"). Rename the inputs.

## Test plan

- [x] Diff is exactly the two input renames
- [ ] welcome job green on this PR
