### PR TITLE
feat(signatif): specimen kit for the abstract test suite

### DIFF
--- a/crates/confium-signatif/src/lib.rs
+++ b/crates/confium-signatif/src/lib.rs
@@ -23,6 +23,7 @@
 //! - [`registry`]: the five scheme-maintained registries.
 //! - [`verify`]: the deep verification entry — fleet, options, and
 //!   verdict in one interface, so transport adapters stay thin.
+//! - [`testing`]: specimen builders every test surface composes from.
 //!
 //! All verification is offline-capable against a trust anchor bundle.
 
@@ -48,6 +49,7 @@ pub mod pipeline;
 pub mod registry;
 pub mod revocation;
 pub mod scope;
+pub mod testing;
 pub mod time;
 pub mod verify;
 pub mod x509;

--- a/crates/confium-signatif/src/testing.rs
+++ b/crates/confium-signatif/src/testing.rs
@@ -1,0 +1,211 @@
+//! Specimen builders for the abstract test suite.
+//!
+//! Building one valid trusted artifact means generating keys,
+//! assembling a trust graph, signing an anchor bundle, and
+//! co-signing the artifact — work every test surface (the Rust
+//! suites, the browser binding, examples) used to duplicate. This
+//! module owns the specimen kit so suites compose from it instead.
+//!
+//! The module ships in the published crate on purpose: a separate
+//! test-support crate consumed as a dev-dependency would recreate the
+//! publish ordering deadlock (published crates must never
+//! dev-depend on a later-publishing workspace crate). It adds no
+//! dependencies beyond what `confium-signatif` already links.
+
+use ed25519_dalek::Signer;
+
+use crate::artifact::TrustedArtifact;
+use crate::bundle::{AnchorRoot, TrustAnchorBundle};
+use crate::graph::{AuthorityKind, AuthorityNode, DelegationEdge, TrustGraph};
+use crate::registry::{DimensionTag, Registry};
+use crate::scope::ScopeDimensions;
+
+/// A valid specimen: root-delegated end authority, signed anchor
+/// bundle, and a data-dimension co-signed artifact over it, plus the
+/// secret keys so tests can sign more, tamper, or re-issue.
+#[derive(Debug, Clone)]
+pub struct Fixture {
+    /// The co-signed trusted artifact.
+    pub artifact: TrustedArtifact,
+    /// The signed trust anchor bundle anchoring `root`.
+    pub bundle: TrustAnchorBundle,
+    /// The root → end delegation graph.
+    pub graph: TrustGraph,
+    /// The registry the artifact was signed under.
+    pub registry: Registry,
+    /// The root authority's signing key.
+    pub root_secret: ed25519_dalek::SigningKey,
+    /// The end authority's signing key (the artifact's co-signer).
+    pub end_secret: ed25519_dalek::SigningKey,
+}
+
+impl Fixture {
+    /// Build a fresh valid specimen with random keys.
+    pub fn valid() -> Fixture {
+        let mut seed = [0u8; 32];
+        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
+        let root_secret = ed25519_dalek::SigningKey::from_bytes(&seed);
+        let mut seed = [0u8; 32];
+        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
+        let end_secret = ed25519_dalek::SigningKey::from_bytes(&seed);
+
+        let registry = Registry::with_initial_values();
+        let root = AuthorityNode {
+            id: "root".into(),
+            kind: AuthorityKind::Root,
+            public_key: root_secret.verifying_key().as_bytes().to_vec(),
+            quorum: None,
+            scope: ScopeDimensions::unconstrained(),
+        };
+        let end = AuthorityNode {
+            id: "end".into(),
+            kind: AuthorityKind::EndCertificate,
+            public_key: end_secret.verifying_key().as_bytes().to_vec(),
+            quorum: None,
+            scope: ScopeDimensions::unconstrained(),
+        };
+        let mut graph = TrustGraph::new();
+        graph.add_node(root.clone());
+        graph.add_node(end.clone());
+        graph
+            .add_delegation(DelegationEdge {
+                parent: "root".into(),
+                child: "end".into(),
+                signature: root_secret
+                    .sign(&end.binding_bytes().unwrap())
+                    .to_bytes()
+                    .to_vec(),
+            })
+            .unwrap();
+
+        let bundle = Self::sign_bundle(
+            root.public_key.clone(),
+            &root_secret,
+            chrono::Utc::now() - chrono::Duration::hours(1),
+            chrono::Utc::now() + chrono::Duration::days(30),
+        );
+
+        let mut artifact = TrustedArtifact::new(
+            crate::artifact::ArtifactVersion { major: 1, minor: 0 },
+            "fixture-1",
+            serde_json::json!({"dose": 500}),
+            None,
+        )
+        .unwrap();
+        artifact
+            .sign(
+                DimensionTag::data(),
+                "Ed25519",
+                "end",
+                end_secret.verifying_key().as_bytes().to_vec(),
+                "root",
+                &|m| end_secret.sign(m).to_bytes().to_vec(),
+                &registry,
+            )
+            .unwrap();
+
+        Fixture {
+            artifact,
+            bundle,
+            graph,
+            registry,
+            root_secret,
+            end_secret,
+        }
+    }
+
+    fn sign_bundle(
+        root_key: Vec<u8>,
+        root_secret: &ed25519_dalek::SigningKey,
+        valid_from: chrono::DateTime<chrono::Utc>,
+        valid_until: chrono::DateTime<chrono::Utc>,
+    ) -> TrustAnchorBundle {
+        let mut bundle = TrustAnchorBundle {
+            bundle_version: "1".into(),
+            valid_from,
+            valid_until,
+            roots: vec![AnchorRoot {
+                name: "root".into(),
+                aggregate_key: root_key.clone(),
+                fingerprint: hex::encode(&root_key),
+                quorum: None,
+            }],
+            transparency_logs: vec![],
+            update_log: None,
+            bundle_signature: vec![],
+        };
+        let msg = bundle.signing_bytes().unwrap();
+        bundle.bundle_signature = root_secret.sign(&msg).to_bytes().to_vec();
+        bundle
+    }
+
+    /// The same artifact with a mutated payload: signature-validity
+    /// hard check must fail.
+    pub fn tampered_artifact(&self) -> TrustedArtifact {
+        let mut value = serde_json::to_value(&self.artifact).unwrap();
+        value["payload"]["dose"] = serde_json::json!(999);
+        serde_json::from_value(value).unwrap()
+    }
+
+    /// The same anchors in a bundle whose validity window has closed:
+    /// the bundle-validity hard check must fail.
+    pub fn expired_bundle(&self) -> TrustAnchorBundle {
+        Self::sign_bundle(
+            self.root_secret.verifying_key().as_bytes().to_vec(),
+            &self.root_secret,
+            chrono::Utc::now() - chrono::Duration::days(30),
+            chrono::Utc::now() - chrono::Duration::hours(1),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::verify::{VerifyOptions, verify_trusted_artifact};
+
+    #[test]
+    fn valid_specimen_ladders() {
+        let f = Fixture::valid();
+        let options = VerifyOptions {
+            transparency_included: true,
+            time_anchored: true,
+            time_attested_at: Some(chrono::Utc::now().to_rfc3339()),
+            accepted_labels: vec!["verified".into()],
+            ..VerifyOptions::default()
+        };
+        let verdict =
+            verify_trusted_artifact(&f.artifact, &f.bundle, &f.graph, &f.registry, &options)
+                .unwrap();
+        assert_eq!(verdict.label, "verified");
+        assert!(verdict.accept);
+    }
+
+    #[test]
+    fn tampered_specimen_hard_fails() {
+        let f = Fixture::valid();
+        let err = verify_trusted_artifact(
+            &f.tampered_artifact(),
+            &f.bundle,
+            &f.graph,
+            &f.registry,
+            &VerifyOptions::default(),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("signature_validity"), "{err}");
+    }
+
+    #[test]
+    fn expired_specimen_hard_fails() {
+        let f = Fixture::valid();
+        let err = verify_trusted_artifact(
+            &f.artifact,
+            &f.expired_bundle(),
+            &f.graph,
+            &f.registry,
+            &VerifyOptions::default(),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("bundle"), "{err}");
+    }
+}

--- a/crates/confium-signatif/src/verify.rs
+++ b/crates/confium-signatif/src/verify.rs
@@ -189,85 +189,14 @@ pub fn verify_trusted_artifact(
 mod tests {
     use super::*;
 
-    fn fixture() -> (TrustedArtifact, TrustAnchorBundle, TrustGraph, Registry) {
-        use crate::bundle::AnchorRoot;
-        use crate::graph::{AuthorityKind, AuthorityNode, DelegationEdge};
-        use crate::scope::ScopeDimensions;
-        use ed25519_dalek::Signer;
-
-        let mut seed = [0u8; 32];
-        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
-        let root_sk = ed25519_dalek::SigningKey::from_bytes(&seed);
-        let mut seed = [0u8; 32];
-        rand_core::RngCore::fill_bytes(&mut rand_core::OsRng, &mut seed);
-        let end_sk = ed25519_dalek::SigningKey::from_bytes(&seed);
-
-        let registry = Registry::with_initial_values();
-        let root = AuthorityNode {
-            id: "root".into(),
-            kind: AuthorityKind::Root,
-            public_key: root_sk.verifying_key().as_bytes().to_vec(),
-            quorum: None,
-            scope: ScopeDimensions::unconstrained(),
-        };
-        let end = AuthorityNode {
-            id: "end".into(),
-            kind: AuthorityKind::EndCertificate,
-            public_key: end_sk.verifying_key().as_bytes().to_vec(),
-            quorum: None,
-            scope: ScopeDimensions::unconstrained(),
-        };
-        let mut graph = TrustGraph::new();
-        graph.add_node(root.clone());
-        graph.add_node(end.clone());
-        graph
-            .add_delegation(DelegationEdge {
-                parent: "root".into(),
-                child: "end".into(),
-                signature: root_sk
-                    .sign(&end.binding_bytes().unwrap())
-                    .to_bytes()
-                    .to_vec(),
-            })
-            .unwrap();
-
-        let mut bundle = TrustAnchorBundle {
-            bundle_version: "1".into(),
-            valid_from: chrono::Utc::now() - chrono::Duration::hours(1),
-            valid_until: chrono::Utc::now() + chrono::Duration::days(30),
-            roots: vec![AnchorRoot {
-                name: "root".into(),
-                aggregate_key: root.public_key.clone(),
-                fingerprint: hex::encode(&root.public_key),
-                quorum: None,
-            }],
-            transparency_logs: vec![],
-            update_log: None,
-            bundle_signature: vec![],
-        };
-        let msg = bundle.signing_bytes().unwrap();
-        bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
-
-        let mut artifact = TrustedArtifact::new(
-            crate::artifact::ArtifactVersion { major: 1, minor: 0 },
-            "v-1",
-            serde_json::json!({"dose": 500}),
-            None,
-        )
-        .unwrap();
-        artifact
-            .sign(
-                crate::registry::DimensionTag::data(),
-                "Ed25519",
-                "end",
-                end_sk.verifying_key().as_bytes().to_vec(),
-                "root",
-                &|m| end_sk.sign(m).to_bytes().to_vec(),
-                &registry,
-            )
-            .unwrap();
-
-        (artifact, bundle, graph, registry)
+    fn fixture() -> (
+        crate::artifact::TrustedArtifact,
+        crate::bundle::TrustAnchorBundle,
+        crate::graph::TrustGraph,
+        crate::registry::Registry,
+    ) {
+        let f = crate::testing::Fixture::valid();
+        (f.artifact, f.bundle, f.graph, f.registry)
     }
 
     #[test]

--- a/crates/confium-signatif/tests/ats.rs
+++ b/crates/confium-signatif/tests/ats.rs
@@ -12,9 +12,7 @@ use confium_signatif::artifact::{ArtifactVersion, TrustedArtifact};
 use confium_signatif::bundle::{AnchorRoot, TrustAnchorBundle};
 use confium_signatif::conformance::{ConformanceStatus, conformance_claims};
 use confium_signatif::coverage::{AcceptancePolicy, HardCheckStatus};
-use confium_signatif::graph::{
-    AuthorityKind, AuthorityNode, DelegationEdge, SignatureVerifier, TrustGraph,
-};
+use confium_signatif::graph::{AuthorityKind, AuthorityNode, DelegationEdge, TrustGraph};
 use confium_signatif::jcs;
 use confium_signatif::passport::Passport;
 use confium_signatif::pipeline::{Pipeline, TransparencyInputs};
@@ -27,22 +25,6 @@ fn generate_key() -> ed25519_dalek::SigningKey {
     let mut seed = [0u8; 32];
     rand_core::OsRng.fill_bytes(&mut seed);
     ed25519_dalek::SigningKey::from_bytes(&seed)
-}
-
-struct Ed25519Verifier;
-
-impl SignatureVerifier for Ed25519Verifier {
-    fn verify(&self, pk: &[u8], msg: &[u8], sig: &[u8]) -> bool {
-        use ed25519_dalek::Signature;
-        use ed25519_dalek::Verifier;
-        let Ok(vk) = ed25519_dalek::VerifyingKey::from_bytes(pk.try_into().unwrap()) else {
-            return false;
-        };
-        let Ok(signature) = Signature::from_slice(sig) else {
-            return false;
-        };
-        vk.verify(msg, &signature).is_ok()
-    }
 }
 
 struct Fixture {
@@ -147,7 +129,7 @@ fn ats_verifier_classes() {
         &f.bundle,
         &f.graph,
         &f.registry,
-        &Ed25519Verifier,
+        &confium_signatif::verify::Fleet::Ed25519,
         &no_revocations,
         TransparencyInputs {
             artifact_included: true,
@@ -180,7 +162,11 @@ fn ats_issuing_authority() {
             &f.registry,
         )
         .unwrap();
-    assert!(living.verify_self(&f.registry, &Ed25519Verifier).is_ok());
+    assert!(
+        living
+            .verify_self(&f.registry, &confium_signatif::verify::Fleet::Ed25519)
+            .is_ok()
+    );
     assert_eq!(living.dimensions_verified().len(), 2);
 }
 
@@ -188,7 +174,11 @@ fn ats_issuing_authority() {
 #[test]
 fn ats_root_authority() {
     let f = build();
-    assert!(f.bundle.verify(Utc::now(), &Ed25519Verifier).is_ok());
+    assert!(
+        f.bundle
+            .verify(Utc::now(), &confium_signatif::verify::Fleet::Ed25519)
+            .is_ok()
+    );
 }
 
 /// `/conf/hierarchical`: narrowing enforced along the chain.
@@ -197,7 +187,7 @@ fn ats_hierarchical_topology() {
     let f = build();
     let paths = f
         .graph
-        .find_paths("end", &f.bundle, &Ed25519Verifier)
+        .find_paths("end", &f.bundle, &confium_signatif::verify::Fleet::Ed25519)
         .unwrap();
     assert_eq!(paths.len(), 1);
     assert_eq!(paths[0].root.id, "root");
@@ -288,7 +278,7 @@ fn ats_transparency_gossip() {
         .collect();
     assert!(
         GossipQuorum { min_sources: 2 }
-            .check(&cosigns, &Ed25519Verifier)
+            .check(&cosigns, &confium_signatif::verify::Fleet::Ed25519)
             .unwrap()
     );
 }

--- a/crates/confium-wasm/Cargo.toml
+++ b/crates/confium-wasm/Cargo.toml
@@ -61,7 +61,6 @@ confium-tc-elgamal-p256 = { workspace = true, optional = true }
 wasm-bindgen = "0.2"
 serde = { workspace = true }
 serde_json = { workspace = true }
-ed25519-dalek = { workspace = true }
 js-sys = "0.3"
 chrono = { workspace = true }
 

--- a/crates/confium-wasm/src/signatif.rs
+++ b/crates/confium-wasm/src/signatif.rs
@@ -60,87 +60,12 @@ mod tests {
     use wasm_bindgen_test::wasm_bindgen_test;
 
     fn fixture() -> (String, String, String, String) {
-        use ed25519_dalek::Signer;
-        use rand_core::RngCore;
-
-        fn generate_key() -> ed25519_dalek::SigningKey {
-            let mut seed = [0u8; 32];
-            rand_core::OsRng.fill_bytes(&mut seed);
-            ed25519_dalek::SigningKey::from_bytes(&seed)
-        }
-
-        let registry = Registry::with_initial_values();
-        let root_sk = generate_key();
-        let end_sk = generate_key();
-        let root = confium_signatif::graph::AuthorityNode {
-            id: "root".into(),
-            kind: confium_signatif::graph::AuthorityKind::Root,
-            public_key: root_sk.verifying_key().as_bytes().to_vec(),
-            quorum: None,
-            scope: confium_signatif::scope::ScopeDimensions::unconstrained(),
-        };
-        let end = confium_signatif::graph::AuthorityNode {
-            id: "end".into(),
-            kind: confium_signatif::graph::AuthorityKind::EndCertificate,
-            public_key: end_sk.verifying_key().as_bytes().to_vec(),
-            quorum: None,
-            scope: confium_signatif::scope::ScopeDimensions::unconstrained(),
-        };
-        let mut graph = TrustGraph::new();
-        graph.add_node(root.clone());
-        graph.add_node(end.clone());
-        use confium_signatif::graph::DelegationEdge;
-        graph
-            .add_delegation(DelegationEdge {
-                parent: "root".into(),
-                child: "end".into(),
-                signature: root_sk
-                    .sign(&end.binding_bytes().unwrap())
-                    .to_bytes()
-                    .to_vec(),
-            })
-            .unwrap();
-        let mut bundle = TrustAnchorBundle {
-            bundle_version: "1".into(),
-            valid_from: chrono::Utc::now() - chrono::Duration::hours(1),
-            valid_until: chrono::Utc::now() + chrono::Duration::days(30),
-            roots: vec![confium_signatif::bundle::AnchorRoot {
-                name: "root".into(),
-                aggregate_key: root.public_key.clone(),
-                fingerprint: hex::encode(&root.public_key),
-                quorum: None,
-            }],
-            transparency_logs: vec![],
-            update_log: None,
-            bundle_signature: vec![],
-        };
-        let msg = bundle.signing_bytes().unwrap();
-        bundle.bundle_signature = root_sk.sign(&msg).to_bytes().to_vec();
-
-        let mut artifact = TrustedArtifact::new(
-            confium_signatif::artifact::ArtifactVersion { major: 1, minor: 0 },
-            "wasm-1",
-            serde_json::json!({"dose": 500}),
-            None,
-        )
-        .unwrap();
-        artifact
-            .sign(
-                confium_signatif::registry::DimensionTag::data(),
-                "Ed25519",
-                "end",
-                end_sk.verifying_key().as_bytes().to_vec(),
-                "root",
-                &|m| end_sk.sign(m).to_bytes().to_vec(),
-                &registry,
-            )
-            .unwrap();
-
+        let f = confium_signatif::testing::Fixture::valid();
         (
-            serde_json::to_string(&artifact).unwrap(),
-            serde_json::to_string(&bundle).unwrap(),
-            serde_json::to_string(&graph).unwrap(),
-            serde_json::to_string(&registry).unwrap(),
+            serde_json::to_string(&f.artifact).unwrap(),
+            serde_json::to_string(&f.bundle).unwrap(),
+            serde_json::to_string(&f.graph).unwrap(),
+            serde_json::to_string(&f.registry).unwrap(),
         )
     }
 


### PR DESCRIPTION
## Summary

- New `confium_signatif::testing` module owns the specimen kit once: `Fixture::valid()` (keys, root→end graph, signed anchor bundle, co-signed artifact, both secret keys), `tampered_artifact()`, and `expired_bundle()`.
- The wasm binding's ~80-line inline fixture, the verify module's test fixture, and the ATS suite's hand-rolled `Ed25519Verifier` (now the named `Fleet::Ed25519`) compose from it instead.
- Ships inside the published crate deliberately — a separate test-support crate as a dev-dependency would recreate the publish ordering deadlock fixed in #243.
- Drops confium-wasm's now-unused `ed25519-dalek` dependency (machete-verified).

Stacked on #254 (base commit); merge that first.

## Test plan

- [x] `cargo test -p confium-signatif` — 96 tests green incl. 3 new specimen tests
- [x] `cargo check -p confium-wasm --all-targets` clean; `cargo machete` clean for wasm
- [x] clippy `-D warnings` clean; fmt applied
- [ ] Full CI incl. wasm32 tests
