### PR TITLE
fix(log-server): 0-based sequences in the postgres backend too

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1303,6 +1303,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-postgres",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/confium-log-server/src/db_pg.rs
+++ b/crates/confium-log-server/src/db_pg.rs
@@ -132,7 +132,9 @@ impl PostgresBackend {
             )
             .await?;
         let seq: i64 = rows.get(0);
-        Ok(seq as u64)
+        // Postgres SERIAL ids are 1-based; entry sequences are 0-based
+        // to match the Merkle leaf index used by the proof endpoints.
+        Ok((seq - 1) as u64)
     }
 
     pub async fn entry_count(&self) -> Result<u64> {


### PR DESCRIPTION
Follow-up to PR 269: the postgres twin of the sqlite sequence fix was left uncommitted, plus the log-server tower dev-dependency entry for Cargo.lock. Same one-line semantics: SERIAL ids are 1-based, proof endpoints index 0-based Merkle leaves.
