### PR TITLE
feat(cli): add keyless configure placeholder

### DIFF
--- a/crates/confium-cli/src/cli.rs
+++ b/crates/confium-cli/src/cli.rs
@@ -287,6 +287,9 @@ pub enum KeylessCommand {
     Sign,
     /// Verify a keyless signature (placeholder).
     Verify,
+    /// Configure the keyless workflow (OIDC issuer and subject allowlists;
+    /// placeholder until the config file format lands).
+    Configure,
 }
 
 /// Subcommands under `confium privacy`.

--- a/crates/confium-cli/src/commands/keyless.rs
+++ b/crates/confium-cli/src/commands/keyless.rs
@@ -11,6 +11,11 @@ pub fn run(cmd: KeylessCommand) {
         KeylessCommand::Verify => {
             eprintln!("confium keyless verify: coming soon — see https://www.confium.org/keyless/")
         }
+        KeylessCommand::Configure => {
+            eprintln!(
+                "confium keyless configure: coming soon — the OIDC issuer/subject allowlist format is being finalized; see https://www.confium.org/keyless/"
+            )
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds the `confium keyless configure` subcommand (placeholder handler until the OIDC issuer/subject allowlist format lands), completing the final acceptance criterion of the product-umbrella CLI work (TODO.restructure/31).
- All six umbrellas now match the spec: `confium keyless --help` lists version, sign, verify, configure.

## Test plan

- [x] `confium keyless --help` lists the full subcommand set
- [x] `cargo test -p confium-cli` — 31 tests pass
- [ ] CI green
