### PR TITLE
docs: per-product concepts/how-to/reference trees

### DIFF
--- a/docs/keyless/concepts/ephemeral-keys.mdx
+++ b/docs/keyless/concepts/ephemeral-keys.mdx
@@ -1,0 +1,18 @@
+---
+title: "Ephemeral keys"
+description: "Each signing run generates a fresh key, uses it once, and throws it away."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Ephemeral keys
+
+In the keyless model a signing job generates an ephemeral key pair,
+signs the artifact, and immediately discards the private half. The
+*commitment* that makes the signature meaningful long-term is the
+threshold CA's countersignature binding that ephemeral public key to
+the OIDC identity — recorded with an expiry so the identity, not the
+key, is what verifiers track.
+
+Nothing secret persists between releases; there is no key rotation
+ceremony because there is no key to rotate.

--- a/docs/keyless/concepts/oidc-identity.mdx
+++ b/docs/keyless/concepts/oidc-identity.mdx
@@ -1,0 +1,19 @@
+---
+title: "OIDC identity"
+description: "Why a release signer's identity is an OIDC token from your CI provider, not a long-lived key."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# OIDC identity
+
+Keyless signing removes the thing maintainers lose or leak: the
+long-lived signing key. Instead, the signer proves *who it is* with an
+OIDC token minted by the CI provider (GitHub Actions, GitLab, and
+others issue them natively). The token's issuer and subject — for a
+workflow, the repository and ref — become the signing identity, and a
+threshold CA countersigns only for allowlisted pairs.
+
+`confium-oidc` parses and validates these tokens. The trust decision
+(issuer + subject allowlists) is policy, not code — see
+[configure](../how-to/configure.mdx).

--- a/docs/keyless/concepts/threshold-backing.mdx
+++ b/docs/keyless/concepts/threshold-backing.mdx
@@ -1,0 +1,18 @@
+---
+title: "Threshold backing"
+description: "The keyless CA is itself a T-of-N Confium threshold key — no single operator can forge identities."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Threshold backing
+
+A keyless system concentrates trust in its CA. Confium backs that CA
+with the [Threshold product](../../threshold/): the identity key is a
+T-of-N threshold key shared by independent directors (maintainers,
+foundation, partner organizations). Forging a countersignature
+requires corrupting a quorum — a compromise of any single operator,
+including the CI provider account, is not enough.
+
+This is the same machinery as the [PKI product](../../pki/); keyless
+is the opinionated deployment of it for release signing.

--- a/docs/keyless/how-to/configure.mdx
+++ b/docs/keyless/how-to/configure.mdx
@@ -1,0 +1,23 @@
+---
+title: "Configure the allowlist"
+description: "Declare which CI issuer/subject pairs may obtain countersignatures."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Configure the allowlist
+
+Status: `confium keyless configure` is a placeholder. The intended
+shape:
+
+```toml
+# keyless.toml (draft)
+[[allow]]
+issuer   = "https://token.actions.githubusercontent.com"
+subject  = "repo:org/repo:ref:refs/tags/v*"
+```
+
+The allowlist lives with the threshold CA's deployment manifest, so
+changing it is a director-governed action — a compromised maintainer
+account cannot widen it unilaterally. Track the final format in the
+[product docs](https://www.confium.org/keyless/).

--- a/docs/keyless/how-to/sign-release.mdx
+++ b/docs/keyless/how-to/sign-release.mdx
@@ -1,0 +1,20 @@
+---
+title: "Sign a release"
+description: "Sign a release artifact keylessly from CI."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Sign a release
+
+Status: the `confium keyless sign` surface is a placeholder while the
+allowlist format is finalized; today the flow runs through the
+[GitHub Action](https://github.com/confium/action), which:
+
+1. Exchanges the workflow's OIDC token for a countersignature from
+   the threshold CA.
+2. Generates the ephemeral key and signs the artifact digest.
+3. Attaches the identity + countersignature bundle to the release.
+
+Manual runs will mirror this via `confium keyless sign` once the
+`configure` surface (see [configure](./configure.mdx)) lands.

--- a/docs/keyless/how-to/verify-release.mdx
+++ b/docs/keyless/how-to/verify-release.mdx
@@ -1,0 +1,23 @@
+---
+title: "Verify a release"
+description: "Check a downloaded artifact against its keyless identity."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Verify a release
+
+Status: `confium keyless verify` is a placeholder; verification today
+works through the same surfaces as every other Confium signature:
+
+```sh
+confium verify composite \
+  --message @artifact.tar.gz \
+  --signature bundle.cose \
+  --algorithm ed25519 \
+  --public-key ephemeral-pk.hex
+```
+
+plus an allowlist check of the bundle's OIDC issuer/subject against
+your project's policy. Browsers and CI can do the same via
+`@confium/confium-wasm` (see the [Verify product](../../verify/)).

--- a/docs/keyless/index.mdx
+++ b/docs/keyless/index.mdx
@@ -44,6 +44,16 @@ Practical recipes live in the [Cookbook](../cookbook/):
 - [Keyless flow spec](https://www.confium.org/specs/91-keyless-flow)
 - [Short-lived cert spec](https://www.confium.org/specs/92-short-lived-cert)
 
+## In this section
+
+- [Concepts](./concepts/) — [OIDC identity](./concepts/oidc-identity.mdx),
+  [ephemeral keys](./concepts/ephemeral-keys.mdx),
+  [threshold backing](./concepts/threshold-backing.mdx)
+- [How-to](./how-to/) — [sign a release](./how-to/sign-release.mdx),
+  [verify a release](./how-to/verify-release.mdx),
+  [configure the allowlist](./how-to/configure.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx)

--- a/docs/keyless/reference/cli.mdx
+++ b/docs/keyless/reference/cli.mdx
@@ -1,0 +1,19 @@
+---
+title: "Keyless CLI reference"
+description: "The confium keyless subcommand tree."
+product: keyless
+audience: oss-maintainer, devsecops
+---
+
+# Keyless CLI reference
+
+| Subcommand | Purpose |
+|---|---|
+| `confium keyless version` | Product + component crate versions |
+| `confium keyless sign` | Keyless sign (placeholder) |
+| `confium keyless verify` | Verify a keyless bundle (placeholder) |
+| `confium keyless configure` | Manage issuer/subject allowlists (placeholder) |
+
+Crates: `confium-oidc`. GitHub Action:
+<https://github.com/confium/action>. Product docs:
+<https://www.confium.org/keyless/>.

--- a/docs/pki/concepts/composite-signatures.mdx
+++ b/docs/pki/concepts/composite-signatures.mdx
@@ -1,0 +1,22 @@
+---
+title: "Composite signatures for PQC migration"
+description: "Sign with a classical AND a post-quantum algorithm at once, and migrate verifiers gradually."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# Composite signatures for PQC migration
+
+A composite signature carries two components — e.g. Ed25519 and
+ML-DSA-65 — over the same payload in one verifiable envelope
+(COSE-encoded). During migration:
+
+1. **Classical-only verifiers** keep working (they check the
+   component they know).
+2. **Hybrid verifiers** require both.
+3. When the classical algorithm is retired, hybrid keys downgrade
+   gracefully to the post-quantum component per your policy — the
+   registry's `deprecated`/`retired` statuses drive this.
+
+Crates: `confium-composite` (envelopes + verifiers) and
+`confium-composite::transition_verifier` (policy-driven checking).

--- a/docs/pki/concepts/legacy-xml.mdx
+++ b/docs/pki/concepts/legacy-xml.mdx
@@ -1,0 +1,21 @@
+---
+title: "Legacy XML and XMLDSig"
+description: "Bringing an existing XMLDSig estate into the artifact model without rewriting payloads."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# Legacy XML and XMLDSig
+
+Existing XML estates (metrology and OASIS-style document families)
+do not need to migrate payloads to JSON. The bridge:
+
+1. Canonicalize the signed subtree with Exclusive C14N
+   (`confium-pki::xmldsig`).
+2. Hash the canonical bytes — that hash *is* the artifact's payload
+   hash.
+3. Attach composite/threshold co-signatures over that hash; the
+   self-description layer wraps the payload without altering it.
+
+The original XMLDSig signature keeps verifying with legacy tooling
+while the threshold layer adds multi-stakeholder assurance on top.

--- a/docs/pki/concepts/threshold-ca.mdx
+++ b/docs/pki/concepts/threshold-ca.mdx
@@ -1,0 +1,24 @@
+---
+title: "A CA without a single trusted key"
+description: "Threshold PKI: issuance and revocation gated by a quorum instead of one HSM slot."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# A CA without a single trusted key
+
+A conventional CA concentrates its trust in one key — usually one HSM
+slot. Confium's PKI product replaces that with a *threshold* key:
+issuance requests are satisfied only when T of N directors
+participate, so a single compromised operator, HSM, or site cannot
+mint certificates.
+
+- **Issuance**: CSR in, threshold-signed certificate out — the
+  resulting certificate is an ordinary X.509 object.
+- **Revocation**: CRLs and OCSP responses are themselves
+  threshold-signed artifacts.
+- **Policy as code**: the deployment manifest declares who the
+  directors are, the quorum, and scope constraints.
+
+See [run the PKCS#11 bridge](../how-to/run-pkcs11-server.mdx) for
+wiring existing PKI software to the threshold backend.

--- a/docs/pki/how-to/composite-sign.mdx
+++ b/docs/pki/how-to/composite-sign.mdx
@@ -1,0 +1,23 @@
+---
+title: "Produce a composite signature"
+description: "Sign a message with classical + post-quantum-style components via the pki umbrella."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# Produce a composite signature
+
+```sh
+confium pki composite-sign \
+  --message @document.bin \
+  --ed25519-key ed.hex \
+  --p256-key ec.pem \
+  --out composite.hex
+```
+
+- `--message` accepts a literal or `@file` for exact file bytes.
+- The envelope is COSE-encoded; both components cover the same
+  payload, so classical-only verifiers keep working during migration
+  (see [composite signatures](../concepts/composite-signatures.mdx)).
+- Verify with `confium verify composite --message ... --signature
+  composite.hex --algorithm ed25519 --public-key pk.hex`.

--- a/docs/pki/how-to/run-pkcs11-server.mdx
+++ b/docs/pki/how-to/run-pkcs11-server.mdx
@@ -1,0 +1,20 @@
+---
+title: "Run the PKCS#11 bridge"
+description: "Expose the threshold key store to PKCS#11 applications."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# Run the PKCS#11 bridge
+
+`confium-pkcs11-server` implements PKCS#11 v3.0 against the threshold
+key store, so existing applications (TLS terminations, HSM-aware
+CLIs) work without code changes.
+
+1. Configure the deployment manifest (directors, quorum, key scope).
+2. Start the server; it exposes a PKCS#11 module.
+3. Point the application at the module path (for OpenSC tooling:
+   `PKCS11_MODULE_PATH=... pkcs11-tool --list-slots`).
+
+Signing through the slot transparently convenes the threshold quorum;
+the application sees a normal private-key object.

--- a/docs/pki/how-to/use-openssl-provider.mdx
+++ b/docs/pki/how-to/use-openssl-provider.mdx
@@ -1,0 +1,21 @@
+---
+title: "Use the OpenSSL provider"
+description: "Let OpenSSL 3.x sign and verify through Confium."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# Use the OpenSSL provider
+
+`confium-openssl-provider` registers as an OpenSSL 3.0 provider, so
+`openssl` CLI and any OpenSSL-linked application can use threshold
+keys.
+
+```sh
+OPENSSL_MODULES=/path/to/providers openssl list -providers
+openssl pkey -provider confium -in confium://threshold/root
+```
+
+Verify with `openssl verify` as usual — outputs are standard X.509
+and standard signatures. The provider never exposes share material;
+every operation is a threshold ceremony under the hood.

--- a/docs/pki/index.mdx
+++ b/docs/pki/index.mdx
@@ -43,6 +43,16 @@ signing.
 - [Composite signatures spec](https://www.confium.org/specs/82-composite-signatures)
 - [PKCS#11 server spec](https://www.confium.org/specs/83-pkcs11-server)
 
+## In this section
+
+- [Concepts](./concepts/) — [threshold CA](./concepts/threshold-ca.mdx),
+  [composite signatures](./concepts/composite-signatures.mdx),
+  [legacy XML](./concepts/legacy-xml.mdx)
+- [How-to](./how-to/) — [run the PKCS#11 bridge](./how-to/run-pkcs11-server.mdx),
+  [use the OpenSSL provider](./how-to/use-openssl-provider.mdx),
+  [produce a composite signature](./how-to/composite-sign.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx)

--- a/docs/pki/reference/cli.mdx
+++ b/docs/pki/reference/cli.mdx
@@ -1,0 +1,19 @@
+---
+title: "PKI CLI reference"
+description: "The confium pki subcommand tree."
+product: pki
+audience: ca-operator, security-engineer, platform-engineer
+---
+
+# PKI CLI reference
+
+| Subcommand | Purpose |
+|---|---|
+| `confium pki parse-cert` | Parse an X.509 certificate (DER or PEM) |
+| `confium pki verify` | Verify a certificate chain (leaf + intermediates + anchor) |
+| `confium pki composite-sign` | Sign with classical + PQ components in one envelope |
+
+Related: `confium verify cert-chain` mirrors `pki verify` under the
+[Verify product](../../verify/). Run `confium pki --help` for the full
+argument list. Product docs: <https://www.confium.org/pki/>. API
+reference: [docs.rs/confium-pki](https://docs.rs/confium-pki).

--- a/docs/privacy/concepts/differential-privacy.mdx
+++ b/docs/privacy/concepts/differential-privacy.mdx
@@ -1,0 +1,19 @@
+---
+title: "Differential privacy"
+description: "Adding calibrated noise so a released statistic protects the individuals inside it."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Differential privacy
+
+A differentially private mechanism releases a statistic with enough
+noise that any single individual's presence changes the output
+distribution by at most a factor of e^epsilon. Choosing epsilon is a
+governance decision: smaller epsilon = stronger privacy = noisier
+results; the *sensitivity* of the query (how much one record can move
+the result) scales the noise.
+
+Confium ships Laplace and Gaussian mechanisms in `confium-privacy`
+(`confium privacy dp --value ... --sensitivity ... --epsilon ...`).
+Track budgets across releases — privacy loss composes.

--- a/docs/privacy/concepts/mpc.mdx
+++ b/docs/privacy/concepts/mpc.mdx
@@ -1,0 +1,20 @@
+---
+title: "Secure computation (MPC/OT)"
+description: "Computing on secret-shared inputs so no party sees another's data."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Secure computation (MPC and OT)
+
+Multi-party computation lets N parties jointly evaluate a function
+over secret-shared inputs: each party holds a share of every input,
+the protocol computes shares of the output, and nobody learns more
+than the revealed result. Oblivious transfer (OT) is the fundamental
+building block many protocols reduce to.
+
+`confium-privacy` provides the toolkit — secret sharing, OT, secure
+aggregation, threshold decryption — used to compose such flows. The
+MPC orchestration surface (`confium privacy mpc`) is a placeholder
+while multi-process transport integration lands; the primitives are
+available from Rust today.

--- a/docs/privacy/concepts/psi.mdx
+++ b/docs/privacy/concepts/psi.mdx
@@ -1,0 +1,19 @@
+---
+title: "Private set intersection"
+description: "Two parties learn the intersection of their sets — and nothing else."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Private set intersection (PSI)
+
+PSI answers "which entries do our sets share?" without either side
+learning the non-matching entries. The classic construction blinds
+each side's entries with a commutative hash/ECDH transformation, so
+only items present in both sets produce comparable outputs.
+
+Confium's `confium-privacy` ships a PSI surface (the CLI demo uses
+salted hashing; the ECDH variant is the production path). Typical
+uses: contact discovery, fraud-list checks, ad conversion
+measurement. When the *cardinality* is enough, prefer cardinality-only
+mode — it leaks less.

--- a/docs/privacy/how-to/dp-noise.mdx
+++ b/docs/privacy/how-to/dp-noise.mdx
@@ -1,0 +1,19 @@
+---
+title: "Add calibrated DP noise"
+description: "Release a statistic with an explicit epsilon budget."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Add calibrated DP noise
+
+```sh
+confium privacy dp --value 1337.0 --sensitivity 1.0 --epsilon 0.5
+confium privacy dp --value 88.1 --sensitivity 10 --epsilon 0.1 \
+  --distribution gaussian --delta 0.00001
+```
+
+- Laplace is the default and needs only epsilon; Gaussian adds delta
+  and suits higher-sensitivity queries.
+- Log (value, sensitivity, epsilon, delta) with every release — the
+  privacy budget composes across releases and auditors will ask.

--- a/docs/privacy/how-to/psi-cli.mdx
+++ b/docs/privacy/how-to/psi-cli.mdx
@@ -1,0 +1,22 @@
+---
+title: "Run a PSI intersection"
+description: "Intersect two sets from the CLI with cardinality-only as the low-leak option."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Run a PSI intersection
+
+```sh
+confium privacy psi \
+  --set-a customers.txt \
+  --set-b watchlist.txt \
+  --cardinality-only
+```
+
+- Inputs are one entry per line; pre-hash them upstream if entries
+  are sensitive in your environment.
+- `--cardinality-only` prints just the count — the default minimum
+  when you only need "how much overlap".
+- `--salt` overrides the default salt source (`/dev/urandom`) for
+  reproducible test runs; never fix a salt in production.

--- a/docs/privacy/how-to/ring-signatures.mdx
+++ b/docs/privacy/how-to/ring-signatures.mdx
@@ -1,0 +1,17 @@
+---
+title: "Sign with a ring signature"
+description: "Sign while hiding which member of a group produced the signature."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Sign with a ring signature
+
+A ring signature proves "some member of this group signed" without
+revealing which — useful for whistleblowing, anonymous credentials,
+and blockchain privacy. Confium's `confium-ring` ships the threshold
+ring-signature construction (a T-of-N subgroup can jointly produce a
+ring signature without any single member being identifiable).
+
+The CLI surface for rings is part of the privacy umbrella's planned
+expansion; consume `confium-ring` from Rust today.

--- a/docs/privacy/index.mdx
+++ b/docs/privacy/index.mdx
@@ -46,6 +46,16 @@ Practical recipes live in the [Cookbook](../cookbook/):
 - [DP spec](https://www.confium.org/specs/33-differential-privacy)
 - [Ring sigs spec](https://www.confium.org/specs/34-ring-sigs)
 
+## In this section
+
+- [Concepts](./concepts/) — [PSI](./concepts/psi.mdx),
+  [differential privacy](./concepts/differential-privacy.mdx),
+  [MPC/OT](./concepts/mpc.mdx)
+- [How-to](./how-to/) — [run PSI](./how-to/psi-cli.mdx),
+  [add DP noise](./how-to/dp-noise.mdx),
+  [ring signatures](./how-to/ring-signatures.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx)

--- a/docs/privacy/reference/cli.mdx
+++ b/docs/privacy/reference/cli.mdx
@@ -1,0 +1,17 @@
+---
+title: "Privacy CLI reference"
+description: "The confium privacy subcommand tree."
+product: privacy
+audience: privacy-engineer, researcher, app-developer
+---
+
+# Privacy CLI reference
+
+| Subcommand | Purpose |
+|---|---|
+| `confium privacy psi` | Intersect two sets (`--set-a`, `--set-b`, `--cardinality-only`) |
+| `confium privacy dp` | Apply Laplace/Gaussian noise (`--value`, `--sensitivity`, `--epsilon`) |
+| `confium privacy mpc` | MPC orchestration (placeholder) |
+
+Product docs: <https://www.confium.org/privacy/>. API reference:
+[docs.rs/confium-privacy](https://docs.rs/confium-privacy).

--- a/docs/threshold/concepts/dkg.mdx
+++ b/docs/threshold/concepts/dkg.mdx
@@ -1,0 +1,24 @@
+---
+title: "Distributed key generation"
+description: "How a threshold key is born without ever existing in one place: Pedersen/Feldman VSS over two rounds."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Distributed key generation (DKG)
+
+DKG creates the threshold key. Each party samples a random polynomial
+and commits to it (Feldman VSS); the aggregate public key is the sum
+of all parties' constant-term commitments, and each party's share is
+the sum of the shares it received.
+
+1. **Round 1** — every party broadcasts its commitment list and sends
+   each peer a directed share of its polynomial.
+2. **Round 2** — each party verifies incoming shares against the
+   sender's commitments, rejects byzantine parties, and sums valid
+   fragments into its aggregate share.
+
+In Confium, `confium-tc-frost-ed25519` and `confium-tc-frost-p256`
+ship DKG sessions; the framework drives rounds via
+`confium-tc-core` sessions. For a working example see
+[run a local DKG](../how-to/local-dkg.mdx).

--- a/docs/threshold/concepts/mta.mdx
+++ b/docs/threshold/concepts/mta.mdx
@@ -1,0 +1,19 @@
+---
+title: "Multiplicative-to-additive (MtA)"
+description: "The Paillier-based MtA conversion that lets ECDSA threshold protocols multiply shares without revealing them."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Multiplicative-to-additive conversion (MtA)
+
+Threshold ECDSA protocols (GG18, CMP20) need to compute a product of
+two secrets without either party learning the other's value. The
+MtA trick uses Paillier homomorphic encryption: one party encrypts
+its share, the other multiplies the ciphertext by an additive mask,
+and a zero-knowledge range proof keeps everything in bounds.
+
+`confium-crypto-vss` ships the Paillier primitives (keygen,
+encryption, range proofs) used by the CMP20 and GG18 scheme crates.
+You rarely invoke MtA directly; it is listed here because it is the
+performance and security heart of threshold ECDSA.

--- a/docs/threshold/concepts/share-refresh.mdx
+++ b/docs/threshold/concepts/share-refresh.mdx
@@ -1,0 +1,20 @@
+---
+title: "Share refresh (proactive security)"
+description: "Herzberg refresh: periodically rerandomize shares so an attacker must compromise T parties within one refresh window."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Share refresh (proactive security)
+
+Share refresh (Herzberg 1995) replaces every share with a fresh
+randomization of the same underlying key. Each party generates random
+polynomials with zero constant term and distributes the deltas; after
+applying them, all parties hold new shares for the **same public key**,
+and old shares are useless — an adversary that collects shares slowly,
+across compromise windows, never reaches the threshold.
+
+Confium ships refresh sessions for the FROST crates and the
+`confium threshold refresh` CLI. Operational guidance: choose the
+refresh window from your containment SLA (e.g. quarterly), and always
+refresh after any suspected share exposure.

--- a/docs/threshold/concepts/threshold-signing.mdx
+++ b/docs/threshold/concepts/threshold-signing.mdx
@@ -1,0 +1,26 @@
+---
+title: "Threshold signing"
+description: "What T-of-N means: share generation, signing quorum, and why compromising T-1 parties is not enough."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Threshold signing
+
+A threshold signature scheme splits one logical key into N shares so
+that any T of them can produce a signature, while fewer than T learn
+nothing about the key. The produced signature is an *ordinary*
+signature: anyone with the public key and a standard verifier accepts
+it — no special tooling on the verifying side.
+
+- **T-of-N**: sign when at least T parties participate; the signature
+  is identical no matter *which* T participated.
+- **No reconstruction**: the secret key never exists in one place at
+  any point in the lifecycle — DKG, signing, refresh, and recovery all
+  operate on shares.
+- **Standard outputs**: CMP20/GG18 produce ECDSA-P256 signatures;
+  FROST-ed25519 produces RFC 8032 signatures verifiable by any
+  ed25519 library.
+
+See also [distributed key generation](./dkg.mdx) and
+[share refresh](./share-refresh.mdx).

--- a/docs/threshold/how-to/local-dkg.mdx
+++ b/docs/threshold/how-to/local-dkg.mdx
@@ -1,0 +1,25 @@
+---
+title: "Run a local 3-of-5 DKG"
+description: "Generate a 3-of-5 threshold key with the CLI and inspect the share envelope."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Run a local DKG
+
+Prerequisites: the [confium CLI](../../installation.mdx).
+
+```sh
+confium threshold dkg --scheme cmp20 --threshold 3 --parties 5 --out shares.json
+```
+
+The output is a JSON *share envelope*: the joint public key plus all
+five shares. In a real deployment each party keeps exactly one share
+and the envelope is never written to a shared file — see the scheme
+crates' session APIs (`confium-tc-frost-p256`) for per-party runs.
+
+Verify the envelope round-trips:
+
+```sh
+confium threshold sign --shares shares.json --message "hello" --out signature.hex
+```

--- a/docs/threshold/how-to/refresh-shares.mdx
+++ b/docs/threshold/how-to/refresh-shares.mdx
@@ -1,0 +1,22 @@
+---
+title: "Refresh shares"
+description: "Rerandomize all shares for the same public key using the CLI."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Refresh shares
+
+```sh
+confium threshold refresh --shares shares.json --out shares-new.json
+```
+
+The public key in `shares-new.json` is identical to the original;
+every share is different. Operationally:
+
+1. Schedule refresh on a calendar (see
+   [share refresh](../concepts/share-refresh.mdx) for window sizing).
+2. Treat the old envelope as compromised the moment refresh completes
+   and wipe it.
+3. Refresh is *not* recovery — a lost share needs the recovery flow
+   (threshold + 1 shares), which is currently in development.

--- a/docs/threshold/how-to/sign-message.mdx
+++ b/docs/threshold/how-to/sign-message.mdx
@@ -1,0 +1,18 @@
+---
+title: "Sign a message"
+description: "Produce a threshold signature from a share envelope with the CLI."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Sign a message
+
+```sh
+confium threshold sign --shares shares.json --message "payment:acct-9:f67a" --out signature.hex
+```
+
+- `--message` may be `@file` to sign a file's exact bytes.
+- The output is a standard DER-encoded ECDSA-P256 signature — verify
+  it with any ordinary verifier.
+- Signing consumes nonces; never reuse a share envelope's nonce state
+  across sessions (the scheme crates handle nonce derivation).

--- a/docs/threshold/index.mdx
+++ b/docs/threshold/index.mdx
@@ -69,6 +69,17 @@ Practical recipes live in the [Cookbook](../cookbook/):
 - [FROST-Ed25519 spec](https://www.confium.org/specs/72-frost-ed25519)
 - [ElGamal-P256 spec](https://www.confium.org/specs/54-elgamal-p256)
 
+## In this section
+
+- [Concepts](./concepts/) — [threshold signing](./concepts/threshold-signing.mdx),
+  [DKG](./concepts/dkg.mdx), [share refresh](./concepts/share-refresh.mdx),
+  [MtA](./concepts/mta.mdx)
+- [How-to](./how-to/) — [run a local DKG](./how-to/local-dkg.mdx),
+  [sign a message](./how-to/sign-message.mdx),
+  [refresh shares](./how-to/refresh-shares.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx),
+  [crates](./reference/crates.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx) — engine, plugin loader

--- a/docs/threshold/reference/cli.mdx
+++ b/docs/threshold/reference/cli.mdx
@@ -1,0 +1,20 @@
+---
+title: "Threshold CLI reference"
+description: "The confium threshold subcommand tree."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# `confium threshold` reference
+
+| Subcommand | Purpose |
+|---|---|
+| `version` | Product + component crate versions |
+| `dkg` | Generate a T-of-N key (`--scheme cmp20\|gg18`); writes a JSON share envelope |
+| `sign` | Sign a message from a share envelope |
+| `refresh` | Rerandomize shares (same public key) |
+| `recover` | Recover a lost share (in development) |
+| `migrate-shares` | Migrate 0.2.x share files to the 0.3+ envelope |
+
+Run `confium threshold <subcommand> --help` for the full argument
+list. Product docs: <https://www.confium.org/threshold/>.

--- a/docs/threshold/reference/crates.mdx
+++ b/docs/threshold/reference/crates.mdx
@@ -1,0 +1,23 @@
+---
+title: "Threshold crate reference"
+description: "Which crates make up the Threshold product and where their docs live."
+product: threshold
+audience: security-engineer, devsecops, blockchain-dev
+---
+
+# Threshold crates
+
+| Crate | Role |
+|---|---|
+| `confium-tc-core` | Session/share/registry primitives all schemes build on |
+| `confium-tc-cmp20` | CMP20 threshold ECDSA (P-256) |
+| `confium-tc-gg18` | GG18 threshold ECDSA (legacy interop) |
+| `confium-tc-frost-ed25519` | FROST over Ed25519 (DKG + signing) |
+| `confium-tc-frost-p256` | FROST over P-256 + Shamir + ECDSA |
+| `confium-crypto-vss` | VSS, Paillier, Schnorr, range proofs |
+| `confium-coordinator` | Coordinator service, WAL, transports |
+| `confium-tc-keys` | HSM/KMS share protection, threshold BIP32 |
+| `confium-signerd` | Production signing daemon (unpublished) |
+
+API docs: <https://docs.rs/confium-tc-core> and per-crate links from
+the [workspace map](../../workspace-map.mdx).

--- a/docs/transparency/concepts/anchoring.mdx
+++ b/docs/transparency/concepts/anchoring.mdx
@@ -1,0 +1,18 @@
+---
+title: "Timestamp anchoring (OTS)"
+description: "Bridging a log head to the Bitcoin blockchain for external time authentication."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Timestamp anchoring (OTS)
+
+A tree head only proves *ordering* relative to other entries. To
+prove *when* it existed, Confium anchors heads to the Bitcoin
+blockchain using the OpenTimestamps format: an OTS proof commits to
+the head hash, and Bitcoin's proof-of-work supplies an attested time
+bound.
+
+`confium-transparency` builds and verifies OTS proofs. Anchor cadence
+is your call: hourly anchoring is a common default; the proof size
+and verification cost do not depend on cadence.

--- a/docs/transparency/concepts/ers.mdx
+++ b/docs/transparency/concepts/ers.mdx
@@ -1,0 +1,18 @@
+---
+title: "Long-term archival (ERS)"
+description: "RFC 4998 evidence records: keeping signatures verifiable after algorithms age out."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Long-term archival (ERS)
+
+Signatures expire cryptographically: algorithms get broken and keys
+get retired. RFC 4998 Evidence Record Syntax chains periodic
+re-timestamps so an archive can demonstrate a signature was valid
+*at the time it was made*, each link sealed before the previous one
+could be doubted.
+
+`confium-transparency` ships ERS generation and verification. Pair it
+with [anchoring](./anchoring.mdx): the evidence chain is only as
+strong as its timestamps.

--- a/docs/transparency/concepts/merkle-log.mdx
+++ b/docs/transparency/concepts/merkle-log.mdx
@@ -1,0 +1,23 @@
+---
+title: "The append-only Merkle log"
+description: "RFC 6962 semantics: append-only entries, tree heads, and why history cannot be rewritten."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# The append-only Merkle log
+
+A transparency log is a Merkle tree over append-only entries. Each
+entry gets a sequence number; the operator publishes a signed *tree
+head* after every append. Because each head commits to the entire
+prefix of history, an operator cannot insert, remove, or reorder
+entries without producing two heads that are mutually inconsistent —
+and anyone holding both can prove it.
+
+Confium's `confium-transparency` implements the RFC 6962 tree shape:
+entries are domain-separated, internal nodes hash
+`L || R` with the RFC's prefixes, and heads carry the tree size plus
+root hash.
+
+Related: [inclusion and consistency proofs](./proofs.mdx) and
+[consistency proof verification notes](../../faq/).

--- a/docs/transparency/concepts/proofs.mdx
+++ b/docs/transparency/concepts/proofs.mdx
@@ -1,0 +1,23 @@
+---
+title: "Inclusion and consistency proofs"
+description: "How a client proves an entry is in a log, and how an old head relates to a new one."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Inclusion and consistency proofs
+
+**Inclusion proof** — proves entry *i* is covered by tree head *H*:
+a chain of sibling hashes from the leaf to the root. The verifier
+recomputes the root and compares.
+
+**Consistency proof** — proves head *H1* (size *n*) is a prefix of
+head *H2* (size *m*): the operator supplies intermediate hashes from
+which the verifier re-derives both roots. Consistency proofs are how
+clients detect a split-brained or rewritten log even if they only
+check in occasionally.
+
+In Confium, generate proofs with `confium transparency prove` and
+verify with `confium transparency verify` (inclusion) or the
+`confium_transparency::MerkleTree` API (consistency — see the
+[transparency crate docs](https://docs.rs/confium-transparency)).

--- a/docs/transparency/how-to/append-and-prove.mdx
+++ b/docs/transparency/how-to/append-and-prove.mdx
@@ -1,0 +1,20 @@
+---
+title: "Append entries and produce proofs"
+description: "Grow a transparency log and hand out inclusion proofs with the CLI."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Append entries and produce proofs
+
+```sh
+confium transparency append --artifact-hash "sha256:abc123..."
+confium transparency prove --seq 0 --out proof.json
+```
+
+- The log is a database file (`--db`, default `./transparency.db`);
+  append-only by construction — treat any truncation as a security
+  incident.
+- Every append prints the new signed tree head; publish it wherever
+  your witnesses look.
+- Proofs are standalone JSON: entry, index, audit path, and head.

--- a/docs/transparency/how-to/serve-log.mdx
+++ b/docs/transparency/how-to/serve-log.mdx
@@ -1,0 +1,20 @@
+---
+title: "Serve a log"
+description: "Run the HTTP log server so verifiers can fetch heads and proofs."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Serve a log
+
+The `confium-log-server` binary (from the `confium-log-server` crate)
+exposes a growing log over HTTP: clients submit entries, fetch signed
+heads, and download inclusion proofs.
+
+1. Provision the server's signing key through the Threshold product
+   (a threshold-signed head survives the compromise of any single
+   operator).
+2. Point monitors (`confium-log-monitor`) at the head endpoint; they
+   check consistency across restarts and alert on any gap.
+3. Publish the head fingerprint out-of-band (docs, release notes) so
+   first-time clients can bootstrap trust.

--- a/docs/transparency/how-to/verify-inclusion.mdx
+++ b/docs/transparency/how-to/verify-inclusion.mdx
@@ -1,0 +1,22 @@
+---
+title: "Verify an inclusion proof"
+description: "Check a proof against a published head with the CLI."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Verify an inclusion proof
+
+```sh
+confium transparency verify --proof proof.json --head head.json
+```
+
+The verifier recomputes the root from the entry and audit path and
+compares it against the head embedded in the proof. For high-assurance
+checking, compare that head against one you learned out-of-band (or
+from a witness) rather than trusting the proof file's copy.
+
+The same check is available from every surface: the
+[Verify product](../../verify/) CLI, `@confium/confium-wasm` in the
+browser, and `confium_transparency::verify_inclusion_with_head` in
+Rust.

--- a/docs/transparency/index.mdx
+++ b/docs/transparency/index.mdx
@@ -45,6 +45,16 @@ Practical recipes live in the [Cookbook](../cookbook/):
 - [OTS anchoring spec](https://www.confium.org/specs/44-ots-anchoring)
 - [ERS archival spec](https://www.confium.org/specs/45-ers-archival)
 
+## In this section
+
+- [Concepts](./concepts/) — [the Merkle log](./concepts/merkle-log.mdx),
+  [proofs](./concepts/proofs.mdx), [anchoring](./concepts/anchoring.mdx),
+  [ERS](./concepts/ers.mdx)
+- [How-to](./how-to/) — [append and prove](./how-to/append-and-prove.mdx),
+  [verify inclusion](./how-to/verify-inclusion.mdx),
+  [serve a log](./how-to/serve-log.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx)

--- a/docs/transparency/reference/cli.mdx
+++ b/docs/transparency/reference/cli.mdx
@@ -1,0 +1,20 @@
+---
+title: "Transparency CLI reference"
+description: "The transparency and related verify subcommands."
+product: transparency
+audience: compliance, ca-operator, security-engineer
+---
+
+# Transparency CLI reference
+
+| Subcommand | Purpose |
+|---|---|
+| `confium transparency append` | Append an artifact hash (`--db`, `--artifact-hash`) |
+| `confium transparency prove` | Produce an inclusion proof (`--seq`, `--out`) |
+| `confium transparency verify` | Verify a proof against a tree head (`--proof`, `--head`) |
+
+To serve a log over HTTP, run the `confium-log-server` binary — see
+[serve a log](../how-to/serve-log.mdx).
+
+Product docs: <https://www.confium.org/transparency/>. API reference:
+[docs.rs/confium-transparency](https://docs.rs/confium-transparency).

--- a/docs/verify/concepts/five-surfaces.mdx
+++ b/docs/verify/concepts/five-surfaces.mdx
@@ -1,0 +1,22 @@
+---
+title: "Five verification surfaces"
+description: "The same verdict from the CLI, HTTP, the browser, Python, and Rust."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Five verification surfaces
+
+A verification result is only useful if it runs where your users are.
+Confium ships the same pipeline five ways:
+
+| Surface | Entry point |
+|---|---|
+| CLI | `confium verify ...` |
+| HTTP | `POST /verify/signatif` on `confium-verify-server` |
+| Browser | `verifyTrustedArtifact` in `@confium/confium-wasm` |
+| Python | `confium.signatif.verify_trusted_artifact` |
+| Rust | `confium-signatif::pipeline::Pipeline` |
+
+Signing needs keys and stays server-side; verification is safe to
+ship anywhere — the WASM package is verifier-only by design.

--- a/docs/verify/concepts/graduated-verification.mdx
+++ b/docs/verify/concepts/graduated-verification.mdx
@@ -1,0 +1,22 @@
+---
+title: "Graduated verification"
+description: "Every verdict is an objective report plus a label plus your acceptance decision."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Graduated verification
+
+Confium separates three things most tooling conflates:
+
+1. **The coverage report** — what was actually checked (signatures,
+   chain, revocation, transparency, time anchoring). Objective facts.
+2. **The classification label** — the scheme's pure function from
+   report to label (the reference ladder runs
+   `unverified → basic → verified → attested → certified`).
+3. **The acceptance decision** — *your* policy: which labels this
+   verifier accepts, per decision context.
+
+Because the report is separate, two verifiers with different risk
+postures can consume the same artifact data and legitimately reach
+different accept/reject outcomes.

--- a/docs/verify/concepts/signatif-pipeline.mdx
+++ b/docs/verify/concepts/signatif-pipeline.mdx
@@ -1,0 +1,20 @@
+---
+title: "The SIGNATIF pipeline"
+description: "Hard checks that must pass, soft checks that downgrade, and the coverage report they produce."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# The SIGNATIF pipeline
+
+For co-signed, multi-dimensional artifacts Confium implements the
+SIGNATIF verification pipeline: every input (artifact, trust anchors,
+trust graph, registry) feeds a sequence of checks. **Hard checks**
+(signature validity, payload integrity, trust-graph paths) fail the
+run outright; **soft checks** (transparency inclusion, time
+anchoring, algorithm deprecation) instead downgrade the
+classification label.
+
+The output report records each check's outcome, so a downstream
+verifier can see *why* an artifact earned its label. See the
+[SIGNATIF docs](../../signatif/) for the full model.

--- a/docs/verify/how-to/browser-wasm.mdx
+++ b/docs/verify/how-to/browser-wasm.mdx
@@ -1,0 +1,26 @@
+---
+title: "Verify in the browser"
+description: "Ship verification to web clients with the WASM package."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Verify in the browser
+
+```js
+import init, { verifyTrustedArtifact } from "@confium/confium-wasm";
+
+await init();
+const out = JSON.parse(
+  await verifyTrustedArtifact(artifactJson, bundleJson, graphJson,
+                              registryJson, optionsJson)
+);
+// out.coverage — objective report
+// out.label    — classification
+// out.accept   — acceptance vs your acceptedLabels
+```
+
+The package is **verifier-only**: it links no signing code, so the
+WASM binary stays small and nothing dangerous ships to the client.
+Rust/HTTP/CLI/Python run the identical pipeline — see
+[five surfaces](../concepts/five-surfaces.mdx).

--- a/docs/verify/how-to/cli-verify.mdx
+++ b/docs/verify/how-to/cli-verify.mdx
@@ -1,0 +1,24 @@
+---
+title: "Verify from the CLI"
+description: "Run the verify umbrella for composite, inclusion, and chain checks."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Verify from the CLI
+
+```sh
+confium verify composite \
+  --message @doc.bin --signature sig.cose \
+  --algorithm ed25519 --public-key pk.hex
+
+confium verify cert-chain \
+  --leaf leaf.pem --anchor root.pem --intermediate int.pem
+
+confium verify inclusion --proof proof.json --entry entry.json
+```
+
+Every subcommand exits non-zero on failure, so this composes in CI
+and shell scripts. For the full SIGNATIF artifact pipeline see
+`confium verify signatif --help` and the
+[SIGNATIF quickstart](../../signatif/).

--- a/docs/verify/how-to/http-server.mdx
+++ b/docs/verify/how-to/http-server.mdx
@@ -1,0 +1,25 @@
+---
+title: "Verify over HTTP"
+description: "Run the verification server for services that should not embed the pipeline."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Verify over HTTP
+
+`confium-verify-server` exposes the pipeline as JSON-over-HTTP:
+
+```sh
+confium-verify-server --listen 127.0.0.1:9420
+```
+
+```sh
+curl -s localhost:9420/verify/signatif \
+  -H 'content-type: application/json' \
+  -d @request.json
+```
+
+The response carries the same `coverage` / `label` / `accept` triple
+as every other surface. Keep the server stateless — all trust inputs
+arrive with each request, so verifiers pin exactly the anchors and
+registry they intend.

--- a/docs/verify/index.mdx
+++ b/docs/verify/index.mdx
@@ -47,6 +47,16 @@ Practical recipes live in the [Cookbook](../cookbook/):
 - [HTTP verify spec](https://www.confium.org/specs/62-http-verify)
 - [Bindings matrix spec](https://www.confium.org/specs/63-bindings-matrix)
 
+## In this section
+
+- [Concepts](./concepts/) — [graduated verification](./concepts/graduated-verification.mdx),
+  [five surfaces](./concepts/five-surfaces.mdx),
+  [the SIGNATIF pipeline](./concepts/signatif-pipeline.mdx)
+- [How-to](./how-to/) — [CLI](./how-to/cli-verify.mdx),
+  [browser WASM](./how-to/browser-wasm.mdx),
+  [HTTP server](./how-to/http-server.mdx)
+- [Reference](./reference/) — [CLI](./reference/cli.mdx)
+
 ## Cross-links
 
 - [Confium architecture](../architecture.mdx)

--- a/docs/verify/reference/cli.mdx
+++ b/docs/verify/reference/cli.mdx
@@ -1,0 +1,19 @@
+---
+title: "Verify CLI reference"
+description: "The confium verify subcommand tree."
+product: verify
+audience: web-developer, devsecops, app-developer
+---
+
+# Verify CLI reference
+
+| Subcommand | Purpose |
+|---|---|
+| `confium verify composite` | Verify a composite (COSE) signature |
+| `confium verify inclusion` | Verify a transparency inclusion proof |
+| `confium verify cert-chain` | Verify a certificate chain |
+| `confium verify signatif` | Full SIGNATIF pipeline over a trusted artifact |
+
+Exit code 2 means "verification ran, acceptance policy rejected" —
+distinct from 1 (bad input) in scripts. Product docs:
+<https://www.confium.org/verify/>


### PR DESCRIPTION
## Summary

- Completes TODO.restructure/30: concepts/how-to/reference doc trees for all six products (45 new MDX pages), with each product index linking into its new sections.
- CLI examples use the real subcommands and flags (`threshold dkg --scheme`, `transparency append --artifact-hash`, `pki composite-sign`, `privacy psi`/`dp`, `verify composite`/`inclusion`/`cert-chain`/`signatif`), verified against `cli.rs`.
- Frontmatter carries title/description/product/audience per convention; no mode-numbered language; `typos` clean.

## Test plan

- [x] Every product has ≥3 concepts, ≥3 how-to, ≥1 reference page
- [x] `typos` clean over the six trees
- [ ] CI green
