### PR TITLE
chore: remove stale code

### DIFF
--- a/crates/confium-composite/src/cose.rs
+++ b/crates/confium-composite/src/cose.rs
@@ -231,11 +231,6 @@ impl<'a> CborReader<'a> {
         Self { bytes, pos: 0 }
     }
 
-    #[allow(dead_code)]
-    fn peek(&self) -> Option<u8> {
-        self.bytes.get(self.pos).copied()
-    }
-
     fn read_u8(&mut self) -> Option<u8> {
         self.bytes.get(self.pos).map(|&b| {
             self.pos += 1;

--- a/crates/confium-composite/src/wycheproof.rs
+++ b/crates/confium-composite/src/wycheproof.rs
@@ -33,8 +33,6 @@
 //!   verifying or rejecting are both defensible (e.g. signature
 //!   value `s = 0`); either outcome counts as acceptable.
 
-#![cfg(feature = "wycheproof")]
-
 use serde::Deserialize;
 use std::path::Path;
 
@@ -80,8 +78,6 @@ struct TestCase {
     msg: String,    // hex
     sig: String,    // hex (DER for ECDSA)
     result: String, // "valid" | "invalid" | "acceptable"
-    #[allow(dead_code)]
-    flags: Option<Vec<String>>,
 }
 
 /// The outcome of one vector-file run. `failed` is the number that

--- a/crates/confium-deployment/src/signatif.rs
+++ b/crates/confium-deployment/src/signatif.rs
@@ -306,10 +306,9 @@ impl SignatifManifest {
         }
 
         // Acyclic: DFS from every authority following parents.
+        // Unvisited nodes are absent from `marks` (tri-color DFS).
         #[derive(PartialEq, Clone, Copy)]
         enum Mark {
-            #[allow(dead_code)]
-            White,
             Grey,
             Black,
         }


### PR DESCRIPTION
## Summary

Small dead-code removals surfaced by the post-release cleanup scan:

- `confium-composite/wycheproof`: drop the module-level `#![cfg(feature = "wycheproof")]` — redundant with the `#[cfg]` gate on the `pub mod` declaration in `lib.rs`
- `confium-composite/wycheproof`: drop the deserialized-but-never-read `flags` field (serde ignores unknown fields, so parsing is unaffected)
- `confium-composite/cose`: drop the private `CborReader::peek`, never called
- `confium-deployment/signatif`: drop the never-constructed `Mark::White` DFS variant — unvisited nodes are absent from the marks map

Also in this cleanup pass (repo hygiene, no code change): deleted 66 local branches whose work already landed (SHA-merged, merged-PR heads, or patch-equivalent after rebase-merge), deleted the merged remote branches `docs/update-claudemd` and `fix/examples-warnings2`, and dropped the now-redundant wycheproof stash.

Kept intentionally: the attic archive, all `#[allow(dead_code)]` markers that hold loaded plugin libraries alive (`Rc<Library>` fields), scaffolding marked with explanatory comments (log-server routes, operator CRDs), and the `run_ecdsa_p256` deprecated shim required by semver until 0.6.0.

## Verification

- `cargo clippy -p confium-composite -p confium-deployment --all-targets -- -D warnings` — clean
- `cargo test -p confium-composite -p confium-deployment` — 65 tests pass
- `cargo test -p confium-composite --features wycheproof wycheproof` — 5 tests pass
- `cargo fmt --all --check` — clean
