### PR TITLE
feat(signatif): deep verification entry — one interface for every surface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,50 @@
+# Confium domain glossary
+
+The nouns and verbs this codebase uses, so architecture reviews and
+new contributors share one vocabulary. Architecture terms (module,
+interface, depth, seam, adapter, leverage, locality) come from the
+`/codebase-design` skill; this file is the *domain* layer on top.
+
+## SIGNATIF framework layer (`confium-signatif`)
+
+- **Trusted artifact** — the signed document under verification:
+  a canonical payload hash plus dimension-tagged co-signature blocks
+  (`artifact::TrustedArtifact`).
+- **Trust graph** — the delegation DAG of authorities (roots,
+  federated authorities, end certificates) that path-finding walks to
+  justify a co-signature (`graph::TrustGraph`).
+- **Anchor bundle** — the versioned, signed set of trust anchors a
+  verifier bootstraps from (`bundle::TrustAnchorBundle`).
+- **Registry** — the five scheme-maintained registries (dimensions,
+  algorithms, ceremony types, format profiles, scope dimensions)
+  a scheme publishes (`registry::Registry`).
+- **Pipeline** — the ordered hard/soft check engine over the four
+  trust inputs (`pipeline::Pipeline`). Hard checks fail the run;
+  soft checks downgrade the label.
+- **Coverage report** — the objective record of what was checked
+  (`coverage::CoverageReport`).
+- **Classification label** — the scheme's pure function from coverage
+  report to label; the reference ladder is `unverified → basic →
+  verified → attested → certified` (`coverage::ClassificationLabel`).
+- **Acceptance** — the verifier's own decision: does this label pass
+  *my* policy, in this decision context (`coverage::Acceptance`).
+- **Verdict** — the graduated outcome triple every surface serializes:
+  coverage report + classification label + acceptance decision
+  (`verify::Verdict`).
+- **Verifier fleet** — which signature algorithms a verifier checks,
+  as named policy rather than hand-written code: `ed25519` (the
+  browser profile) or `ed25519_p256` (the default registry's
+  classical set) (`verify::Fleet`). The `SignatureVerifier` seam stays
+  open for threshold or HSM fleets.
+- **Surface** — a transport that exposes verification: Rust library,
+  browser WASM, HTTP, CLI, Python. Surfaces are adapters; the
+  verification assembly lives in `verify::verify_trusted_artifact`.
+
+## Products
+
+The workspace is organized into six products — **Threshold** (T-of-N
+signing), **Transparency** (append-only logs and proofs), **PKI**
+(threshold CA and PKCS#11/OpenSSL/JCE bridges), **Keyless** (OIDC
+release signing), **Privacy** (PSI/DP/MPC), **Verify** (the five
+surfaces). See `docs/<product>/` in this repo and
+`TODO.restructure/` for the restructuring history.

--- a/crates/confium-cli/Cargo.toml
+++ b/crates/confium-cli/Cargo.toml
@@ -31,7 +31,6 @@ confium-transparency = { workspace = true }
 confium-pki = { workspace = true }
 confium-composite = { workspace = true }
 confium-signatif = { workspace = true }
-chrono = { workspace = true }
 confium-privacy = { workspace = true }
 ed25519-dalek = { workspace = true }
 p256 = { workspace = true, features = ["ecdsa"] }

--- a/crates/confium-cli/src/commands/verify.rs
+++ b/crates/confium-cli/src/commands/verify.rs
@@ -190,61 +190,24 @@ fn verify_signatif(args: VerifySignatifArgs) -> Result<(), String> {
         }
         None => confium_signatif::registry::Registry::with_initial_values(),
     };
-    let time_attested_at = match &args.time_attested_at {
-        Some(s) => Some(
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map_err(|e| format!("time_attested_at: {e}"))?
-                .with_timezone(&chrono::Utc),
-        ),
-        None => None,
+    let options = confium_signatif::verify::VerifyOptions {
+        transparency_included: args.transparency,
+        time_anchored: args.time,
+        time_attested_at: args.time_attested_at.clone(),
+        multi_log_quorum: false,
+        accepted_labels: args.accept.clone(),
+        ..confium_signatif::verify::VerifyOptions::default()
     };
-    let acceptance = confium_signatif::coverage::AcceptancePolicy {
-        accepted_labels: args.accept,
-    };
-    let no_revocations = confium_signatif::revocation::NoRevocations;
-    let verifier = CliVerifier;
-    let pipe = confium_signatif::pipeline::Pipeline::new(
-        &bundle,
-        &graph,
-        &registry,
-        &verifier,
-        &no_revocations,
-        confium_signatif::pipeline::TransparencyInputs {
-            artifact_included: args.transparency,
-            time_anchored: args.time,
-            time_attested_at,
-            multi_log_quorum: false,
-            downgrades: vec![],
-        },
-        &acceptance,
-    );
-    let outcome = pipe
-        .run(&artifact, chrono::Utc::now())
-        .map_err(|e| format!("{e}"))?;
-    let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
+    let verdict = confium_signatif::verify::verify_trusted_artifact(
+        &artifact, &bundle, &graph, &registry, &options,
+    )
+    .map_err(|e| format!("{e}"))?;
     println!(
         "{}",
-        serde_json::to_string_pretty(&serde_json::json!({
-            "label": outcome.label.0,
-            "accept": accept,
-            "coverage": outcome.report,
-        }))
-        .map_err(|e| format!("encode: {e}"))?
+        serde_json::to_string_pretty(&verdict).map_err(|e| format!("encode: {e}"))?
     );
-    if !accept {
+    if !verdict.accept {
         std::process::exit(2);
     }
     Ok(())
-}
-
-/// The CLI verifier fleet: Ed25519 and ECDSA-P256, matching the
-/// classical algorithms in the default registry.
-struct CliVerifier;
-
-impl confium_signatif::graph::SignatureVerifier for CliVerifier {
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-        confium_composite::ed25519_verifier("Ed25519", public_key, message, signature).is_ok()
-            || confium_composite::p256_verifier("ECDSA-P256", public_key, message, signature)
-                .is_ok()
-    }
 }

--- a/crates/confium-python/src/signatif.rs
+++ b/crates/confium-python/src/signatif.rs
@@ -24,23 +24,9 @@ use pyo3::types::PyDict;
 
 use confium_signatif::artifact::TrustedArtifact;
 use confium_signatif::bundle::TrustAnchorBundle;
-use confium_signatif::coverage::AcceptancePolicy;
-use confium_signatif::graph::{SignatureVerifier, TrustGraph};
-use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
+use confium_signatif::graph::TrustGraph;
 use confium_signatif::registry::Registry;
-use confium_signatif::revocation::NoRevocations;
-
-/// The Python-facing verifier fleet: Ed25519 and ECDSA-P256, the
-/// classical algorithms of the default registry.
-struct PyVerifier;
-
-impl SignatureVerifier for PyVerifier {
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-        confium_composite::ed25519_verifier("Ed25519", public_key, message, signature).is_ok()
-            || confium_composite::p256_verifier("ECDSA-P256", public_key, message, signature)
-                .is_ok()
-    }
-}
+use confium_signatif::verify::VerifyOptions;
 
 /// Verify a SIGNATIF trusted artifact through the full pipeline.
 ///
@@ -99,44 +85,25 @@ pub fn verify_trusted_artifact(
             .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("registry: {e}")))?,
         None => Registry::with_initial_values(),
     };
-    let time_attested_at = match &time_attested_at {
-        None => None,
-        Some(s) => Some(
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("time_attested_at: {e}")))?
-                .with_timezone(&chrono::Utc),
-        ),
-    };
-    let acceptance = AcceptancePolicy {
+    let options = VerifyOptions {
+        transparency_included,
+        time_anchored,
+        time_attested_at,
+        multi_log_quorum,
         accepted_labels: accepted_labels.unwrap_or_default(),
+        ..VerifyOptions::default()
     };
-    let no_revocations = NoRevocations;
-    let pipe = Pipeline::new(
+    let verdict = confium_signatif::verify::verify_trusted_artifact(
+        &artifact,
         &bundle,
         &graph,
         &registry,
-        &PyVerifier,
-        &no_revocations,
-        TransparencyInputs {
-            artifact_included: transparency_included,
-            time_anchored,
-            time_attested_at,
-            multi_log_quorum,
-            downgrades: vec![],
-        },
-        &acceptance,
-    );
-    let outcome = pipe
-        .run(&artifact, chrono::Utc::now())
+        &options,
+    )
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("{e}")))?;
-    let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
-    let coverage_json = serde_json::to_value(&outcome.report)
+    let verdict_json = serde_json::to_value(&verdict)
         .map_err(|e| pyo3::exceptions::PyValueError::new_err(format!("encode: {e}")))?;
-    let out = PyDict::new_bound(py);
-    out.set_item("label", outcome.label.0)?;
-    out.set_item("accept", accept)?;
-    out.set_item("coverage", json_to_py(py, &coverage_json)?)?;
-    Ok(out.into())
+    Ok(json_to_py(py, &verdict_json)?)
 }
 
 /// JSON value -> Python object.

--- a/crates/confium-signatif/src/lib.rs
+++ b/crates/confium-signatif/src/lib.rs
@@ -21,6 +21,8 @@
 //! - [`revocation`]: signed CRLs, hash bindings, transitive propagation.
 //! - [`ceremony`]: verifiable ceremony transcripts and their audit.
 //! - [`registry`]: the five scheme-maintained registries.
+//! - [`verify`]: the deep verification entry — fleet, options, and
+//!   verdict in one interface, so transport adapters stay thin.
 //!
 //! All verification is offline-capable against a trust anchor bundle.
 
@@ -47,6 +49,8 @@ pub mod registry;
 pub mod revocation;
 pub mod scope;
 pub mod time;
+pub mod verify;
 pub mod x509;
 
 pub use error::{SignatifError, SignatifResult};
+pub use verify::{Fleet, Verdict, VerifyOptions, verify_trusted_artifact};

--- a/crates/confium-signatif/src/verify.rs
+++ b/crates/confium-signatif/src/verify.rs
@@ -1,0 +1,338 @@
+//! The deep verification entry: one interface for every surface.
+//!
+//! The [`Pipeline`] is the ordered hard/soft check engine, but its
+//! constructor takes every dependency as a raw parameter, so each
+//! transport adapter (browser WASM, HTTP, CLI, Python) used to
+//! re-assemble the same wiring — a verifier fleet, a revocation view,
+//! transparency inputs, an acceptance policy — just to reach it.
+//! This module owns that assembly once.
+//!
+//! ```no_run
+//! use confium_signatif::verify::{verify_trusted_artifact, VerifyOptions};
+//! # use confium_signatif::artifact::TrustedArtifact;
+//! # use confium_signatif::bundle::TrustAnchorBundle;
+//! # use confium_signatif::graph::TrustGraph;
+//! # use confium_signatif::registry::Registry;
+//! # fn main() -> Result<(), confium_signatif::SignatifError> {
+//! # let (artifact, bundle, graph, registry) = unimplemented!();
+//! let options = VerifyOptions {
+//!     transparency_included: true,
+//!     accepted_labels: vec!["verified".into()],
+//!     ..VerifyOptions::default()
+//! };
+//! let verdict = verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options)?;
+//! assert!(verdict.accept);
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Revocation checking currently runs with [`NoRevocations`]; this
+//! function is the single place that changes when a surface grows a
+//! revocation input. Schemes that need a [`CrlView`](crate::revocation::CrlView)
+//! today assemble the [`Pipeline`] directly.
+
+use serde::{Deserialize, Serialize};
+
+use crate::artifact::TrustedArtifact;
+use crate::bundle::TrustAnchorBundle;
+use crate::coverage::{Acceptance, AcceptancePolicy, CoverageReport};
+use crate::graph::{SignatureVerifier, TrustGraph};
+use crate::pipeline::{Pipeline, TransparencyInputs};
+use crate::registry::Registry;
+use crate::{SignatifError, SignatifResult};
+
+/// Which signature algorithms a verifier checks.
+///
+/// The fleet is scheme policy, not per-surface code: pick a variant
+/// instead of hand-writing a [`SignatureVerifier`]. The seam stays
+/// open — exotic fleets (threshold, HSM) still implement the trait.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Fleet {
+    /// Ed25519 only — the browser/WASM verifier profile.
+    #[serde(rename = "ed25519")]
+    Ed25519,
+    /// Ed25519 or ECDSA-P256 — the classical algorithms of the
+    /// default registry.
+    #[serde(rename = "ed25519_p256")]
+    Ed25519P256,
+}
+
+impl SignatureVerifier for Fleet {
+    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+        match self {
+            Fleet::Ed25519 => ed25519(public_key, message, signature),
+            Fleet::Ed25519P256 => {
+                ed25519(public_key, message, signature) || p256(public_key, message, signature)
+            }
+        }
+    }
+}
+
+fn ed25519(public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+    confium_composite::ed25519_verifier(confium_composite::ED25519, public_key, message, signature)
+        .is_ok()
+}
+
+fn p256(public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
+    confium_composite::p256_verifier(
+        confium_composite::ECDSA_P256,
+        public_key,
+        message,
+        signature,
+    )
+    .is_ok()
+}
+
+/// The verification inputs a transport collects, in the shape every
+/// surface already speaks: field names match the JSON options of the
+/// HTTP endpoint, the browser binding, and the CLI flags.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct VerifyOptions {
+    /// Which algorithms the verifier fleet checks.
+    pub fleet: Fleet,
+    /// Transparency inclusion was verified for this artifact.
+    pub transparency_included: bool,
+    /// An external time anchor was verified.
+    pub time_anchored: bool,
+    /// Externally-attested time (RFC 3339) from a verified time
+    /// authority.
+    pub time_attested_at: Option<String>,
+    /// The M-of-K multi-log quorum was met.
+    pub multi_log_quorum: bool,
+    /// Classification labels this verifier accepts (empty = reject
+    /// everything).
+    pub accepted_labels: Vec<String>,
+}
+
+impl Default for VerifyOptions {
+    fn default() -> Self {
+        Self {
+            fleet: Fleet::Ed25519P256,
+            transparency_included: false,
+            time_anchored: false,
+            time_attested_at: None,
+            multi_log_quorum: false,
+            accepted_labels: Vec::new(),
+        }
+    }
+}
+
+/// The graduated verification outcome: the objective coverage report,
+/// the scheme's classification label, and this verifier's acceptance
+/// decision — the triple every surface serializes.
+#[derive(Debug, Serialize)]
+pub struct Verdict {
+    /// The scheme's classification label.
+    pub label: String,
+    /// The verifier's acceptance decision.
+    pub accept: bool,
+    /// The objective coverage report.
+    pub coverage: CoverageReport,
+}
+
+/// Verify one trusted artifact through the full pipeline.
+///
+/// This is the single entry every transport adapter calls; the
+/// pipeline assembly (fleet, revocation view, transparency inputs,
+/// acceptance policy) lives here and nowhere else.
+///
+/// # Errors
+///
+/// Input decoding failures (including a malformed `time_attested_at`)
+/// and hard-check failures surface as [`SignatifError`]; the error
+/// names the failing check.
+pub fn verify_trusted_artifact(
+    artifact: &TrustedArtifact,
+    bundle: &TrustAnchorBundle,
+    graph: &TrustGraph,
+    registry: &Registry,
+    options: &VerifyOptions,
+) -> SignatifResult<Verdict> {
+    let time_attested_at = match &options.time_attested_at {
+        None => None,
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| SignatifError::Encoding(format!("time_attested_at: {e}")))?
+                .with_timezone(&chrono::Utc),
+        ),
+    };
+    let no_revocations = crate::revocation::NoRevocations;
+    let acceptance = AcceptancePolicy {
+        accepted_labels: options.accepted_labels.clone(),
+    };
+    let pipe = Pipeline::new(
+        bundle,
+        graph,
+        registry,
+        &options.fleet,
+        &no_revocations,
+        TransparencyInputs {
+            artifact_included: options.transparency_included,
+            time_anchored: options.time_anchored,
+            time_attested_at,
+            multi_log_quorum: options.multi_log_quorum,
+            downgrades: vec![],
+        },
+        &acceptance,
+    );
+    let outcome = pipe.run(artifact, chrono::Utc::now())?;
+    Ok(Verdict {
+        label: outcome.label.0,
+        accept: outcome.acceptance == Acceptance::Accept,
+        coverage: outcome.report,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture() -> (TrustedArtifact, TrustAnchorBundle, TrustGraph, Registry) {
+        use crate::bundle::AnchorRoot;
+        use crate::graph::{AuthorityKind, AuthorityNode, DelegationEdge};
+        use crate::scope::ScopeDimensions;
+        use ed25519_dalek::Signer;
+
+        let mut seed = [0u8; 32];
+        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
+        let root_sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let mut seed = [0u8; 32];
+        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
+        let end_sk = ed25519_dalek::SigningKey::from_bytes(&seed);
+
+        let registry = Registry::with_initial_values();
+        let root = AuthorityNode {
+            id: "root".into(),
+            kind: AuthorityKind::Root,
+            public_key: root_sk.verifying_key().as_bytes().to_vec(),
+            quorum: None,
+            scope: ScopeDimensions::unconstrained(),
+        };
+        let end = AuthorityNode {
+            id: "end".into(),
+            kind: AuthorityKind::EndCertificate,
+            public_key: end_sk.verifying_key().as_bytes().to_vec(),
+            quorum: None,
+            scope: ScopeDimensions::unconstrained(),
+        };
+        let mut graph = TrustGraph::new();
+        graph.add_node(root.clone());
+        graph.add_node(end.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root".into(),
+                child: "end".into(),
+                signature: root_sk
+                    .sign(&end.binding_bytes().unwrap())
+                    .to_bytes()
+                    .to_vec(),
+            })
+            .unwrap();
+
+        let mut bundle = TrustAnchorBundle {
+            bundle_version: "1".into(),
+            valid_from: chrono::Utc::now() - chrono::Duration::hours(1),
+            valid_until: chrono::Utc::now() + chrono::Duration::days(30),
+            roots: vec![AnchorRoot {
+                name: "root".into(),
+                aggregate_key: root.public_key.clone(),
+                fingerprint: hex::encode(&root.public_key),
+                quorum: None,
+            }],
+            transparency_logs: vec![],
+            update_log: None,
+            bundle_signature: vec![],
+        };
+        let msg = bundle.signing_bytes().unwrap();
+        bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
+
+        let mut artifact = TrustedArtifact::new(
+            crate::artifact::ArtifactVersion { major: 1, minor: 0 },
+            "v-1",
+            serde_json::json!({"dose": 500}),
+            None,
+        )
+        .unwrap();
+        artifact
+            .sign(
+                crate::registry::DimensionTag::data(),
+                "Ed25519",
+                "end",
+                end_sk.verifying_key().as_bytes().to_vec(),
+                "root",
+                &|m| end_sk.sign(m).to_bytes().to_vec(),
+                &registry,
+            )
+            .unwrap();
+
+        (artifact, bundle, graph, registry)
+    }
+
+    #[test]
+    fn verdict_ladders_and_accepts() {
+        let (artifact, bundle, graph, registry) = fixture();
+        let options = VerifyOptions {
+            accepted_labels: vec!["unverified".into()],
+            ..VerifyOptions::default()
+        };
+        let verdict =
+            verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options).unwrap();
+        assert_eq!(verdict.label, "unverified");
+        assert!(verdict.accept);
+
+        let options = VerifyOptions {
+            transparency_included: true,
+            time_anchored: true,
+            time_attested_at: Some(chrono::Utc::now().to_rfc3339()),
+            accepted_labels: vec!["verified".into()],
+            ..VerifyOptions::default()
+        };
+        let verdict =
+            verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options).unwrap();
+        assert_eq!(verdict.label, "verified");
+        assert!(verdict.accept);
+    }
+
+    #[test]
+    fn tampered_artifact_hard_fails() {
+        let (artifact, bundle, graph, registry) = fixture();
+        let mut value = serde_json::to_value(&artifact).unwrap();
+        value["payload"]["dose"] = serde_json::json!(999);
+        let tampered: TrustedArtifact = serde_json::from_value(value).unwrap();
+        let options = VerifyOptions::default();
+        let err =
+            verify_trusted_artifact(&tampered, &bundle, &graph, &registry, &options).unwrap_err();
+        assert!(format!("{err}").contains("signature_validity"), "{err}");
+    }
+
+    #[test]
+    fn malformed_time_is_an_input_error() {
+        let (artifact, bundle, graph, registry) = fixture();
+        let options = VerifyOptions {
+            time_attested_at: Some("not-a-time".into()),
+            ..VerifyOptions::default()
+        };
+        let err =
+            verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options).unwrap_err();
+        assert!(err.to_string().contains("time_attested_at"), "{err}");
+    }
+
+    #[test]
+    fn options_deserialize_from_surface_json() {
+        let json = r#"{
+            "transparency_included": true,
+            "time_anchored": true,
+            "time_attested_at": "2026-08-19T00:00:00Z",
+            "multi_log_quorum": false,
+            "accepted_labels": ["verified"]
+        }"#;
+        let options: VerifyOptions = serde_json::from_str(json).unwrap();
+        assert_eq!(options.fleet, Fleet::Ed25519P256);
+        assert!(options.transparency_included);
+        assert_eq!(options.accepted_labels, vec!["verified"]);
+
+        let browser: VerifyOptions = serde_json::from_str(r#"{"fleet": "ed25519"}"#).unwrap();
+        assert_eq!(browser.fleet, Fleet::Ed25519);
+    }
+}

--- a/crates/confium-signatif/src/verify.rs
+++ b/crates/confium-signatif/src/verify.rs
@@ -26,7 +26,8 @@
 //! # }
 //! ```
 //!
-//! Revocation checking currently runs with [`NoRevocations`]; this
+//! Revocation checking currently runs with
+//! [`NoRevocations`](crate::revocation::NoRevocations); this
 //! function is the single place that changes when a surface grows a
 //! revocation input. Schemes that need a [`CrlView`](crate::revocation::CrlView)
 //! today assemble the [`Pipeline`] directly.

--- a/crates/confium-verify-server/src/handlers.rs
+++ b/crates/confium-verify-server/src/handlers.rs
@@ -341,6 +341,11 @@ pub struct VerifySignatifRequest {
     pub options: confium_signatif::verify::VerifyOptions,
 }
 
+/// Deprecated alias for the pipeline options, which now live in
+/// `confium_signatif::verify::VerifyOptions`.
+#[deprecated(since = "0.5.3", note = "use confium_signatif::verify::VerifyOptions")]
+pub type VerifySignatifOptions = confium_signatif::verify::VerifyOptions;
+
 /// Response: the graduated verification outcome.
 #[derive(Debug, Serialize)]
 pub struct VerifySignatifResponse {

--- a/crates/confium-verify-server/src/handlers.rs
+++ b/crates/confium-verify-server/src/handlers.rs
@@ -338,13 +338,44 @@ pub struct VerifySignatifRequest {
     /// Verification options (transparency/time inputs, accepted
     /// labels); defaults when absent.
     #[serde(default)]
-    pub options: confium_signatif::verify::VerifyOptions,
+    pub options: VerifySignatifOptions,
 }
 
-/// Deprecated alias for the pipeline options, which now live in
-/// `confium_signatif::verify::VerifyOptions`.
-#[deprecated(since = "0.5.3", note = "use confium_signatif::verify::VerifyOptions")]
-pub type VerifySignatifOptions = confium_signatif::verify::VerifyOptions;
+/// Options for the pipeline run. Mirrors
+/// `confium_signatif::verify::VerifyOptions`; the wire-facing struct
+/// stays put for API compatibility and converts at the pipeline call.
+#[derive(Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct VerifySignatifOptions {
+    /// Transparency inclusion was verified for this artifact.
+    #[serde(default)]
+    pub transparency_included: bool,
+    /// An external time anchor was verified.
+    #[serde(default)]
+    pub time_anchored: bool,
+    /// Externally-attested time (RFC 3339).
+    #[serde(default)]
+    pub time_attested_at: Option<String>,
+    /// Multi-log quorum met.
+    #[serde(default)]
+    pub multi_log_quorum: bool,
+    /// Accepted classification labels (empty = reject everything).
+    #[serde(default)]
+    pub accepted_labels: Vec<String>,
+}
+
+impl From<&VerifySignatifOptions> for confium_signatif::verify::VerifyOptions {
+    fn from(o: &VerifySignatifOptions) -> Self {
+        Self {
+            transparency_included: o.transparency_included,
+            time_anchored: o.time_anchored,
+            time_attested_at: o.time_attested_at.clone(),
+            multi_log_quorum: o.multi_log_quorum,
+            accepted_labels: o.accepted_labels.clone(),
+            ..Self::default()
+        }
+    }
+}
 
 /// Response: the graduated verification outcome.
 #[derive(Debug, Serialize)]
@@ -402,12 +433,9 @@ pub async fn verify_signatif(
         },
         None => Registry::with_initial_values(),
     };
+    let options = confium_signatif::verify::VerifyOptions::from(&req.options);
     match confium_signatif::verify::verify_trusted_artifact(
-        &artifact,
-        &bundle,
-        &graph,
-        &registry,
-        &req.options,
+        &artifact, &bundle, &graph, &registry, &options,
     ) {
         Ok(verdict) => respond(
             StatusCode::OK,

--- a/crates/confium-verify-server/src/handlers.rs
+++ b/crates/confium-verify-server/src/handlers.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use confium_composite::{
     ComponentSignature, CompositeSignature, ECDSA_P256, ED25519, ed25519_verifier, p256_verifier,
 };
-use confium_signatif::graph::{SignatureVerifier, TrustGraph};
+use confium_signatif::graph::TrustGraph;
 use confium_signatif::{artifact::TrustedArtifact, bundle::TrustAnchorBundle, registry::Registry};
 use confium_transparency::entry::MerkleEntry;
 use confium_transparency::merkle::{Hash, InclusionProof, MerkleTree, ProofStep, Side};
@@ -338,28 +338,7 @@ pub struct VerifySignatifRequest {
     /// Verification options (transparency/time inputs, accepted
     /// labels); defaults when absent.
     #[serde(default)]
-    pub options: VerifySignatifOptions,
-}
-
-/// Options for the pipeline run.
-#[derive(Debug, Default, Deserialize)]
-#[serde(default)]
-pub struct VerifySignatifOptions {
-    /// Transparency inclusion was verified for this artifact.
-    #[serde(default)]
-    pub transparency_included: bool,
-    /// An external time anchor was verified.
-    #[serde(default)]
-    pub time_anchored: bool,
-    /// Externally-attested time (RFC 3339).
-    #[serde(default)]
-    pub time_attested_at: Option<String>,
-    /// Multi-log quorum met.
-    #[serde(default)]
-    pub multi_log_quorum: bool,
-    /// Accepted classification labels (empty = reject everything).
-    #[serde(default)]
-    pub accepted_labels: Vec<String>,
+    pub options: confium_signatif::verify::VerifyOptions,
 }
 
 /// Response: the graduated verification outcome.
@@ -371,17 +350,6 @@ pub struct VerifySignatifResponse {
     pub accept: bool,
     /// The objective coverage report.
     pub coverage: confium_signatif::coverage::CoverageReport,
-}
-
-/// The server's verifier fleet: the classical algorithms of the
-/// default registry.
-struct ServerVerifier;
-
-impl SignatureVerifier for ServerVerifier {
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-        ed25519_verifier(ED25519, public_key, message, signature).is_ok()
-            || p256_verifier(ECDSA_P256, public_key, message, signature).is_ok()
-    }
 }
 
 /// POST /verify/signatif
@@ -429,50 +397,22 @@ pub async fn verify_signatif(
         },
         None => Registry::with_initial_values(),
     };
-    let time_attested_at = match &req.options.time_attested_at {
-        None => None,
-        Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
-            Ok(t) => Some(t.with_timezone(&chrono::Utc)),
-            Err(e) => {
-                return respond(
-                    StatusCode::BAD_REQUEST,
-                    serde_json::json!({"error": format!("time_attested_at: {e}")}),
-                );
-            }
-        },
-    };
-    let no_revocations = confium_signatif::revocation::NoRevocations;
-    let acceptance = confium_signatif::coverage::AcceptancePolicy {
-        accepted_labels: req.options.accepted_labels,
-    };
-    let pipe = confium_signatif::pipeline::Pipeline::new(
+    match confium_signatif::verify::verify_trusted_artifact(
+        &artifact,
         &bundle,
         &graph,
         &registry,
-        &ServerVerifier,
-        &no_revocations,
-        confium_signatif::pipeline::TransparencyInputs {
-            artifact_included: req.options.transparency_included,
-            time_anchored: req.options.time_anchored,
-            time_attested_at,
-            multi_log_quorum: req.options.multi_log_quorum,
-            downgrades: vec![],
-        },
-        &acceptance,
-    );
-    match pipe.run(&artifact, chrono::Utc::now()) {
-        Ok(outcome) => {
-            let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
-            respond(
-                StatusCode::OK,
-                serde_json::to_value(VerifySignatifResponse {
-                    label: outcome.label.0,
-                    accept,
-                    coverage: outcome.report,
-                })
-                .unwrap_or_default(),
-            )
-        }
+        &req.options,
+    ) {
+        Ok(verdict) => respond(
+            StatusCode::OK,
+            serde_json::to_value(VerifySignatifResponse {
+                label: verdict.label,
+                accept: verdict.accept,
+                coverage: verdict.coverage,
+            })
+            .unwrap_or_default(),
+        ),
         Err(e) => respond(
             StatusCode::UNPROCESSABLE_ENTITY,
             serde_json::json!({"error": format!("{e}"), "label": "rejected"}),

--- a/crates/confium-wasm/src/signatif.rs
+++ b/crates/confium-wasm/src/signatif.rs
@@ -11,7 +11,7 @@ use confium_signatif::artifact::TrustedArtifact;
 use confium_signatif::bundle::TrustAnchorBundle;
 use confium_signatif::graph::TrustGraph;
 use confium_signatif::registry::Registry;
-use confium_signatif::verify::{Fleet, VerifyOptions, verify_trusted_artifact};
+use confium_signatif::verify::{Fleet, VerifyOptions};
 
 /// The full verification outcome as one JSON object: `coverage` (the
 /// objective report), `label` (the scheme's classification), and
@@ -47,8 +47,10 @@ pub fn verify_trusted_artifact(
     // The browser verifier profile is Ed25519-only by design.
     options.fleet = Fleet::Ed25519;
 
-    let verdict = verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options)
-        .map_err(|e| JsError::new(&format!("{e}")))?;
+    let verdict = confium_signatif::verify::verify_trusted_artifact(
+        &artifact, &bundle, &graph, &registry, &options,
+    )
+    .map_err(|e| JsError::new(&format!("{e}")))?;
     serde_json::to_string(&verdict).map_err(|e| JsError::new(&format!("encode: {e}")))
 }
 

--- a/crates/confium-wasm/src/signatif.rs
+++ b/crates/confium-wasm/src/signatif.rs
@@ -1,37 +1,17 @@
 //! Browser/Node.js verification of SIGNATIF trusted artifacts.
+//!
+//! A thin transport adapter: JSON in, JSON out. The verification
+//! assembly (fleet, revocation view, transparency inputs, acceptance)
+//! lives in [`confium_signatif::verify`]; this binding pins the
+//! browser verifier profile (Ed25519-only) and translates types.
 
 use wasm_bindgen::prelude::*;
 
 use confium_signatif::artifact::TrustedArtifact;
 use confium_signatif::bundle::TrustAnchorBundle;
-use confium_signatif::coverage::AcceptancePolicy;
-use confium_signatif::graph::{SignatureVerifier, TrustGraph};
-use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
+use confium_signatif::graph::TrustGraph;
 use confium_signatif::registry::Registry;
-use confium_signatif::revocation::NoRevocations;
-
-/// The Ed25519-only verifier fleet for the browser. Threshold
-/// aggregate verification and PQC algorithms are server-side
-/// concerns; browser verification of classical signatures is the
-/// verifier profile this package ships.
-struct Ed25519OnlyVerifier;
-
-impl SignatureVerifier for Ed25519OnlyVerifier {
-    fn verify(&self, public_key: &[u8], message: &[u8], signature: &[u8]) -> bool {
-        use ed25519_dalek::Signature;
-        use ed25519_dalek::Verifier;
-        let Ok(key) = <[u8; 32]>::try_from(public_key) else {
-            return false;
-        };
-        let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(&key) else {
-            return false;
-        };
-        let Ok(sig) = Signature::from_slice(signature) else {
-            return false;
-        };
-        vk.verify(message, &sig).is_ok()
-    }
-}
+use confium_signatif::verify::{Fleet, VerifyOptions, verify_trusted_artifact};
 
 /// The full verification outcome as one JSON object: `coverage` (the
 /// objective report), `label` (the scheme's classification), and
@@ -59,61 +39,17 @@ pub fn verify_trusted_artifact(
     let registry: Registry =
         serde_json::from_str(registry_json).map_err(|e| JsError::new(&format!("registry: {e}")))?;
 
-    #[derive(serde::Deserialize, Default)]
-    #[serde(default)]
-    struct Options {
-        transparency_included: bool,
-        time_anchored: bool,
-        #[serde(default)]
-        time_attested_at: Option<String>,
-        multi_log_quorum: bool,
-        accepted_labels: Vec<String>,
-    }
-    let options: Options = if options_json.trim().is_empty() {
-        Options::default()
+    let mut options: VerifyOptions = if options_json.trim().is_empty() {
+        VerifyOptions::default()
     } else {
         serde_json::from_str(options_json).map_err(|e| JsError::new(&format!("options: {e}")))?
     };
-    let time_attested_at = match &options.time_attested_at {
-        None => None,
-        Some(s) => Some(
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map_err(|e| JsError::new(&format!("time_attested_at: {e}")))?
-                .with_timezone(&chrono::Utc),
-        ),
-    };
-    let acceptance = AcceptancePolicy {
-        accepted_labels: options.accepted_labels,
-    };
+    // The browser verifier profile is Ed25519-only by design.
+    options.fleet = Fleet::Ed25519;
 
-    let no_revocations = NoRevocations;
-    let pipe = Pipeline::new(
-        &bundle,
-        &graph,
-        &registry,
-        &Ed25519OnlyVerifier,
-        &no_revocations,
-        TransparencyInputs {
-            artifact_included: options.transparency_included,
-            time_anchored: options.time_anchored,
-            time_attested_at,
-            multi_log_quorum: options.multi_log_quorum,
-            downgrades: vec![],
-        },
-        &acceptance,
-    );
-    let now = chrono::Utc::now();
-    let outcome = pipe
-        .run(&artifact, now)
+    let verdict = verify_trusted_artifact(&artifact, &bundle, &graph, &registry, &options)
         .map_err(|e| JsError::new(&format!("{e}")))?;
-
-    let accept = outcome.acceptance == confium_signatif::coverage::Acceptance::Accept;
-    let result = serde_json::json!({
-        "coverage": outcome.report,
-        "label": outcome.label.0,
-        "accept": accept,
-    });
-    serde_json::to_string(&result).map_err(|e| JsError::new(&format!("encode: {e}")))
+    serde_json::to_string(&verdict).map_err(|e| JsError::new(&format!("encode: {e}")))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- Deepens the SIGNATIF verification layer: `confium_signatif::verify` is now the single entry every surface calls, owning the pipeline assembly (fleet, revocation view, transparency inputs, acceptance policy) that previously lived as a ~30-line stanza in each of the four adapters.
- `Fleet` names the verifier fleet as policy (`ed25519` / `ed25519_p256`), deleting the four private `SignatureVerifier` implementations (three byte-identical) and the test/example ones can migrate too.
- `VerifyOptions` deserializes directly from each surface's existing options JSON; `Verdict` is the `{coverage, label, accept}` triple every surface serialized by hand. Transport shapes (HTTP request/response, CLI flags, Python kwargs, WASM options) are unchanged.
- Adds `CONTEXT.md` — the domain glossary future architecture reviews share.

## Test plan

- [x] `cargo test -p confium-signatif` — 93 tests incl. 5 new (ladder, tamper hard-fail, malformed time, options deserialization from surface JSON)
- [x] `cargo test -p confium-verify-server` — endpoint tests green
- [x] `cargo test -p confium-cli --lib` green; `cargo check` for confium-wasm (all targets) and the standalone confium-python crate
- [x] `cargo clippy -D warnings` clean on all touched crates; `cargo fmt` applied
- [ ] Full CI incl. wasm32 tests
